### PR TITLE
chore: regenerate Rust CycloneDX SBOMs

### DIFF
--- a/openobserve.cdx.xml
+++ b/openobserve.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:85ee9808-382a-4b75-a633-3ab02d9e9127" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:dd3e1b35-843c-47b8-bc19-d56543107f23" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.318303000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.863747000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0">
+    <component type="application" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d#openobserve@0.93.0">
       <name>openobserve</name>
       <version>0.93.0</version>
       <description>OpenObserve is an observability platform that allows you to capture, search, and analyze your logs, metrics, and traces.</description>
@@ -27,12 +27,12 @@
         </reference>
       </externalReferences>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d#openobserve@0.93.0 bin-target-0">
           <name>openobserve</name>
           <version>0.93.0</version>
           <purl>pkg:cargo/openobserve@0.93.0?download_url=file://.#src/lib.rs</purl>
         </component>
-        <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0 bin-target-1">
+        <component type="application" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d#openobserve@0.93.0 bin-target-1">
           <name>openobserve</name>
           <version>0.93.0</version>
           <purl>pkg:cargo/openobserve@0.93.0?download_url=file://.#src/main.rs</purl>
@@ -45,7 +45,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -53,7 +53,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -61,7 +61,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -69,7 +69,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -77,7 +77,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -85,7 +85,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -96,7 +96,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -104,7 +104,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -115,7 +115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -123,7 +123,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -134,7 +134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -142,7 +142,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -153,7 +153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -161,7 +161,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -179,7 +179,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -194,7 +194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -202,7 +202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -210,7 +210,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -221,7 +221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -229,7 +229,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -240,7 +240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -248,7 +248,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -259,7 +259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -267,7 +267,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -278,7 +278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -286,7 +286,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -297,7 +297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -305,7 +305,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -316,7 +316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -324,7 +324,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -335,7 +335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -343,7 +343,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -354,7 +354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -362,7 +362,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -373,7 +373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -381,7 +381,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -392,7 +392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -400,7 +400,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -411,7 +411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -419,7 +419,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -430,7 +430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -438,7 +438,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -449,7 +449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -457,7 +457,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -468,7 +468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -476,7 +476,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -487,7 +487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -495,7 +495,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -506,7 +506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -514,7 +514,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -525,7 +525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -533,7 +533,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -544,7 +544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -552,7 +552,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -563,7 +563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -571,7 +571,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -582,7 +582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -590,7 +590,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -601,7 +601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -609,7 +609,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -620,7 +620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -628,7 +628,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -639,7 +639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -647,7 +647,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -658,7 +658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -666,7 +666,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -677,7 +677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -685,7 +685,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -696,7 +696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -704,7 +704,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -715,7 +715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -723,7 +723,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -734,7 +734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -742,7 +742,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -753,7 +753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -761,7 +761,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -772,7 +772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -780,7 +780,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -791,7 +791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -799,7 +799,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -810,7 +810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -818,7 +818,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -837,7 +837,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%3Fbranch=v0.23.2-feat%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
+      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
       <externalReferences>
         <reference type="website">
           <url>https://gitlab.com/lx-industries/rmcp-openapi</url>
@@ -863,7 +863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -871,7 +871,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -885,7 +885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -893,7 +893,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -907,7 +907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -915,7 +915,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -936,7 +936,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -947,7 +947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -955,7 +955,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -969,7 +969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -977,7 +977,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -995,7 +995,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1013,7 +1013,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1031,7 +1031,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1042,24 +1042,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1067,7 +1067,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1078,7 +1078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1086,7 +1086,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1097,7 +1097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1105,7 +1105,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1116,7 +1116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1124,7 +1124,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1135,7 +1135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1143,7 +1143,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1154,7 +1154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1162,7 +1162,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1173,7 +1173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1181,7 +1181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1192,7 +1192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1200,7 +1200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1211,7 +1211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1219,7 +1219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1230,7 +1230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1238,7 +1238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1249,7 +1249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1257,7 +1257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1268,7 +1268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1276,7 +1276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1287,7 +1287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1295,7 +1295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1306,7 +1306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1314,7 +1314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1325,7 +1325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1333,7 +1333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1344,7 +1344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1352,7 +1352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1363,7 +1363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1371,7 +1371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1382,7 +1382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1390,7 +1390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1401,7 +1401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1409,7 +1409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1420,7 +1420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1428,7 +1428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1439,7 +1439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1447,7 +1447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1458,7 +1458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1466,7 +1466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1477,7 +1477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1485,7 +1485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1496,7 +1496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1504,7 +1504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1515,7 +1515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1523,7 +1523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1534,7 +1534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1542,7 +1542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1553,7 +1553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1561,7 +1561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1572,7 +1572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1580,7 +1580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1591,7 +1591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1599,7 +1599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1610,7 +1610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1618,7 +1618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1629,7 +1629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1637,7 +1637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1647,7 +1647,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1656,7 +1656,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://src/api/common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0">
       <name>openobserve-api-grpc</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1665,7 +1665,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://src/api/grpc</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0">
       <name>openobserve-api-http</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1674,7 +1674,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://src/api/http</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <name>openobserve-api-ingest</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1683,7 +1683,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://src/api/ingest</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <name>openobserve-api-management</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1692,7 +1692,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://src/api/management</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <name>openobserve-api-pipelines</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1701,7 +1701,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://src/api/pipelines</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <name>openobserve-api-search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1710,7 +1710,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://src/api/search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1719,7 +1719,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://src/audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1728,7 +1728,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://src/builtins</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1737,7 +1737,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://src/common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1746,7 +1746,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://src/compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1755,7 +1755,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://src/config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1764,7 +1764,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://src/core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1773,7 +1773,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://src/db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1782,7 +1782,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://src/enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1791,7 +1791,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://src/flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1800,7 +1800,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://src/infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1809,7 +1809,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://src/ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1818,7 +1818,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://src/ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0">
       <name>openobserve-jobs</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1827,7 +1827,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://src/jobs</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <name>openobserve-mcp</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1836,7 +1836,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://src/mcp</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1845,7 +1845,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://src/node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1854,7 +1854,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://src/org_storage</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1863,7 +1863,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://src/promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1872,7 +1872,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://src/promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1881,7 +1881,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://src/proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <name>report_server</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1890,7 +1890,7 @@
       </licenses>
       <purl>pkg:cargo/report_server@0.1.0?download_url=file://src/report_server</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1899,7 +1899,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://src/schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1908,7 +1908,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://src/search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1917,7 +1917,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://src/search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <name>openobserve-sourcemaps</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1926,7 +1926,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://src/sourcemaps</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1935,7 +1935,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://src/stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0">
       <name>super_cluster_queue</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1944,7 +1944,7 @@
       </licenses>
       <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://src/super_cluster_queue</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1953,7 +1953,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://src/tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <name>openobserve-tls</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1962,7 +1962,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://src/tls</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1971,7 +1971,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://src/transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1980,7 +1980,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://src/usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1989,7 +1989,7 @@
       </licenses>
       <purl>pkg:cargo/wal@0.1.0?download_url=file://src/wal</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0">
       <name>web</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1999,7 +1999,7 @@
       <purl>pkg:cargo/web@0.1.0?download_url=file://src/web</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-codec</name>
       <version>0.5.2</version>
       <description>Codec utilities for working with framed protocols</description>
@@ -2018,7 +2018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-http</name>
       <version>3.13.1</version>
       <description>HTTP types and services for the Actix ecosystem</description>
@@ -2040,7 +2040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-router</name>
       <version>0.5.4</version>
       <description>Resource path matching and router</description>
@@ -2059,7 +2059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-rt</name>
       <version>2.11.0</version>
       <description>Tokio-based single-threaded async runtime for the Actix ecosystem</description>
@@ -2081,7 +2081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com></author>
       <name>actix-server</name>
       <version>2.6.0</version>
       <description>General purpose TCP server built for the Actix ecosystem</description>
@@ -2103,7 +2103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-service</name>
       <version>2.0.3</version>
       <description>Service trait and combinators for representing asynchronous request/response operations.</description>
@@ -2122,7 +2122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-utils</name>
       <version>3.0.1</version>
       <description>Various utilities used in the Actix ecosystem</description>
@@ -2141,7 +2141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-web</name>
       <version>4.14.0</version>
       <description>Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust</description>
@@ -2163,7 +2163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -2251,7 +2251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -2273,7 +2273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -2295,7 +2295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -2317,7 +2317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2342,10 +2342,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2367,7 +2367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2392,7 +2392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2417,7 +2417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2514,7 +2514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2554,7 +2554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2576,7 +2576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2598,10 +2598,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2642,7 +2642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2686,7 +2686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2708,7 +2708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2730,7 +2730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2752,7 +2752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2774,7 +2774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2796,7 +2796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2818,7 +2818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2840,7 +2840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2862,7 +2862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2884,7 +2884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2906,7 +2906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2928,7 +2928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2950,7 +2950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2972,7 +2972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2994,7 +2994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -3016,7 +3016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -3122,7 +3122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-derive</name>
       <version>0.6.0</version>
       <description>Derive macros for the `asn1-rs` crate</description>
@@ -3144,7 +3144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-impl</name>
       <version>0.2.0</version>
       <description>Implementation details for the `asn1-rs` crate</description>
@@ -3166,7 +3166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs</name>
       <version>0.7.1</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -3188,7 +3188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -3207,7 +3207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -3226,7 +3226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -3245,7 +3245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -3270,7 +3270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -3289,7 +3289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -3308,7 +3308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -3333,7 +3333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -3358,7 +3358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -3377,7 +3377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -3399,7 +3399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3418,7 +3418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3437,7 +3437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3456,7 +3456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3475,7 +3475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3497,7 +3497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3544,7 +3544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3563,7 +3563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3585,7 +3585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3604,7 +3604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3673,7 +3673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3692,7 +3692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3711,7 +3711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3730,7 +3730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3749,7 +3749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3768,7 +3768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3787,7 +3787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3806,7 +3806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3825,7 +3825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3844,7 +3844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3863,7 +3863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3882,7 +3882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3901,7 +3901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3920,7 +3920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3939,7 +3939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3958,7 +3958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3977,7 +3977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -4077,7 +4077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-server@0.8.0">
-      <author>Programatik &lt;programatik29@gmail.com&gt;, Adi Salimgereev &lt;adisalimgereev@gmail.com&gt;</author>
+      <author>Programatik &lt;programatik29@gmail.com>, Adi Salimgereev &lt;adisalimgereev@gmail.com></author>
       <name>axum-server</name>
       <version>0.8.0</version>
       <description>High level server designed to be used with axum framework.</description>
@@ -4120,7 +4120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -4142,7 +4142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -4204,7 +4204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -4273,7 +4273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -4295,7 +4295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -4339,7 +4339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -4361,7 +4361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -4386,7 +4386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -4411,7 +4411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -4436,7 +4436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -4461,7 +4461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4486,7 +4486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4536,7 +4536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4604,7 +4604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4692,7 +4692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4753,7 +4753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4775,7 +4775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4797,7 +4797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4819,7 +4819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4844,7 +4844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4869,7 +4869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4894,7 +4894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4916,7 +4916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4938,7 +4938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4960,7 +4960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4979,7 +4979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4998,7 +4998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -5023,7 +5023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -5045,7 +5045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -5064,7 +5064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>bytestring</name>
       <version>1.5.1</version>
       <description>A UTF-8 encoded read-only string using `Bytes` as storage</description>
@@ -5110,7 +5110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -5129,7 +5129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -5175,7 +5175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -5216,7 +5216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -5241,7 +5241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -5263,7 +5263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -5307,7 +5307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -5326,7 +5326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -5351,7 +5351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -5436,7 +5436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5506,7 +5506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5528,7 +5528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5550,7 +5550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5572,7 +5572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5637,7 +5637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5774,7 +5774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5799,7 +5799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5842,7 +5842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5867,7 +5867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5886,7 +5886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5905,7 +5905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5924,7 +5924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5943,7 +5943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -6015,7 +6015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -6037,7 +6037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -6097,7 +6097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -6119,7 +6119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -6138,7 +6138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -6157,7 +6157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -6176,7 +6176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -6195,7 +6195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cookie</name>
       <version>0.18.1</version>
       <description>HTTP cookie parsing and cookie jar management. Supports signed and private (encrypted, authenticated) jars. </description>
@@ -6280,7 +6280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -6349,7 +6349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -6368,7 +6368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -6387,7 +6387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -6409,7 +6409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6536,7 +6536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6624,7 +6624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6649,7 +6649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6696,7 +6696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6742,7 +6742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6764,7 +6764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6786,7 +6786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6805,7 +6805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6824,7 +6824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6843,7 +6843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6862,7 +6862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6887,7 +6887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6952,7 +6952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>debugid</name>
       <version>0.8.0</version>
       <description>Common reusable types for implementing the sentry.io protocol.</description>
@@ -6977,7 +6977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
-      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <author>anatawa12 &lt;anatawa12@icloud.com></author>
       <name>deflate64</name>
       <version>0.1.11</version>
       <description>Deflate64 implementation based on .NET's implementation</description>
@@ -6999,7 +6999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>der-parser</name>
       <version>10.0.0</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -7040,7 +7040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -7059,7 +7059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -7081,7 +7081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -7103,7 +7103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -7125,7 +7125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -7191,7 +7191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -7248,7 +7248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -7267,7 +7267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.5.0</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -7286,7 +7286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs</name>
       <version>6.0.0</version>
       <description>A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -7305,7 +7305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -7330,7 +7330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -7352,7 +7352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -7374,7 +7374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -7399,7 +7399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -7424,7 +7424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -7449,7 +7449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -7489,7 +7489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -7508,7 +7508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -7533,7 +7533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -7555,7 +7555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7642,7 +7642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7664,7 +7664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7686,7 +7686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7708,7 +7708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7733,7 +7733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7758,7 +7758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7837,7 +7837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7859,7 +7859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7881,7 +7881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7900,7 +7900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7919,7 +7919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7944,7 +7944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7966,7 +7966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7988,7 +7988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -8010,7 +8010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -8032,7 +8032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -8054,7 +8054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -8073,7 +8073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -8095,7 +8095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -8114,7 +8114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -8133,7 +8133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -8201,7 +8201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -8223,7 +8223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -8248,7 +8248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -8270,7 +8270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -8292,7 +8292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -8314,7 +8314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -8333,7 +8333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -8371,7 +8371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -8396,7 +8396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>fs-err</name>
       <version>3.3.0</version>
       <description>A drop-in replacement for std::fs with more helpful error messages.</description>
@@ -8418,7 +8418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -8440,7 +8440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -8465,7 +8465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -8484,7 +8484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -8569,7 +8569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -8612,7 +8612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8700,7 +8700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8767,7 +8767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8899,7 +8899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>globset</name>
       <version>0.4.18</version>
       <description>Cross platform single glob and glob set matching. Glob set matching is the process of matching one or more glob patterns against a single candidate path simultaneously, and returning all of the globs that matched. </description>
@@ -8924,7 +8924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8971,7 +8971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8993,7 +8993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -9012,7 +9012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -9031,7 +9031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -9050,7 +9050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -9069,7 +9069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -9106,7 +9106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -9149,7 +9149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -9174,7 +9174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers-core</name>
       <version>0.3.0</version>
       <description>typed HTTP headers core trait</description>
@@ -9196,7 +9196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers</name>
       <version>0.4.1</version>
       <description>typed HTTP headers</description>
@@ -9218,7 +9218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -9261,7 +9261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -9327,7 +9327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -9370,7 +9370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -9389,7 +9389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
-      <author>Esteban Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Esteban Borai &lt;estebanborai@gmail.com></author>
       <name>http-auth-basic</name>
       <version>0.3.7</version>
       <description>HTTP Basic Authentication Scheme (RFC 7617 and RFC 2617 compliant, base64-encoded credentials) for Rust applications</description>
@@ -9408,7 +9408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -9430,7 +9430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -9452,7 +9452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -9474,7 +9474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -9496,7 +9496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -9518,7 +9518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -9540,7 +9540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -9559,7 +9559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -9654,7 +9654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -9679,7 +9679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -9704,7 +9704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9729,7 +9729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9902,7 +9902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9968,7 +9968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com></author>
       <name>if_chain</name>
       <version>1.0.3</version>
       <description>Macro for writing nested `if let` expressions.</description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1">
-      <author>Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Rob Ede &lt;robjtede@icloud.com></author>
       <name>impl-more</name>
       <version>0.3.1</version>
       <description>Concise, declarative trait implementation macros</description>
@@ -10030,7 +10030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -10074,7 +10074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -10118,7 +10118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -10140,7 +10140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -10162,7 +10162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -10184,7 +10184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -10206,7 +10206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -10225,7 +10225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -10244,7 +10244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -10350,7 +10350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -10372,7 +10372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -10397,7 +10397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -10419,7 +10419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -10441,7 +10441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -10466,7 +10466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -10485,7 +10485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -10551,7 +10551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -10570,7 +10570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -10589,7 +10589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2">
-      <author>Pyfisch &lt;pyfisch@gmail.com&gt;, Tpt &lt;thomas@pellissier-tanon.fr&gt;</author>
+      <author>Pyfisch &lt;pyfisch@gmail.com>, Tpt &lt;thomas@pellissier-tanon.fr></author>
       <name>language-tags</name>
       <version>0.3.2</version>
       <description>Language tags for Rust</description>
@@ -10608,7 +10608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -10630,7 +10630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -10652,7 +10652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -10674,7 +10674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -10696,7 +10696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -10718,7 +10718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -10743,7 +10743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -10762,7 +10762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10781,7 +10781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10800,7 +10800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10819,7 +10819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10838,7 +10838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10897,7 +10897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10919,7 +10919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10944,7 +10944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10966,7 +10966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -11007,7 +11007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -11051,7 +11051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -11073,7 +11073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>local-waker</name>
       <version>0.1.4</version>
       <description>A synchronization primitive for thread-local task wakeup</description>
@@ -11092,7 +11092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -11133,7 +11133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -11152,7 +11152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -11171,7 +11171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -11190,7 +11190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -11209,7 +11209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -11234,7 +11234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -11256,7 +11256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -11299,7 +11299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -11318,7 +11318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -11337,7 +11337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -11362,7 +11362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -11387,7 +11387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -11406,7 +11406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -11475,7 +11475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -11500,7 +11500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -11522,7 +11522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -11547,7 +11547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -11569,7 +11569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -11588,7 +11588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -11610,7 +11610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -11632,7 +11632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -11654,7 +11654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -11679,7 +11679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -11722,7 +11722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -11744,7 +11744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -11766,7 +11766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11788,7 +11788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11810,7 +11810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11829,7 +11829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11848,7 +11848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11870,7 +11870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11892,7 +11892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;, Lynnesbian &lt;lynne@bune.city&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com>, Lynnesbian &lt;lynne@bune.city></author>
       <name>new_mime_guess</name>
       <version>4.0.4</version>
       <description>A simple crate for associating MIME types to file extensions.</description>
@@ -11977,7 +11977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -12065,7 +12065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -12087,7 +12087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -12197,7 +12197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -12247,7 +12247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -12391,7 +12391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -12410,7 +12410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -12429,7 +12429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -12448,7 +12448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>oas3</name>
       <version>0.20.1</version>
       <description>Structures and tools to parse, navigate, and validate OpenAPI v3.1.xß specifications</description>
@@ -12521,7 +12521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -12565,7 +12565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>oid-registry</name>
       <version>0.8.1</version>
       <description>Object Identifier (OID) database</description>
@@ -12587,7 +12587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -12609,7 +12609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -12628,7 +12628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -12647,7 +12647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -12669,7 +12669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -12821,7 +12821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -12846,7 +12846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12865,7 +12865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12884,7 +12884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12903,7 +12903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12928,7 +12928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12950,7 +12950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12990,7 +12990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -13012,7 +13012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -13031,7 +13031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -13056,7 +13056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -13075,7 +13075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -13094,7 +13094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -13116,7 +13116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -13157,7 +13157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -13179,7 +13179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3">
-      <author>Aditya Kumar &lt;git@adityais.dev&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Aditya Kumar &lt;git@adityais.dev>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>pastey</name>
       <version>0.2.3</version>
       <description>Macros for all your token pasting needs. Successor of paste.</description>
@@ -13220,7 +13220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -13239,7 +13239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -13277,7 +13277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -13321,7 +13321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -13346,7 +13346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -13371,7 +13371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -13396,7 +13396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -13465,7 +13465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -13484,7 +13484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -13503,7 +13503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -13522,7 +13522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -13595,7 +13595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -13617,7 +13617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -13674,7 +13674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -13696,7 +13696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -13718,7 +13718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -13737,7 +13737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -13821,7 +13821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -13880,7 +13880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -13899,7 +13899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -13921,7 +13921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -13971,7 +13971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13993,7 +13993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -14018,7 +14018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -14090,7 +14090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -14109,7 +14109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -14128,7 +14128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -14147,7 +14147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -14169,7 +14169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -14188,7 +14188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -14207,7 +14207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -14229,7 +14229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -14251,7 +14251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -14273,7 +14273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -14292,7 +14292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -14311,7 +14311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -14336,7 +14336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -14361,7 +14361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -14383,7 +14383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -14405,7 +14405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -14427,7 +14427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -14449,7 +14449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -14515,7 +14515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -14537,7 +14537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -14562,7 +14562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -14581,7 +14581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -14603,7 +14603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -14628,7 +14628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -14650,7 +14650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -14672,7 +14672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -14742,7 +14742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -14821,7 +14821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -14843,7 +14843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -14865,7 +14865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -14890,7 +14890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -15207,7 +15207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -15226,7 +15226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -15245,7 +15245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -15267,7 +15267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -15289,7 +15289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -15308,7 +15308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -15357,7 +15357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -15382,7 +15382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -15407,7 +15407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -15432,7 +15432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -15457,7 +15457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -15479,7 +15479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -15501,7 +15501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -15520,7 +15520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -15539,7 +15539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -15561,7 +15561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -15583,7 +15583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -15623,7 +15623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -15642,7 +15642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -15664,7 +15664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -15683,7 +15683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -15819,7 +15819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -15841,7 +15841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -15863,7 +15863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15882,7 +15882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -15901,7 +15901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15920,7 +15920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -16065,7 +16065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -16084,7 +16084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -16165,7 +16165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>rusticata-macros</name>
       <version>4.1.0</version>
       <description>Helper macros for Rusticata</description>
@@ -16187,7 +16187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -16209,7 +16209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -16333,7 +16333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -16355,7 +16355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -16377,7 +16377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -16421,7 +16421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -16446,7 +16446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars</name>
       <version>1.2.1</version>
       <description>Generate JSON Schemas from Rust code</description>
@@ -16468,7 +16468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars_derive</name>
       <version>1.2.1</version>
       <description>Macros for #[derive(JsonSchema)], for use with schemars</description>
@@ -16512,7 +16512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -16537,7 +16537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -16562,7 +16562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -16587,7 +16587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -16612,7 +16612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -16637,7 +16637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -16659,7 +16659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -16681,7 +16681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -16703,7 +16703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -16725,7 +16725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -16747,7 +16747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -16769,7 +16769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -16791,7 +16791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -16816,7 +16816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -16835,7 +16835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -16857,7 +16857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -16879,7 +16879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -16904,7 +16904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -16929,7 +16929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -16954,7 +16954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive_internals</name>
       <version>0.29.1</version>
       <description>AST representation used by Serde derive macros. Unstable.</description>
@@ -16997,7 +16997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -17019,7 +17019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -17038,7 +17038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -17060,7 +17060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -17082,7 +17082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -17104,7 +17104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -17126,7 +17126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -17192,7 +17192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -17277,7 +17277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -17302,7 +17302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
-      <author>Vladimir Matveev &lt;vmatveev@citrine.cc&gt;, Ian Jackson &lt;iwj@torproject.org&gt;</author>
+      <author>Vladimir Matveev &lt;vmatveev@citrine.cc>, Ian Jackson &lt;iwj@torproject.org></author>
       <name>shellexpand</name>
       <version>3.1.2</version>
       <description>Shell-like expansions in strings</description>
@@ -17324,7 +17324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -17343,7 +17343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -17365,7 +17365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -17409,7 +17409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -17428,7 +17428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -17453,7 +17453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -17472,7 +17472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -17497,7 +17497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -17519,7 +17519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -17560,7 +17560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -17579,7 +17579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -17601,7 +17601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -17623,7 +17623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -17645,7 +17645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -17667,7 +17667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -17689,7 +17689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -17711,7 +17711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -17736,7 +17736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.5.10</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -17761,7 +17761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -17786,7 +17786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>sourcemap</name>
       <version>9.3.2</version>
       <description>Basic sourcemap handling for Rust</description>
@@ -17808,7 +17808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -17827,7 +17827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -17865,7 +17865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -17915,7 +17915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -17934,7 +17934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -17953,7 +17953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -17972,7 +17972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -17994,7 +17994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -18016,7 +18016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -18038,7 +18038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -18060,7 +18060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4">
-      <author>4t145 &lt;u4t145@163.com&gt;</author>
+      <author>4t145 &lt;u4t145@163.com></author>
       <name>sse-stream</name>
       <version>0.2.4</version>
       <description>Conversion between http body and sse stream</description>
@@ -18082,7 +18082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -18104,7 +18104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -18176,7 +18176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -18195,7 +18195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -18220,7 +18220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -18245,7 +18245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18270,7 +18270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18295,7 +18295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18320,7 +18320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18345,7 +18345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18370,7 +18370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18395,7 +18395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -18420,7 +18420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -18442,7 +18442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -18511,7 +18511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -18533,7 +18533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -18552,7 +18552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -18634,7 +18634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -18656,7 +18656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -18681,7 +18681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -18703,7 +18703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -18778,7 +18778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -18827,7 +18827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -18846,7 +18846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -18865,7 +18865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -18887,7 +18887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -18909,7 +18909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -18931,7 +18931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -18956,7 +18956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -18981,7 +18981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -19000,7 +19000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -19019,7 +19019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -19041,7 +19041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -19079,7 +19079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -19098,7 +19098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -19117,7 +19117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -19163,7 +19163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -19185,7 +19185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -19225,7 +19225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -19301,7 +19301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -19323,7 +19323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -19345,7 +19345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -19367,7 +19367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-types@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;, Rafael Lemos &lt;flemos.rafael.dev@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com>, Rafael Lemos &lt;flemos.rafael.dev@gmail.com></author>
       <name>tonic-types</name>
       <version>0.14.5</version>
       <description>A collection of useful protobuf types that can be used with `tonic`. </description>
@@ -19389,7 +19389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -19411,7 +19411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -19433,7 +19433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -19458,7 +19458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -19483,7 +19483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -19505,7 +19505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.4">
-      <author>Zeki Sherif &lt;zekshi@amazon.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Zeki Sherif &lt;zekshi@amazon.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-appender</name>
       <version>0.2.4</version>
       <description>Provides utilities for file appenders and making non-blocking writers. </description>
@@ -19527,7 +19527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -19549,7 +19549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -19571,7 +19571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -19614,7 +19614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -19636,7 +19636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -19658,7 +19658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -19680,7 +19680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -19705,7 +19705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -19755,7 +19755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -19777,7 +19777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
-      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <author>Chip Senkbeil &lt;chip@senkbeil.org></author>
       <name>typed-path</name>
       <version>0.12.3</version>
       <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
@@ -19799,7 +19799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -19842,7 +19842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -19864,7 +19864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -19935,7 +19935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -19978,7 +19978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -20000,7 +20000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -20044,7 +20044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -20069,7 +20069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Boshen &lt;boshenc@gmail.com></author>
       <name>unicode-id-start</name>
       <version>1.4.0</version>
       <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
@@ -20091,7 +20091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -20113,7 +20113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -20138,7 +20138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -20163,7 +20163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -20185,7 +20185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -20207,7 +20207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -20229,7 +20229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -20276,7 +20276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -20298,7 +20298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -20320,7 +20320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -20364,7 +20364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -20386,7 +20386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -20405,7 +20405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -20430,7 +20430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -20452,7 +20452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -20477,7 +20477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -20499,7 +20499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -20518,7 +20518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui-vendored@0.1.2">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-swagger-ui-vendored</name>
       <version>0.1.2</version>
       <description>Vendored Swagger UI for utoipa</description>
@@ -20537,7 +20537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-swagger-ui</name>
       <version>9.0.2</version>
       <description>Swagger UI for utoipa</description>
@@ -20556,7 +20556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -20593,7 +20593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -20618,7 +20618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -20640,7 +20640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -20665,7 +20665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -20690,7 +20690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -20712,7 +20712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -20731,7 +20731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -20771,7 +20771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -20793,7 +20793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -20818,7 +20818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -20907,7 +20907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -20989,7 +20989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -21030,7 +21030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -21055,7 +21055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>x509-parser</name>
       <version>0.18.1</version>
       <description>Parser for the X.509 v3 format (RFC 5280 certificates)</description>
@@ -21077,7 +21077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -21099,7 +21099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -21118,7 +21118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -21140,7 +21140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -21159,7 +21159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -21178,7 +21178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -21197,7 +21197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -21216,7 +21216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -21235,7 +21235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -21317,7 +21317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -21355,7 +21355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -21374,7 +21374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21393,7 +21393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@3.0.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>3.0.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21412,7 +21412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>8.2.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21452,7 +21452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -21495,7 +21495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -21514,7 +21514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -21536,7 +21536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -22718,7 +22718,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d#openobserve@0.93.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
@@ -22729,7 +22729,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
@@ -22742,21 +22742,21 @@
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -22765,9 +22765,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
@@ -22777,13 +22777,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
@@ -22796,18 +22796,18 @@
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -22818,11 +22818,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -22839,29 +22839,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -22869,74 +22869,74 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-server@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -22945,21 +22945,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
@@ -22967,126 +22967,126 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -23095,18 +23095,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -23125,36 +23125,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -23200,7 +23200,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -23231,25 +23231,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -23257,36 +23257,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -23295,31 +23295,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -23330,10 +23330,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -23341,38 +23341,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -23381,7 +23381,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -23391,7 +23391,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -23402,7 +23402,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -23418,80 +23418,80 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -23503,41 +23503,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -23547,33 +23547,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -23584,12 +23584,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
@@ -23597,24 +23597,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -23623,17 +23623,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -23643,7 +23643,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -23652,48 +23652,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -23701,58 +23701,58 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -23760,10 +23760,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -23775,9 +23775,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -23786,9 +23786,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -23796,23 +23796,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1" />

--- a/src/api/common/openobserve-api-common.cdx.xml
+++ b/src/api/common/openobserve-api-common.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:30328441-fc32-4335-8a3f-edf16ad95e7c" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d80c27da-8e32-4ef3-911c-fe4192c6f1b0" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.791292000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.374021000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0 bin-target-0">
           <name>openobserve_api_common</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1805,7 +1805,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1893,7 +1893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1915,7 +1915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1937,7 +1937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1959,7 +1959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1984,10 +1984,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2009,7 +2009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2034,7 +2034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2059,7 +2059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2196,7 +2196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2218,7 +2218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2240,10 +2240,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2284,7 +2284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2328,7 +2328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2350,7 +2350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2372,7 +2372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2394,7 +2394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2416,7 +2416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2438,7 +2438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2460,7 +2460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2482,7 +2482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2526,7 +2526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2548,7 +2548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2592,7 +2592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2614,7 +2614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2636,7 +2636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2658,7 +2658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2764,7 +2764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2783,7 +2783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2802,7 +2802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2821,7 +2821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2846,7 +2846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2865,7 +2865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2884,7 +2884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2909,7 +2909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2934,7 +2934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2953,7 +2953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2975,7 +2975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2994,7 +2994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3013,7 +3013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3032,7 +3032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3051,7 +3051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3073,7 +3073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3120,7 +3120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3139,7 +3139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3161,7 +3161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3180,7 +3180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3287,7 +3287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3306,7 +3306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3325,7 +3325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3344,7 +3344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3363,7 +3363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3382,7 +3382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3401,7 +3401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3420,7 +3420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3439,7 +3439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3458,7 +3458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3477,7 +3477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3496,7 +3496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3515,7 +3515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3534,7 +3534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3553,7 +3553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3653,7 +3653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3675,7 +3675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3694,7 +3694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3737,7 +3737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3784,7 +3784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3806,7 +3806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3850,7 +3850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3872,7 +3872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3897,7 +3897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3922,7 +3922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3947,7 +3947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3972,7 +3972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3997,7 +3997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4047,7 +4047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4115,7 +4115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4203,7 +4203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4264,7 +4264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4286,7 +4286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4308,7 +4308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4330,7 +4330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4355,7 +4355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4380,7 +4380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4405,7 +4405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4427,7 +4427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4449,7 +4449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4471,7 +4471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4490,7 +4490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4509,7 +4509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4534,7 +4534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4556,7 +4556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4599,7 +4599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4618,7 +4618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4664,7 +4664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4705,7 +4705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4730,7 +4730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4752,7 +4752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4796,7 +4796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4815,7 +4815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4840,7 +4840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4925,7 +4925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4995,7 +4995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5017,7 +5017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5039,7 +5039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5061,7 +5061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5126,7 +5126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5263,7 +5263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5288,7 +5288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5331,7 +5331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5356,7 +5356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5375,7 +5375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5394,7 +5394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5413,7 +5413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5432,7 +5432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5504,7 +5504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5526,7 +5526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5548,7 +5548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5586,7 +5586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5608,7 +5608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5627,7 +5627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5646,7 +5646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5665,7 +5665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5747,7 +5747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5816,7 +5816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5835,7 +5835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5854,7 +5854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5876,7 +5876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6003,7 +6003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6091,7 +6091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6163,7 +6163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6209,7 +6209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6231,7 +6231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6253,7 +6253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6272,7 +6272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6291,7 +6291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6310,7 +6310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6329,7 +6329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6354,7 +6354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6438,7 +6438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6457,7 +6457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6479,7 +6479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6501,7 +6501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6523,7 +6523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6589,7 +6589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6646,7 +6646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6665,7 +6665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6690,7 +6690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6712,7 +6712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6734,7 +6734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6759,7 +6759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6784,7 +6784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6809,7 +6809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6849,7 +6849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6868,7 +6868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6893,7 +6893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6915,7 +6915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7002,7 +7002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7024,7 +7024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7046,7 +7046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7068,7 +7068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7093,7 +7093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7118,7 +7118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7197,7 +7197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7219,7 +7219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7241,7 +7241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7260,7 +7260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7279,7 +7279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7304,7 +7304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7348,7 +7348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7370,7 +7370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7392,7 +7392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7433,7 +7433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7455,7 +7455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7474,7 +7474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7493,7 +7493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7561,7 +7561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7583,7 +7583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7608,7 +7608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7630,7 +7630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7652,7 +7652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7674,7 +7674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7693,7 +7693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7731,7 +7731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7756,7 +7756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7778,7 +7778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7803,7 +7803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7822,7 +7822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7907,7 +7907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7950,7 +7950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8105,7 +8105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8237,7 +8237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8284,7 +8284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8306,7 +8306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8325,7 +8325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8344,7 +8344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8363,7 +8363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8382,7 +8382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8419,7 +8419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8462,7 +8462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8487,7 +8487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8530,7 +8530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8596,7 +8596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8639,7 +8639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8658,7 +8658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8680,7 +8680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8702,7 +8702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8724,7 +8724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8746,7 +8746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8768,7 +8768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8790,7 +8790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8809,7 +8809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8904,7 +8904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8929,7 +8929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8954,7 +8954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8979,7 +8979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9152,7 +9152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9239,7 +9239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9283,7 +9283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9327,7 +9327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9349,7 +9349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9371,7 +9371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9393,7 +9393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9415,7 +9415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9434,7 +9434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9453,7 +9453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9559,7 +9559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9581,7 +9581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9606,7 +9606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9628,7 +9628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9650,7 +9650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9675,7 +9675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9694,7 +9694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9760,7 +9760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9779,7 +9779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9798,7 +9798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9820,7 +9820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9842,7 +9842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9864,7 +9864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9886,7 +9886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9908,7 +9908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9933,7 +9933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9952,7 +9952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9971,7 +9971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10009,7 +10009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10028,7 +10028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10087,7 +10087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10109,7 +10109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10134,7 +10134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10156,7 +10156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10197,7 +10197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10241,7 +10241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10263,7 +10263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10304,7 +10304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10323,7 +10323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10342,7 +10342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10361,7 +10361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10380,7 +10380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10405,7 +10405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10427,7 +10427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10449,7 +10449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10468,7 +10468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10487,7 +10487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10512,7 +10512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10537,7 +10537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10556,7 +10556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10625,7 +10625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10650,7 +10650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10672,7 +10672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10697,7 +10697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10719,7 +10719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10738,7 +10738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10760,7 +10760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10782,7 +10782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10804,7 +10804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10829,7 +10829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10872,7 +10872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10894,7 +10894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10916,7 +10916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10938,7 +10938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10960,7 +10960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10979,7 +10979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10998,7 +10998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11020,7 +11020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11105,7 +11105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11193,7 +11193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11215,7 +11215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11237,7 +11237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11256,7 +11256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11275,7 +11275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11325,7 +11325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11375,7 +11375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11519,7 +11519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11538,7 +11538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11557,7 +11557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11630,7 +11630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11674,7 +11674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11696,7 +11696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11715,7 +11715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11734,7 +11734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11756,7 +11756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11866,7 +11866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11891,7 +11891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11910,7 +11910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11929,7 +11929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11948,7 +11948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11973,7 +11973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11995,7 +11995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12035,7 +12035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12057,7 +12057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12076,7 +12076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12101,7 +12101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12120,7 +12120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12139,7 +12139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12161,7 +12161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12202,7 +12202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12224,7 +12224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12243,7 +12243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12281,7 +12281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12325,7 +12325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12350,7 +12350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12375,7 +12375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12400,7 +12400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12469,7 +12469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12488,7 +12488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12507,7 +12507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12526,7 +12526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12599,7 +12599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12621,7 +12621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12678,7 +12678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12700,7 +12700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12722,7 +12722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12741,7 +12741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12825,7 +12825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12863,7 +12863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12882,7 +12882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12904,7 +12904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12954,7 +12954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12976,7 +12976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13001,7 +13001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13073,7 +13073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13092,7 +13092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13111,7 +13111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13130,7 +13130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13152,7 +13152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13171,7 +13171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13190,7 +13190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13212,7 +13212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13234,7 +13234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13256,7 +13256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13275,7 +13275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13294,7 +13294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13319,7 +13319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13344,7 +13344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13366,7 +13366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13388,7 +13388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13410,7 +13410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13432,7 +13432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13454,7 +13454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13476,7 +13476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13498,7 +13498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13520,7 +13520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13545,7 +13545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13564,7 +13564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13586,7 +13586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13611,7 +13611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13633,7 +13633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13655,7 +13655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13725,7 +13725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13804,7 +13804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13826,7 +13826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13848,7 +13848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13873,7 +13873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14209,7 +14209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14228,7 +14228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14250,7 +14250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14272,7 +14272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14291,7 +14291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14340,7 +14340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14365,7 +14365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14390,7 +14390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14415,7 +14415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14440,7 +14440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14462,7 +14462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14484,7 +14484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14503,7 +14503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14522,7 +14522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14544,7 +14544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14566,7 +14566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14606,7 +14606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14625,7 +14625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14647,7 +14647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14666,7 +14666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14685,7 +14685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14707,7 +14707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14729,7 +14729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14748,7 +14748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14767,7 +14767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14786,7 +14786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14808,7 +14808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14827,7 +14827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14908,7 +14908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14930,7 +14930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15054,7 +15054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15076,7 +15076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15098,7 +15098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15142,7 +15142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15189,7 +15189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15214,7 +15214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15239,7 +15239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15264,7 +15264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15289,7 +15289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15314,7 +15314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15336,7 +15336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15358,7 +15358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15380,7 +15380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15402,7 +15402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15424,7 +15424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15446,7 +15446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15468,7 +15468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15512,7 +15512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15534,7 +15534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15556,7 +15556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15581,7 +15581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15606,7 +15606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15631,7 +15631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15653,7 +15653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15672,7 +15672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15694,7 +15694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15716,7 +15716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15738,7 +15738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15760,7 +15760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15826,7 +15826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15911,7 +15911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15936,7 +15936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15955,7 +15955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15977,7 +15977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16021,7 +16021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16040,7 +16040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16065,7 +16065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16084,7 +16084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16109,7 +16109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16131,7 +16131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16172,7 +16172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16191,7 +16191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16213,7 +16213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16235,7 +16235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16257,7 +16257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16279,7 +16279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16301,7 +16301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16323,7 +16323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16348,7 +16348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16373,7 +16373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16392,7 +16392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16430,7 +16430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16480,7 +16480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16499,7 +16499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16518,7 +16518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16537,7 +16537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16559,7 +16559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16581,7 +16581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16603,7 +16603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16625,7 +16625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16647,7 +16647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16719,7 +16719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16738,7 +16738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16763,7 +16763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16788,7 +16788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16813,7 +16813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16838,7 +16838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16863,7 +16863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16888,7 +16888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16913,7 +16913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16938,7 +16938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16963,7 +16963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16985,7 +16985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17007,7 +17007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17029,7 +17029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17054,7 +17054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17076,7 +17076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17095,7 +17095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17177,7 +17177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17199,7 +17199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17224,7 +17224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17246,7 +17246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17321,7 +17321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17370,7 +17370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17389,7 +17389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17408,7 +17408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17430,7 +17430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17452,7 +17452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17474,7 +17474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17524,7 +17524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17562,7 +17562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17584,7 +17584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17622,7 +17622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17641,7 +17641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17660,7 +17660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17706,7 +17706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17728,7 +17728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17768,7 +17768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17844,7 +17844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17866,7 +17866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17888,7 +17888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17910,7 +17910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17932,7 +17932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17954,7 +17954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18004,7 +18004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18026,7 +18026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18048,7 +18048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18070,7 +18070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18113,7 +18113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18135,7 +18135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18157,7 +18157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18179,7 +18179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18204,7 +18204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18254,7 +18254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18276,7 +18276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18319,7 +18319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18341,7 +18341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18412,7 +18412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18455,7 +18455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18477,7 +18477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18521,7 +18521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18546,7 +18546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18568,7 +18568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18593,7 +18593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18618,7 +18618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18640,7 +18640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18662,7 +18662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18684,7 +18684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18731,7 +18731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18753,7 +18753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18775,7 +18775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18819,7 +18819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18841,7 +18841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18860,7 +18860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18885,7 +18885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18907,7 +18907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18932,7 +18932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18954,7 +18954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18973,7 +18973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19010,7 +19010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19035,7 +19035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19057,7 +19057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19082,7 +19082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19107,7 +19107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19129,7 +19129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19148,7 +19148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19188,7 +19188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19210,7 +19210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19235,7 +19235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19324,7 +19324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19406,7 +19406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19447,7 +19447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19472,7 +19472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19494,7 +19494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19513,7 +19513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19535,7 +19535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19554,7 +19554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19573,7 +19573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19592,7 +19592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19611,7 +19611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19630,7 +19630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19712,7 +19712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19750,7 +19750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19769,7 +19769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19809,7 +19809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19831,7 +19831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19850,7 +19850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19872,7 +19872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21033,18 +21033,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -21052,27 +21052,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21091,12 +21091,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21142,7 +21142,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21173,25 +21173,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21199,36 +21199,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21237,31 +21237,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21272,15 +21272,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21289,7 +21289,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21299,7 +21299,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21310,7 +21310,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21326,55 +21326,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21384,33 +21384,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21421,24 +21421,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21447,17 +21447,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21467,7 +21467,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21476,48 +21476,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21525,25 +21525,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21551,10 +21551,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21566,9 +21566,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21576,16 +21576,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/common/openobserve-api-common.cdx.xml
+++ b/src/api/common/openobserve-api-common.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:30328441-fc32-4335-8a3f-edf16ad95e7c" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.791292000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0 bin-target-0">
+          <name>openobserve_api_common</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1640,88 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1730,79 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2883,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3849,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3896,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3943,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4379,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4595,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4836,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5431,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5547,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5639,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6162,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6494,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6911,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7369,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7489,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8126,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8431,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9414,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9627,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9690,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10303,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10552,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11079,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11252,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11802,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11841,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12053,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12277,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13047,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13563,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14091,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14728,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14845,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15213,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15251,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15379,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15489,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15652,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15690,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15742,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15976,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16061,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16234,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16291,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16369,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16812,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16875,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17223,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17498,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17746,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18091,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18200,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18386,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18433,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19056,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19125,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19987,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20491,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20593,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20749,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21033,69 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21173,108 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21289,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21420,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21894,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22315,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22330,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22413,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22442,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22475,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22590,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22605,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22614,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22689,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22771,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22848,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +22923,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +22947,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23048,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23115,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23310,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23339,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23371,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23504,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23563,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23654,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23683,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23775,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23833,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23893,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24028,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24157,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24267,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24474,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24513,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24584,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24604,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24669,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24693,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24723,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24794,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24843,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24858,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25079,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25090,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25156,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25192,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25250,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25384,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25418,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25454,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25520,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/api/grpc/openobserve-api-grpc.cdx.xml
+++ b/src/api/grpc/openobserve-api-grpc.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:99be0280-34aa-4e55-9572-881997b411fd" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.232106000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+      <name>openobserve-api-grpc</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0 bin-target-0">
+          <name>openobserve_api_grpc</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,33 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1649,97 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1748,79 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2901,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3867,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3914,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3961,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4397,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4613,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4854,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5449,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5565,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5657,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6180,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6512,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6929,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7387,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7507,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8144,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7819,6 +8458,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8012,6 +8672,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/veddan/rust-htmlescape</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
+      <author>Esteban Borai &lt;estebanborai@gmail.com&gt;</author>
+      <name>http-auth-basic</name>
+      <version>0.3.7</version>
+      <description>HTTP Basic Authentication Scheme (RFC 7617 and RFC 2617 compliant, base64-encoded credentials) for Rust applications</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e92637d714ad90b81c91bce86e8c1f98fb32ca79bddf8d69e9d83fee3966946</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/http-auth-basic@0.3.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/EstebanBorai/http-auth-basic</url>
         </reference>
       </externalReferences>
     </component>
@@ -8772,6 +9451,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9664,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9727,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10340,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10589,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11116,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11289,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11839,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11878,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12090,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12314,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13084,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13600,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14128,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14765,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14882,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15250,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15288,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15416,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15526,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15689,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15727,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15779,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +16013,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16098,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16271,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16328,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16406,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16849,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16912,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17260,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17535,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17783,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18128,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18237,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18423,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18470,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19093,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19162,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +20024,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20528,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20630,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20786,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21070,109 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21250,142 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21400,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21531,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +22005,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22426,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22441,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22524,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22553,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22586,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22701,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22716,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22725,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22800,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22882,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22959,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +23034,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +23058,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23159,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20798,6 +23227,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20817,6 +23249,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -20989,6 +23424,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23453,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23485,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23618,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23677,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23768,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23797,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23889,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23947,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +24007,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24142,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24271,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24381,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24588,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24627,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24698,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24718,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24783,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24807,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24837,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24908,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24957,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24972,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25193,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25204,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25270,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25306,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25364,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25498,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25532,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25568,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25634,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/api/grpc/openobserve-api-grpc.cdx.xml
+++ b/src/api/grpc/openobserve-api-grpc.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:99be0280-34aa-4e55-9572-881997b411fd" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:60296e5c-734e-402e-abe2-2b867c482297" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.232106000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.779918000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0">
       <name>openobserve-api-grpc</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0 bin-target-0">
           <name>openobserve_api_grpc</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1823,7 +1823,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1911,7 +1911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1933,7 +1933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1955,7 +1955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1977,7 +1977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2027,7 +2027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2052,7 +2052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2077,7 +2077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2174,7 +2174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2214,7 +2214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2236,7 +2236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2258,10 +2258,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2302,7 +2302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2346,7 +2346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2368,7 +2368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2390,7 +2390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2412,7 +2412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2434,7 +2434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2456,7 +2456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2478,7 +2478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2500,7 +2500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2522,7 +2522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2544,7 +2544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2566,7 +2566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2588,7 +2588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2610,7 +2610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2632,7 +2632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2654,7 +2654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2676,7 +2676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2782,7 +2782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2801,7 +2801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2820,7 +2820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2839,7 +2839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2864,7 +2864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2883,7 +2883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2902,7 +2902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2927,7 +2927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2952,7 +2952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2971,7 +2971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2993,7 +2993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3012,7 +3012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3031,7 +3031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3050,7 +3050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3091,7 +3091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3138,7 +3138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3157,7 +3157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3179,7 +3179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3198,7 +3198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3267,7 +3267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3286,7 +3286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3305,7 +3305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3324,7 +3324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3343,7 +3343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3362,7 +3362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3381,7 +3381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3400,7 +3400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3419,7 +3419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3438,7 +3438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3457,7 +3457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3476,7 +3476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3495,7 +3495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3514,7 +3514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3533,7 +3533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3552,7 +3552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3571,7 +3571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3671,7 +3671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3693,7 +3693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3712,7 +3712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3755,7 +3755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3802,7 +3802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3824,7 +3824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3868,7 +3868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3890,7 +3890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3915,7 +3915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3940,7 +3940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3965,7 +3965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3990,7 +3990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4015,7 +4015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4065,7 +4065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4133,7 +4133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4221,7 +4221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4282,7 +4282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4326,7 +4326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4348,7 +4348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4373,7 +4373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4398,7 +4398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4423,7 +4423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4445,7 +4445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4467,7 +4467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4489,7 +4489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4508,7 +4508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4527,7 +4527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4552,7 +4552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4574,7 +4574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4617,7 +4617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4636,7 +4636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4682,7 +4682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4723,7 +4723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4748,7 +4748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4770,7 +4770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4814,7 +4814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4833,7 +4833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4858,7 +4858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4943,7 +4943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5013,7 +5013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5035,7 +5035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5057,7 +5057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5079,7 +5079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5281,7 +5281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5306,7 +5306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5349,7 +5349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5374,7 +5374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5412,7 +5412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5431,7 +5431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5450,7 +5450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5522,7 +5522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5544,7 +5544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5566,7 +5566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5604,7 +5604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5626,7 +5626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5645,7 +5645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5664,7 +5664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5683,7 +5683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5765,7 +5765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5834,7 +5834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5853,7 +5853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5872,7 +5872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5894,7 +5894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6021,7 +6021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6109,7 +6109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6134,7 +6134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6181,7 +6181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6227,7 +6227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6249,7 +6249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6271,7 +6271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6290,7 +6290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6309,7 +6309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6328,7 +6328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6347,7 +6347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6372,7 +6372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6456,7 +6456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6475,7 +6475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6497,7 +6497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6519,7 +6519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6607,7 +6607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6708,7 +6708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6730,7 +6730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6752,7 +6752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6777,7 +6777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6802,7 +6802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6827,7 +6827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6867,7 +6867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6886,7 +6886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6911,7 +6911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6933,7 +6933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7020,7 +7020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7042,7 +7042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7064,7 +7064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7086,7 +7086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7111,7 +7111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7136,7 +7136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7215,7 +7215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7237,7 +7237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7259,7 +7259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7278,7 +7278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7297,7 +7297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7322,7 +7322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7344,7 +7344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7366,7 +7366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7388,7 +7388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7410,7 +7410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7432,7 +7432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7451,7 +7451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7473,7 +7473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7492,7 +7492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7511,7 +7511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7579,7 +7579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7601,7 +7601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7626,7 +7626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7648,7 +7648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7670,7 +7670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7692,7 +7692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7711,7 +7711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7749,7 +7749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7774,7 +7774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7796,7 +7796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7821,7 +7821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7840,7 +7840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7925,7 +7925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7968,7 +7968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8056,7 +8056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8123,7 +8123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8255,7 +8255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8302,7 +8302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8324,7 +8324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8343,7 +8343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8362,7 +8362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8381,7 +8381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8400,7 +8400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8437,7 +8437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8480,7 +8480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8505,7 +8505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8548,7 +8548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8614,7 +8614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8657,7 +8657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8676,7 +8676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
-      <author>Esteban Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Esteban Borai &lt;estebanborai@gmail.com></author>
       <name>http-auth-basic</name>
       <version>0.3.7</version>
       <description>HTTP Basic Authentication Scheme (RFC 7617 and RFC 2617 compliant, base64-encoded credentials) for Rust applications</description>
@@ -8695,7 +8695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8717,7 +8717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8739,7 +8739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8761,7 +8761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8783,7 +8783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8805,7 +8805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8827,7 +8827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8846,7 +8846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8941,7 +8941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8966,7 +8966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8991,7 +8991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9016,7 +9016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9189,7 +9189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9276,7 +9276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9320,7 +9320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9364,7 +9364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9386,7 +9386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9408,7 +9408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9430,7 +9430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9452,7 +9452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9471,7 +9471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9490,7 +9490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9596,7 +9596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9618,7 +9618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9687,7 +9687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9712,7 +9712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9731,7 +9731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9797,7 +9797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9835,7 +9835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9857,7 +9857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9879,7 +9879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9901,7 +9901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9923,7 +9923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9945,7 +9945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9970,7 +9970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9989,7 +9989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10008,7 +10008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10027,7 +10027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10046,7 +10046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10065,7 +10065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10124,7 +10124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10146,7 +10146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10171,7 +10171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10193,7 +10193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10278,7 +10278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10300,7 +10300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10341,7 +10341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10360,7 +10360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10379,7 +10379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10398,7 +10398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10417,7 +10417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10442,7 +10442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10464,7 +10464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10486,7 +10486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10505,7 +10505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10524,7 +10524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10549,7 +10549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10574,7 +10574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10593,7 +10593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10662,7 +10662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10687,7 +10687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10709,7 +10709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10734,7 +10734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10756,7 +10756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10775,7 +10775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10797,7 +10797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10819,7 +10819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10841,7 +10841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10866,7 +10866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10909,7 +10909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10931,7 +10931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10953,7 +10953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10975,7 +10975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10997,7 +10997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11016,7 +11016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11035,7 +11035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11057,7 +11057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11142,7 +11142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11230,7 +11230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11252,7 +11252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11274,7 +11274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11293,7 +11293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11312,7 +11312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11362,7 +11362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11412,7 +11412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11556,7 +11556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11575,7 +11575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11594,7 +11594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11667,7 +11667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11711,7 +11711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11733,7 +11733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11752,7 +11752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11771,7 +11771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11793,7 +11793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11903,7 +11903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11928,7 +11928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11947,7 +11947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11966,7 +11966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11985,7 +11985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12010,7 +12010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12032,7 +12032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12072,7 +12072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12094,7 +12094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12113,7 +12113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12138,7 +12138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12157,7 +12157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12176,7 +12176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12198,7 +12198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12239,7 +12239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12261,7 +12261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12280,7 +12280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12318,7 +12318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12362,7 +12362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12387,7 +12387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12412,7 +12412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12437,7 +12437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12506,7 +12506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12525,7 +12525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12544,7 +12544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12563,7 +12563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12636,7 +12636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12658,7 +12658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12715,7 +12715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12737,7 +12737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12759,7 +12759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12778,7 +12778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12862,7 +12862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12900,7 +12900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12919,7 +12919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12941,7 +12941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12991,7 +12991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13013,7 +13013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13038,7 +13038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13110,7 +13110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13129,7 +13129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13148,7 +13148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13167,7 +13167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13189,7 +13189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13208,7 +13208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13227,7 +13227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13249,7 +13249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13271,7 +13271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13293,7 +13293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13312,7 +13312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13331,7 +13331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13356,7 +13356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13381,7 +13381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13403,7 +13403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13425,7 +13425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13447,7 +13447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13469,7 +13469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13491,7 +13491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13513,7 +13513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13535,7 +13535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13557,7 +13557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13582,7 +13582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13601,7 +13601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13623,7 +13623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13648,7 +13648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13670,7 +13670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13692,7 +13692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13762,7 +13762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13841,7 +13841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13863,7 +13863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13885,7 +13885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13910,7 +13910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14227,7 +14227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14246,7 +14246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14265,7 +14265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14287,7 +14287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14328,7 +14328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14377,7 +14377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14402,7 +14402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14427,7 +14427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14452,7 +14452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14477,7 +14477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14499,7 +14499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14521,7 +14521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14540,7 +14540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14559,7 +14559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14581,7 +14581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14603,7 +14603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14643,7 +14643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14662,7 +14662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14703,7 +14703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14722,7 +14722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14744,7 +14744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14766,7 +14766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14785,7 +14785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14804,7 +14804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14823,7 +14823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14845,7 +14845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14864,7 +14864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14945,7 +14945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14967,7 +14967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15091,7 +15091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15113,7 +15113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15135,7 +15135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15179,7 +15179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15226,7 +15226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15251,7 +15251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15276,7 +15276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15301,7 +15301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15326,7 +15326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15351,7 +15351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15373,7 +15373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15395,7 +15395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15417,7 +15417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15439,7 +15439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15461,7 +15461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15483,7 +15483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15505,7 +15505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15530,7 +15530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15549,7 +15549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15571,7 +15571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15593,7 +15593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15618,7 +15618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15643,7 +15643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15668,7 +15668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15690,7 +15690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15709,7 +15709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15731,7 +15731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15753,7 +15753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15775,7 +15775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15797,7 +15797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15863,7 +15863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15948,7 +15948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15973,7 +15973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15992,7 +15992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -16014,7 +16014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16058,7 +16058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16077,7 +16077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16102,7 +16102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16121,7 +16121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16146,7 +16146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16168,7 +16168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16209,7 +16209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16228,7 +16228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16250,7 +16250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16272,7 +16272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16294,7 +16294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16316,7 +16316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16338,7 +16338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16360,7 +16360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16385,7 +16385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16410,7 +16410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16429,7 +16429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16467,7 +16467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16536,7 +16536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16555,7 +16555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16574,7 +16574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16596,7 +16596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16618,7 +16618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16640,7 +16640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16662,7 +16662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16684,7 +16684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16756,7 +16756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16775,7 +16775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16800,7 +16800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16825,7 +16825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16850,7 +16850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16875,7 +16875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16900,7 +16900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16925,7 +16925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16975,7 +16975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -17000,7 +17000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -17022,7 +17022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17044,7 +17044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17066,7 +17066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17091,7 +17091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17113,7 +17113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17132,7 +17132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17214,7 +17214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17236,7 +17236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17261,7 +17261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17283,7 +17283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17358,7 +17358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17407,7 +17407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17426,7 +17426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17445,7 +17445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17467,7 +17467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17489,7 +17489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17511,7 +17511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17536,7 +17536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17561,7 +17561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17580,7 +17580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17599,7 +17599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17621,7 +17621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17659,7 +17659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17678,7 +17678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17743,7 +17743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17765,7 +17765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17805,7 +17805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17881,7 +17881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17903,7 +17903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17925,7 +17925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17947,7 +17947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17969,7 +17969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17991,7 +17991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -18016,7 +18016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18041,7 +18041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18063,7 +18063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18085,7 +18085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18107,7 +18107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18150,7 +18150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18172,7 +18172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18194,7 +18194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18216,7 +18216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18241,7 +18241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18291,7 +18291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18313,7 +18313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18356,7 +18356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18378,7 +18378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18449,7 +18449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18492,7 +18492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18514,7 +18514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18558,7 +18558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18583,7 +18583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18605,7 +18605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18630,7 +18630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18655,7 +18655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18677,7 +18677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18699,7 +18699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18721,7 +18721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18768,7 +18768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18790,7 +18790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18812,7 +18812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18856,7 +18856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18878,7 +18878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18897,7 +18897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18922,7 +18922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18944,7 +18944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18969,7 +18969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18991,7 +18991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -19010,7 +19010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19047,7 +19047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19072,7 +19072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19094,7 +19094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19119,7 +19119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19144,7 +19144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19166,7 +19166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19185,7 +19185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19225,7 +19225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19247,7 +19247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19272,7 +19272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19361,7 +19361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19443,7 +19443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19484,7 +19484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19509,7 +19509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19531,7 +19531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19550,7 +19550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19572,7 +19572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19591,7 +19591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19610,7 +19610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19629,7 +19629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19648,7 +19648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19667,7 +19667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19749,7 +19749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19787,7 +19787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19806,7 +19806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19846,7 +19846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19868,7 +19868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19887,7 +19887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19909,7 +19909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21070,62 +21070,62 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/grpc#openobserve-api-grpc@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21144,36 +21144,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21219,7 +21219,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21250,25 +21250,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21276,36 +21276,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21314,31 +21314,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21349,10 +21349,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -21360,38 +21360,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21400,7 +21400,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21410,7 +21410,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21421,7 +21421,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21437,55 +21437,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21495,33 +21495,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21532,24 +21532,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21558,17 +21558,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21578,7 +21578,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21587,48 +21587,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21636,25 +21636,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21662,10 +21662,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21677,9 +21677,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21687,16 +21687,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/http/openobserve-api-http.cdx.xml
+++ b/src/api/http/openobserve-api-http.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:8f05c422-3b11-4591-8771-17eb93c93d5d" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:95cd0509-73ff-4af7-8f43-b2fd440a397a" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.550383000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.144915000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0">
       <name>openobserve-api-http</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0 bin-target-0">
           <name>openobserve_api_http</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -838,7 +838,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%3Fbranch=v0.23.2-feat%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
+      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
       <externalReferences>
         <reference type="website">
           <url>https://gitlab.com/lx-industries/rmcp-openapi</url>
@@ -849,7 +849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -857,7 +857,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -871,7 +871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -879,7 +879,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -893,7 +893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -901,7 +901,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -922,7 +922,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -933,7 +933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -941,7 +941,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -955,7 +955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1017,7 +1017,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1028,24 +1028,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1053,7 +1053,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1064,7 +1064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1072,7 +1072,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1083,7 +1083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1091,7 +1091,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1102,7 +1102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1110,7 +1110,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1121,7 +1121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1129,7 +1129,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1140,7 +1140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1148,7 +1148,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1159,7 +1159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1167,7 +1167,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1178,7 +1178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1186,7 +1186,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1197,7 +1197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1205,7 +1205,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1216,7 +1216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1224,7 +1224,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1235,7 +1235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1243,7 +1243,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1254,7 +1254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1262,7 +1262,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1273,7 +1273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1281,7 +1281,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1292,7 +1292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1300,7 +1300,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1311,7 +1311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1319,7 +1319,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1330,7 +1330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1338,7 +1338,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1349,7 +1349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1357,7 +1357,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1368,7 +1368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1376,7 +1376,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1387,7 +1387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1395,7 +1395,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1406,7 +1406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1414,7 +1414,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1425,7 +1425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1433,7 +1433,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1444,7 +1444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1452,7 +1452,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1463,7 +1463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1471,7 +1471,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1482,7 +1482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1490,7 +1490,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1501,7 +1501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1509,7 +1509,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1520,7 +1520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1528,7 +1528,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1539,7 +1539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1547,7 +1547,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1558,7 +1558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1566,7 +1566,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1577,7 +1577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1585,7 +1585,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1596,7 +1596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1604,7 +1604,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1623,7 +1623,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1633,7 +1633,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <name>openobserve-api-ingest</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://../ingest</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <name>openobserve-api-management</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://../management</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <name>openobserve-api-pipelines</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://../pipelines</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <name>openobserve-api-search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <name>openobserve-mcp</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://../../mcp</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../../org_storage</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1822,7 +1822,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1831,7 +1831,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1840,7 +1840,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1849,7 +1849,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1858,7 +1858,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1867,7 +1867,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <name>openobserve-sourcemaps</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1876,7 +1876,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://../../sourcemaps</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1885,7 +1885,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1894,7 +1894,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <name>openobserve-tls</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1903,7 +1903,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://../../tls</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1912,7 +1912,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1921,7 +1921,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1931,7 +1931,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-codec</name>
       <version>0.5.2</version>
       <description>Codec utilities for working with framed protocols</description>
@@ -1950,7 +1950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-http</name>
       <version>3.13.1</version>
       <description>HTTP types and services for the Actix ecosystem</description>
@@ -1972,7 +1972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-router</name>
       <version>0.5.4</version>
       <description>Resource path matching and router</description>
@@ -1991,7 +1991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-rt</name>
       <version>2.11.0</version>
       <description>Tokio-based single-threaded async runtime for the Actix ecosystem</description>
@@ -2013,7 +2013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com></author>
       <name>actix-server</name>
       <version>2.6.0</version>
       <description>General purpose TCP server built for the Actix ecosystem</description>
@@ -2035,7 +2035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-service</name>
       <version>2.0.3</version>
       <description>Service trait and combinators for representing asynchronous request/response operations.</description>
@@ -2054,7 +2054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-utils</name>
       <version>3.0.1</version>
       <description>Various utilities used in the Actix ecosystem</description>
@@ -2073,7 +2073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-web</name>
       <version>4.14.0</version>
       <description>Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust</description>
@@ -2095,7 +2095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -2183,7 +2183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -2205,7 +2205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -2227,7 +2227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -2249,7 +2249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2274,10 +2274,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2299,7 +2299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2324,7 +2324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2349,7 +2349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2446,7 +2446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2486,7 +2486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2508,7 +2508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2530,10 +2530,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2574,7 +2574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2618,7 +2618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2640,7 +2640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2662,7 +2662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2684,7 +2684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2706,7 +2706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2750,7 +2750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2772,7 +2772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2794,7 +2794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2816,7 +2816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2838,7 +2838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2860,7 +2860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2882,7 +2882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2904,7 +2904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2926,7 +2926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2948,7 +2948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -3054,7 +3054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-derive</name>
       <version>0.6.0</version>
       <description>Derive macros for the `asn1-rs` crate</description>
@@ -3076,7 +3076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-impl</name>
       <version>0.2.0</version>
       <description>Implementation details for the `asn1-rs` crate</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs</name>
       <version>0.7.1</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -3120,7 +3120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -3139,7 +3139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -3158,7 +3158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -3177,7 +3177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -3202,7 +3202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -3221,7 +3221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -3240,7 +3240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -3265,7 +3265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -3290,7 +3290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -3309,7 +3309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -3331,7 +3331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3350,7 +3350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3369,7 +3369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3388,7 +3388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3407,7 +3407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3429,7 +3429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3476,7 +3476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3495,7 +3495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3517,7 +3517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3536,7 +3536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3605,7 +3605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3624,7 +3624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3643,7 +3643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3662,7 +3662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3681,7 +3681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3700,7 +3700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3719,7 +3719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3738,7 +3738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3757,7 +3757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3776,7 +3776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3795,7 +3795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3814,7 +3814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3833,7 +3833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3852,7 +3852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3871,7 +3871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3890,7 +3890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3909,7 +3909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -4009,7 +4009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-server@0.8.0">
-      <author>Programatik &lt;programatik29@gmail.com&gt;, Adi Salimgereev &lt;adisalimgereev@gmail.com&gt;</author>
+      <author>Programatik &lt;programatik29@gmail.com>, Adi Salimgereev &lt;adisalimgereev@gmail.com></author>
       <name>axum-server</name>
       <version>0.8.0</version>
       <description>High level server designed to be used with axum framework.</description>
@@ -4052,7 +4052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -4074,7 +4074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -4093,7 +4093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -4136,7 +4136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -4183,7 +4183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -4205,7 +4205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -4249,7 +4249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -4271,7 +4271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -4296,7 +4296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -4321,7 +4321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -4346,7 +4346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -4371,7 +4371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4396,7 +4396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4446,7 +4446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4514,7 +4514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4602,7 +4602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4663,7 +4663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4685,7 +4685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4707,7 +4707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4729,7 +4729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4754,7 +4754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4779,7 +4779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4804,7 +4804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4826,7 +4826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4848,7 +4848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4870,7 +4870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4889,7 +4889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4908,7 +4908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4933,7 +4933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4974,7 +4974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>bytestring</name>
       <version>1.5.1</version>
       <description>A UTF-8 encoded read-only string using `Bytes` as storage</description>
@@ -5020,7 +5020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -5039,7 +5039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -5085,7 +5085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -5126,7 +5126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -5151,7 +5151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -5173,7 +5173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -5217,7 +5217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -5236,7 +5236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -5261,7 +5261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -5346,7 +5346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5416,7 +5416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5438,7 +5438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5460,7 +5460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5482,7 +5482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5547,7 +5547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5684,7 +5684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5709,7 +5709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5752,7 +5752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5777,7 +5777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5796,7 +5796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5815,7 +5815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5834,7 +5834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5853,7 +5853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5925,7 +5925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5947,7 +5947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5969,7 +5969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -6007,7 +6007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -6029,7 +6029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -6048,7 +6048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -6067,7 +6067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -6086,7 +6086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -6105,7 +6105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cookie</name>
       <version>0.18.1</version>
       <description>HTTP cookie parsing and cookie jar management. Supports signed and private (encrypted, authenticated) jars. </description>
@@ -6190,7 +6190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -6259,7 +6259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -6278,7 +6278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -6297,7 +6297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6446,7 +6446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6534,7 +6534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6559,7 +6559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6606,7 +6606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6652,7 +6652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6674,7 +6674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6696,7 +6696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6715,7 +6715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6734,7 +6734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6753,7 +6753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6772,7 +6772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6797,7 +6797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6862,7 +6862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>debugid</name>
       <version>0.8.0</version>
       <description>Common reusable types for implementing the sentry.io protocol.</description>
@@ -6887,7 +6887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
-      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <author>anatawa12 &lt;anatawa12@icloud.com></author>
       <name>deflate64</name>
       <version>0.1.11</version>
       <description>Deflate64 implementation based on .NET's implementation</description>
@@ -6909,7 +6909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>der-parser</name>
       <version>10.0.0</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -6950,7 +6950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6969,7 +6969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6991,7 +6991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -7013,7 +7013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -7035,7 +7035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -7101,7 +7101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -7158,7 +7158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -7177,7 +7177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -7202,7 +7202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -7224,7 +7224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -7246,7 +7246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -7271,7 +7271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -7296,7 +7296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -7321,7 +7321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -7361,7 +7361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -7380,7 +7380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -7405,7 +7405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -7427,7 +7427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7514,7 +7514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7536,7 +7536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7558,7 +7558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7580,7 +7580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7605,7 +7605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7630,7 +7630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7709,7 +7709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7731,7 +7731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7753,7 +7753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7772,7 +7772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7791,7 +7791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7816,7 +7816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7838,7 +7838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7860,7 +7860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7882,7 +7882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7904,7 +7904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7926,7 +7926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7945,7 +7945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7967,7 +7967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7986,7 +7986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -8005,7 +8005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -8073,7 +8073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -8095,7 +8095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -8120,7 +8120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -8142,7 +8142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -8164,7 +8164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -8186,7 +8186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -8205,7 +8205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -8243,7 +8243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -8268,7 +8268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>fs-err</name>
       <version>3.3.0</version>
       <description>A drop-in replacement for std::fs with more helpful error messages.</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -8312,7 +8312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -8337,7 +8337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -8356,7 +8356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -8441,7 +8441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -8484,7 +8484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8572,7 +8572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8639,7 +8639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8771,7 +8771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8818,7 +8818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8840,7 +8840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8859,7 +8859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8878,7 +8878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8897,7 +8897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8916,7 +8916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8953,7 +8953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8996,7 +8996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -9021,7 +9021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers-core</name>
       <version>0.3.0</version>
       <description>typed HTTP headers core trait</description>
@@ -9043,7 +9043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers</name>
       <version>0.4.1</version>
       <description>typed HTTP headers</description>
@@ -9065,7 +9065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -9108,7 +9108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -9174,7 +9174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -9217,7 +9217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -9236,7 +9236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -9258,7 +9258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -9280,7 +9280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -9302,7 +9302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -9324,7 +9324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -9346,7 +9346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -9368,7 +9368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -9387,7 +9387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -9482,7 +9482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -9507,7 +9507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -9532,7 +9532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9557,7 +9557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9730,7 +9730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9796,7 +9796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com></author>
       <name>if_chain</name>
       <version>1.0.3</version>
       <description>Macro for writing nested `if let` expressions.</description>
@@ -9818,7 +9818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1">
-      <author>Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Rob Ede &lt;robjtede@icloud.com></author>
       <name>impl-more</name>
       <version>0.3.1</version>
       <description>Concise, declarative trait implementation macros</description>
@@ -9858,7 +9858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9902,7 +9902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9946,7 +9946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9968,7 +9968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -10012,7 +10012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -10034,7 +10034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -10053,7 +10053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -10072,7 +10072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -10178,7 +10178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -10200,7 +10200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -10225,7 +10225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -10247,7 +10247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -10269,7 +10269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -10294,7 +10294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -10313,7 +10313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -10379,7 +10379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -10398,7 +10398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -10417,7 +10417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2">
-      <author>Pyfisch &lt;pyfisch@gmail.com&gt;, Tpt &lt;thomas@pellissier-tanon.fr&gt;</author>
+      <author>Pyfisch &lt;pyfisch@gmail.com>, Tpt &lt;thomas@pellissier-tanon.fr></author>
       <name>language-tags</name>
       <version>0.3.2</version>
       <description>Language tags for Rust</description>
@@ -10436,7 +10436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -10458,7 +10458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -10480,7 +10480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -10502,7 +10502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -10524,7 +10524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -10546,7 +10546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -10571,7 +10571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -10590,7 +10590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10609,7 +10609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10628,7 +10628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10647,7 +10647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10666,7 +10666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10725,7 +10725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10747,7 +10747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10772,7 +10772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10794,7 +10794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10835,7 +10835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10879,7 +10879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10901,7 +10901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>local-waker</name>
       <version>0.1.4</version>
       <description>A synchronization primitive for thread-local task wakeup</description>
@@ -10920,7 +10920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10961,7 +10961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10980,7 +10980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10999,7 +10999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -11018,7 +11018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -11037,7 +11037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -11062,7 +11062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -11084,7 +11084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -11127,7 +11127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -11146,7 +11146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -11165,7 +11165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -11190,7 +11190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -11215,7 +11215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -11234,7 +11234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -11303,7 +11303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -11328,7 +11328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -11350,7 +11350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -11375,7 +11375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -11397,7 +11397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -11416,7 +11416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -11438,7 +11438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -11460,7 +11460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -11482,7 +11482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -11507,7 +11507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -11550,7 +11550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -11572,7 +11572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -11594,7 +11594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11616,7 +11616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11638,7 +11638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11657,7 +11657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11676,7 +11676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11698,7 +11698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11871,7 +11871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11893,7 +11893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11915,7 +11915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11934,7 +11934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11953,7 +11953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -12003,7 +12003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -12053,7 +12053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -12197,7 +12197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -12216,7 +12216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -12235,7 +12235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -12254,7 +12254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>oas3</name>
       <version>0.20.1</version>
       <description>Structures and tools to parse, navigate, and validate OpenAPI v3.1.xß specifications</description>
@@ -12327,7 +12327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -12371,7 +12371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>oid-registry</name>
       <version>0.8.1</version>
       <description>Object Identifier (OID) database</description>
@@ -12393,7 +12393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -12415,7 +12415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -12434,7 +12434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -12453,7 +12453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -12475,7 +12475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -12585,7 +12585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -12610,7 +12610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12629,7 +12629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12648,7 +12648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12667,7 +12667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12692,7 +12692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12714,7 +12714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12754,7 +12754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12776,7 +12776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12795,7 +12795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12820,7 +12820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12839,7 +12839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12858,7 +12858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12880,7 +12880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12921,7 +12921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12943,7 +12943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3">
-      <author>Aditya Kumar &lt;git@adityais.dev&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Aditya Kumar &lt;git@adityais.dev>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>pastey</name>
       <version>0.2.3</version>
       <description>Macros for all your token pasting needs. Successor of paste.</description>
@@ -12984,7 +12984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -13003,7 +13003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -13041,7 +13041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -13085,7 +13085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -13110,7 +13110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -13135,7 +13135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -13160,7 +13160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -13229,7 +13229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -13248,7 +13248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -13267,7 +13267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -13286,7 +13286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -13359,7 +13359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -13381,7 +13381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -13438,7 +13438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -13460,7 +13460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -13482,7 +13482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -13501,7 +13501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -13585,7 +13585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -13644,7 +13644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -13663,7 +13663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -13685,7 +13685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -13735,7 +13735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13757,7 +13757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13782,7 +13782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13854,7 +13854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13873,7 +13873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13911,7 +13911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13933,7 +13933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13952,7 +13952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13971,7 +13971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13993,7 +13993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -14015,7 +14015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -14037,7 +14037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -14056,7 +14056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -14075,7 +14075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -14100,7 +14100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -14125,7 +14125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -14147,7 +14147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -14169,7 +14169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -14191,7 +14191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -14213,7 +14213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -14235,7 +14235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -14257,7 +14257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -14279,7 +14279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -14301,7 +14301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -14326,7 +14326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -14345,7 +14345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -14367,7 +14367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -14392,7 +14392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -14414,7 +14414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -14436,7 +14436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -14506,7 +14506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -14585,7 +14585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -14607,7 +14607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -14629,7 +14629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -14654,7 +14654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14971,7 +14971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14990,7 +14990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -15009,7 +15009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -15031,7 +15031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -15053,7 +15053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -15072,7 +15072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -15146,7 +15146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -15171,7 +15171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -15196,7 +15196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -15221,7 +15221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -15243,7 +15243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -15265,7 +15265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -15284,7 +15284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -15303,7 +15303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -15325,7 +15325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -15347,7 +15347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -15387,7 +15387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -15406,7 +15406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -15428,7 +15428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -15447,7 +15447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -15583,7 +15583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -15627,7 +15627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15646,7 +15646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -15665,7 +15665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15684,7 +15684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -15772,7 +15772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -15791,7 +15791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -15872,7 +15872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>rusticata-macros</name>
       <version>4.1.0</version>
       <description>Helper macros for Rusticata</description>
@@ -15894,7 +15894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15916,7 +15916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -16040,7 +16040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -16062,7 +16062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -16084,7 +16084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -16128,7 +16128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -16153,7 +16153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars</name>
       <version>1.2.1</version>
       <description>Generate JSON Schemas from Rust code</description>
@@ -16175,7 +16175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars_derive</name>
       <version>1.2.1</version>
       <description>Macros for #[derive(JsonSchema)], for use with schemars</description>
@@ -16219,7 +16219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -16269,7 +16269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -16294,7 +16294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -16319,7 +16319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -16344,7 +16344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -16366,7 +16366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -16388,7 +16388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -16410,7 +16410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -16432,7 +16432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -16454,7 +16454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -16476,7 +16476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -16498,7 +16498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -16523,7 +16523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -16542,7 +16542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -16564,7 +16564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -16586,7 +16586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -16611,7 +16611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -16636,7 +16636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -16661,7 +16661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive_internals</name>
       <version>0.29.1</version>
       <description>AST representation used by Serde derive macros. Unstable.</description>
@@ -16704,7 +16704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -16726,7 +16726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -16745,7 +16745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -16767,7 +16767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -16789,7 +16789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -16811,7 +16811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -16833,7 +16833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -16899,7 +16899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -16984,7 +16984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -17009,7 +17009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -17028,7 +17028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -17050,7 +17050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -17094,7 +17094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -17113,7 +17113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -17138,7 +17138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -17157,7 +17157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -17182,7 +17182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -17204,7 +17204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -17245,7 +17245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -17264,7 +17264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -17286,7 +17286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -17308,7 +17308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -17330,7 +17330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -17352,7 +17352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -17374,7 +17374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -17396,7 +17396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -17421,7 +17421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.5.10</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -17446,7 +17446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -17471,7 +17471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>sourcemap</name>
       <version>9.3.2</version>
       <description>Basic sourcemap handling for Rust</description>
@@ -17493,7 +17493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -17512,7 +17512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -17550,7 +17550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -17600,7 +17600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -17619,7 +17619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -17638,7 +17638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -17657,7 +17657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -17679,7 +17679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -17701,7 +17701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -17723,7 +17723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -17745,7 +17745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4">
-      <author>4t145 &lt;u4t145@163.com&gt;</author>
+      <author>4t145 &lt;u4t145@163.com></author>
       <name>sse-stream</name>
       <version>0.2.4</version>
       <description>Conversion between http body and sse stream</description>
@@ -17767,7 +17767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -17789,7 +17789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -17861,7 +17861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -17880,7 +17880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -17905,7 +17905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -17930,7 +17930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17955,7 +17955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17980,7 +17980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18005,7 +18005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18030,7 +18030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18055,7 +18055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -18080,7 +18080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -18105,7 +18105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -18127,7 +18127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -18149,7 +18149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -18171,7 +18171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -18196,7 +18196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -18218,7 +18218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -18237,7 +18237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -18319,7 +18319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -18341,7 +18341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -18366,7 +18366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -18388,7 +18388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -18463,7 +18463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -18512,7 +18512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -18531,7 +18531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -18550,7 +18550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -18572,7 +18572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -18594,7 +18594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -18616,7 +18616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -18641,7 +18641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -18666,7 +18666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -18685,7 +18685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -18704,7 +18704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -18726,7 +18726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -18764,7 +18764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -18783,7 +18783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -18802,7 +18802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -18848,7 +18848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -18870,7 +18870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -18910,7 +18910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -18986,7 +18986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -19008,7 +19008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -19030,7 +19030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -19052,7 +19052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -19074,7 +19074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -19096,7 +19096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -19121,7 +19121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -19146,7 +19146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -19168,7 +19168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -19190,7 +19190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -19212,7 +19212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -19255,7 +19255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -19277,7 +19277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -19299,7 +19299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -19321,7 +19321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -19346,7 +19346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -19396,7 +19396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -19418,7 +19418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
-      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <author>Chip Senkbeil &lt;chip@senkbeil.org></author>
       <name>typed-path</name>
       <version>0.12.3</version>
       <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
@@ -19440,7 +19440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -19483,7 +19483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -19505,7 +19505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -19576,7 +19576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -19619,7 +19619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -19641,7 +19641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -19685,7 +19685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -19710,7 +19710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Boshen &lt;boshenc@gmail.com></author>
       <name>unicode-id-start</name>
       <version>1.4.0</version>
       <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
@@ -19732,7 +19732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -19754,7 +19754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -19779,7 +19779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -19804,7 +19804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -19826,7 +19826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -19848,7 +19848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -19870,7 +19870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -19917,7 +19917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -19939,7 +19939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -19961,7 +19961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -20005,7 +20005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -20027,7 +20027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -20046,7 +20046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -20071,7 +20071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -20093,7 +20093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -20118,7 +20118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -20140,7 +20140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -20159,7 +20159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui-vendored@0.1.2">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-swagger-ui-vendored</name>
       <version>0.1.2</version>
       <description>Vendored Swagger UI for utoipa</description>
@@ -20178,7 +20178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-swagger-ui</name>
       <version>9.0.2</version>
       <description>Swagger UI for utoipa</description>
@@ -20197,7 +20197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -20234,7 +20234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -20259,7 +20259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -20281,7 +20281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -20306,7 +20306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -20331,7 +20331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -20353,7 +20353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -20372,7 +20372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -20412,7 +20412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -20434,7 +20434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -20459,7 +20459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -20548,7 +20548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -20630,7 +20630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -20671,7 +20671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -20696,7 +20696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>x509-parser</name>
       <version>0.18.1</version>
       <description>Parser for the X.509 v3 format (RFC 5280 certificates)</description>
@@ -20718,7 +20718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -20740,7 +20740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -20759,7 +20759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -20781,7 +20781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -20800,7 +20800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -20819,7 +20819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -20838,7 +20838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -20857,7 +20857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -20876,7 +20876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -20958,7 +20958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -20996,7 +20996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -21015,7 +21015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21034,7 +21034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@3.0.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>3.0.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21053,7 +21053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>8.2.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -21093,7 +21093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -21136,7 +21136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -21155,7 +21155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -21177,7 +21177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -22359,18 +22359,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -22378,39 +22378,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/http#openobserve-api-http@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-server@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -22419,21 +22419,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
@@ -22441,126 +22441,126 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22569,18 +22569,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -22599,36 +22599,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -22674,7 +22674,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -22705,25 +22705,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -22731,36 +22731,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -22769,31 +22769,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -22804,10 +22804,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -22815,38 +22815,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -22855,7 +22855,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -22865,7 +22865,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -22876,7 +22876,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -22892,38 +22892,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -22935,41 +22935,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -22979,33 +22979,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -23016,24 +23016,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -23042,17 +23042,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -23062,7 +23062,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -23071,48 +23071,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -23120,39 +23120,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -23160,10 +23160,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -23175,9 +23175,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -23186,9 +23186,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -23196,16 +23196,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/http/openobserve-api-http.cdx.xml
+++ b/src/api/http/openobserve-api-http.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:85ee9808-382a-4b75-a633-3ab02d9e9127" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:8f05c422-3b11-4591-8771-17eb93c93d5d" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.318303000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.550383000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,33 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0">
-      <name>openobserve</name>
-      <version>0.93.0</version>
-      <description>OpenObserve is an observability platform that allows you to capture, search, and analyze your logs, metrics, and traces.</description>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
+      <name>openobserve-api-http</name>
+      <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve@0.93.0?download_url=file://.</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://openobserve.ai/</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/openobserve/openobserve/</url>
-        </reference>
-      </externalReferences>
+      <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0 bin-target-0">
-          <name>openobserve</name>
-          <version>0.93.0</version>
-          <purl>pkg:cargo/openobserve@0.93.0?download_url=file://.#src/lib.rs</purl>
-        </component>
-        <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0 bin-target-1">
-          <name>openobserve</name>
-          <version>0.93.0</version>
-          <purl>pkg:cargo/openobserve@0.93.0?download_url=file://.#src/main.rs</purl>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0 bin-target-0">
+          <name>openobserve_api_http</name>
+          <version>0.1.0</version>
+          <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -1654,25 +1640,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://src/api/common</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
-      <name>openobserve-api-grpc</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/openobserve-api-grpc@0.1.0?download_url=file://src/api/grpc</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
-      <name>openobserve-api-http</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/openobserve-api-http@0.1.0?download_url=file://src/api/http</purl>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
       <name>openobserve-api-ingest</name>
@@ -1681,7 +1649,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://src/api/ingest</purl>
+      <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://../ingest</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
       <name>openobserve-api-management</name>
@@ -1690,7 +1658,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://src/api/management</purl>
+      <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://../management</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <name>openobserve-api-pipelines</name>
@@ -1699,7 +1667,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://src/api/pipelines</purl>
+      <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://../pipelines</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
       <name>openobserve-api-search</name>
@@ -1708,7 +1676,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://src/api/search</purl>
+      <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://../search</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
       <name>audit</name>
@@ -1717,7 +1685,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/audit@0.1.0?download_url=file://src/audit</purl>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
@@ -1726,7 +1694,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://src/builtins</purl>
+      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
       <name>common</name>
@@ -1735,7 +1703,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/common@0.1.0?download_url=file://src/common</purl>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
       <name>compaction</name>
@@ -1744,7 +1712,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/compaction@0.1.0?download_url=file://src/compaction</purl>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
@@ -1753,7 +1721,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://src/config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
@@ -1762,7 +1730,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://src/core</purl>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
       <name>db</name>
@@ -1771,7 +1739,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/db@0.1.0?download_url=file://src/db</purl>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
@@ -1780,7 +1748,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://src/enrichment_data</purl>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <name>flight</name>
@@ -1789,7 +1757,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://src/flight</purl>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
       <name>infra</name>
@@ -1798,7 +1766,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/infra@0.1.0?download_url=file://src/infra</purl>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
       <name>ingester</name>
@@ -1807,7 +1775,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/ingester@0.1.0?download_url=file://src/ingester</purl>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
@@ -1816,16 +1784,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://src/ingestion_common</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
-      <name>openobserve-jobs</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://src/jobs</purl>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
       <name>openobserve-mcp</name>
@@ -1834,7 +1793,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://src/mcp</purl>
+      <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://../../mcp</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
@@ -1843,7 +1802,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://src/node</purl>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
@@ -1852,7 +1811,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://src/org_storage</purl>
+      <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../../org_storage</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
       <name>promql</name>
@@ -1861,7 +1820,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql@0.1.0?download_url=file://src/promql</purl>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
@@ -1870,7 +1829,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://src/promql_service</purl>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1879,16 +1838,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://src/proto</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
-      <name>report_server</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/report_server@0.1.0?download_url=file://src/report_server</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
       <name>schema</name>
@@ -1897,7 +1847,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/schema@0.1.0?download_url=file://src/schema</purl>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
       <name>search</name>
@@ -1906,7 +1856,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/search@0.1.0?download_url=file://src/search</purl>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
       <name>search_service</name>
@@ -1915,7 +1865,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/search_service@0.1.0?download_url=file://src/search_service</purl>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <name>openobserve-sourcemaps</name>
@@ -1924,7 +1874,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://src/sourcemaps</purl>
+      <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://../../sourcemaps</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
       <name>stream</name>
@@ -1933,16 +1883,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/stream@0.1.0?download_url=file://src/stream</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
-      <name>super_cluster_queue</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://src/super_cluster_queue</purl>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
@@ -1951,7 +1892,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://src/tantivy_utils</purl>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
       <name>openobserve-tls</name>
@@ -1960,7 +1901,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://src/tls</purl>
+      <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://../../tls</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
       <name>transform</name>
@@ -1969,7 +1910,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/transform@0.1.0?download_url=file://src/transform</purl>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
@@ -1978,7 +1919,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://src/usage_reporting</purl>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
       <name>wal</name>
@@ -1987,16 +1928,7 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/wal@0.1.0?download_url=file://src/wal</purl>
-    </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
-      <name>web</name>
-      <version>0.1.0</version>
-      <scope>required</scope>
-      <licenses>
-        <expression>AGPL-3.0</expression>
-      </licenses>
-      <purl>pkg:cargo/web@0.1.0?download_url=file://src/web</purl>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
       <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
@@ -4247,28 +4179,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3">
-      <author>YetiBarBar</author>
-      <name>base85rs</name>
-      <version>0.1.3</version>
-      <description>A base85 (RFC1924 variant) encoder / decoder</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">87678d33a2af71f019ed11f52db246ca6c5557edee2cccbe689676d1ad9c6b5a</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/base85rs@0.1.3</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/base85rs/</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/YetiBarBar/base85rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7266,44 +7176,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
-      <name>dirs-sys</name>
-      <version>0.5.0</version>
-      <description>System-level helper functions for the dirs and directories crates.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/dirs-sys@0.5.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/dirs-dev/dirs-sys-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
-      <name>dirs</name>
-      <version>6.0.0</version>
-      <description>A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/dirs@6.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/soc/dirs-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
       <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
       <name>displaydoc</name>
@@ -8898,31 +8770,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
-      <name>globset</name>
-      <version>0.4.18</version>
-      <description>Cross platform single glob and glob set matching. Glob set matching is the process of matching one or more glob patterns against a single candidate path simultaneously, and returning all of the globs that matched. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3</hash>
-      </hashes>
-      <licenses>
-        <expression>Unlicense OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/globset@0.4.18</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/globset</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/BurntSushi/ripgrep/tree/master/crates/globset</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/BurntSushi/ripgrep/tree/master/crates/globset</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
       <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
       <name>grok</name>
@@ -9385,25 +9232,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/veddan/rust-htmlescape</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
-      <author>Esteban Borai &lt;estebanborai@gmail.com&gt;</author>
-      <name>http-auth-basic</name>
-      <version>0.3.7</version>
-      <description>HTTP Basic Authentication Scheme (RFC 7617 and RFC 2617 compliant, base64-encoded credentials) for Rust applications</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8e92637d714ad90b81c91bce86e8c1f98fb32ca79bddf8d69e9d83fee3966946</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/http-auth-basic@0.3.7</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/EstebanBorai/http-auth-basic</url>
         </reference>
       </externalReferences>
     </component>
@@ -11891,28 +11719,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;, Lynnesbian &lt;lynne@bune.city&gt;</author>
-      <name>new_mime_guess</name>
-      <version>4.0.4</version>
-      <description>A simple crate for associating MIME types to file extensions.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">02a2dfb3559d53e90b709376af1c379462f7fb3085a0177deb73e6ea0d99eff4</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/new_mime_guess@4.0.4</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/new_mime_guess/</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/Lynnesbian/mime_guess</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
       <author>The nix-rust Project Developers</author>
       <name>nix</name>
@@ -12712,48 +12518,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/utils</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.32.0">
-      <name>opentelemetry-http</name>
-      <version>0.32.0</version>
-      <description>Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/opentelemetry-http@0.32.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.32.0">
-      <name>opentelemetry-otlp</name>
-      <version>0.32.0</version>
-      <description>Exporter for the OpenTelemetry Collector</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/opentelemetry-otlp@0.32.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp</url>
         </reference>
       </externalReferences>
     </component>
@@ -15941,63 +15705,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1">
-      <name>rust-embed-for-web-impl</name>
-      <version>11.4.1</version>
-      <description>The proc-macro implementation of rust-embed-for-web.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8527f04d3f734ff9ebab526fcc3e03d61d66386975b2cf898d6b2a221f7dee29</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rust-embed-for-web-impl@11.4.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1">
-      <name>rust-embed-for-web-utils</name>
-      <version>11.4.1</version>
-      <description>Utilities for rust-embed-for-web</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d05939009fc97b73cd5ccee07f5af565b2e3f676a60de30fe8c29419dd33b2c2</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rust-embed-for-web-utils@11.4.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1">
-      <name>rust-embed-for-web</name>
-      <version>11.4.1</version>
-      <description>Rust Macro which embeds files into your executable. A fork of `rust-embed` with a focus on usage on web servers.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">cc9de9fc1c7cb74c76c770e9ae5454c050aead66420ad59cdad7544e1a5d85fc</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rust-embed-for-web@11.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/rust-embed-for-web</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-impl@8.11.0">
       <author>pyrossh</author>
       <name>rust-embed-impl</name>
@@ -17298,28 +17005,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hawkw/sharded-slab</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
-      <author>Vladimir Matveev &lt;vmatveev@citrine.cc&gt;, Ian Jackson &lt;iwj@torproject.org&gt;</author>
-      <name>shellexpand</name>
-      <version>3.1.2</version>
-      <description>Shell-like expansions in strings</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/shellexpand@3.1.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>http://docs.rs/shellexpand/</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://gitlab.com/ijackson/rust-shellexpand</url>
         </reference>
       </externalReferences>
     </component>
@@ -19366,28 +19051,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-types@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;, Rafael Lemos &lt;flemos.rafael.dev@gmail.com&gt;</author>
-      <name>tonic-types</name>
-      <version>0.14.5</version>
-      <description>A collection of useful protobuf types that can be used with `tonic`. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tonic-types@0.14.5</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/hyperium/tonic</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/tonic</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
       <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
       <name>tonic</name>
@@ -19501,28 +19164,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tower-rs/tower</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.4">
-      <author>Zeki Sherif &lt;zekshi@amazon.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
-      <name>tracing-appender</name>
-      <version>0.2.4</version>
-      <description>Provides utilities for file appenders and making non-blocking writers. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tracing-appender@0.2.4</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://tokio.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tokio-rs/tracing</url>
         </reference>
       </externalReferences>
     </component>
@@ -22718,138 +22359,6 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve#0.93.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-server@0.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prettytable-rs@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
-      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-swagger-ui@9.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
@@ -22868,41 +22377,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-    </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/grpc#openobserve-api-grpc@0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/http#openobserve-api-http@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -23445,48 +22919,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -23583,19 +23015,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
-    </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
-      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -23733,25 +23152,6 @@
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -23811,11 +23211,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-    </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
@@ -24686,7 +24081,6 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -25211,13 +24605,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -25481,13 +24868,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1" />
@@ -25573,9 +24953,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-auth-basic@0.3.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -26086,10 +25463,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
@@ -26238,28 +25611,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.32.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.32.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-types@0.14.5" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
@@ -27067,30 +26418,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-impl@8.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -27425,9 +26752,6 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
@@ -27971,11 +27295,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-types@0.14.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
@@ -28037,12 +27356,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.4">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />

--- a/src/api/ingest/openobserve-api-ingest.cdx.xml
+++ b/src/api/ingest/openobserve-api-ingest.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f0f55027-135b-4b73-881a-37e5e3bdb101" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.017277000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+      <name>openobserve-api-ingest</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0 bin-target-0">
+          <name>openobserve_api_ingest</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,33 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <name>openobserve-api-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1649,88 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1739,79 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2892,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3858,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3905,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3952,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4388,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4604,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4845,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5440,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5556,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5648,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6171,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6503,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6920,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7378,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7498,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8135,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8440,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9423,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9636,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9699,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10312,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10561,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11088,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11261,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11811,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11850,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12062,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12286,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13056,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13572,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14100,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14737,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14854,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15222,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15260,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15388,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15498,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15661,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15699,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15751,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15985,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16070,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16243,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16300,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16378,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16821,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16884,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17232,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17507,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17755,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18100,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18209,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18395,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18442,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19065,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19134,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19996,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20500,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20602,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20758,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21042,91 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21204,108 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21320,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21451,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21925,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22346,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22361,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22444,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22473,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22506,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22621,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22636,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22645,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22720,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22802,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22879,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +22954,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +22978,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23079,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23146,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23341,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23370,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23402,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23535,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23594,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23685,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23714,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23806,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23864,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23924,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24059,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24188,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24298,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24505,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24544,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24615,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24635,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24700,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24724,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24754,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24825,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24874,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24889,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25110,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25121,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25187,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25223,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25281,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25415,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25449,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25485,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25551,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/api/ingest/openobserve-api-ingest.cdx.xml
+++ b/src/api/ingest/openobserve-api-ingest.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f0f55027-135b-4b73-881a-37e5e3bdb101" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:836a7bc1-5f89-4eef-a864-5fac0d6a33d1" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.017277000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.583857000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <name>openobserve-api-ingest</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0 bin-target-0">
           <name>openobserve_api_ingest</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-ingest@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1814,7 +1814,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1902,7 +1902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1924,7 +1924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1946,7 +1946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1968,7 +1968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1993,10 +1993,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2018,7 +2018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2043,7 +2043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2068,7 +2068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2165,7 +2165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2205,7 +2205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2227,7 +2227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2249,10 +2249,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2293,7 +2293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2337,7 +2337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2359,7 +2359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2381,7 +2381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2403,7 +2403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2425,7 +2425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2447,7 +2447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2469,7 +2469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2491,7 +2491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2513,7 +2513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2535,7 +2535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2557,7 +2557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2579,7 +2579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2601,7 +2601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2623,7 +2623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2645,7 +2645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2667,7 +2667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2773,7 +2773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2792,7 +2792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2811,7 +2811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2830,7 +2830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2855,7 +2855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2874,7 +2874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2893,7 +2893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2918,7 +2918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2943,7 +2943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2962,7 +2962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2984,7 +2984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3003,7 +3003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3022,7 +3022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3041,7 +3041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3060,7 +3060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3082,7 +3082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3129,7 +3129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3148,7 +3148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3170,7 +3170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3189,7 +3189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3258,7 +3258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3277,7 +3277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3296,7 +3296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3315,7 +3315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3334,7 +3334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3353,7 +3353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3372,7 +3372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3391,7 +3391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3410,7 +3410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3429,7 +3429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3448,7 +3448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3467,7 +3467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3505,7 +3505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3524,7 +3524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3543,7 +3543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3562,7 +3562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3662,7 +3662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3684,7 +3684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3703,7 +3703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3746,7 +3746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3793,7 +3793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3815,7 +3815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3859,7 +3859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3881,7 +3881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3906,7 +3906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3931,7 +3931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3956,7 +3956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3981,7 +3981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4006,7 +4006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4056,7 +4056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4124,7 +4124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4212,7 +4212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4273,7 +4273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4295,7 +4295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4317,7 +4317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4339,7 +4339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4364,7 +4364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4389,7 +4389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4436,7 +4436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4458,7 +4458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4480,7 +4480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4499,7 +4499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4518,7 +4518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4543,7 +4543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4565,7 +4565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4608,7 +4608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4627,7 +4627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4673,7 +4673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4714,7 +4714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4739,7 +4739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4761,7 +4761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4805,7 +4805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4824,7 +4824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4849,7 +4849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4934,7 +4934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5004,7 +5004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5026,7 +5026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5048,7 +5048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5135,7 +5135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5272,7 +5272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5297,7 +5297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5340,7 +5340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5365,7 +5365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5384,7 +5384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5403,7 +5403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5422,7 +5422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5441,7 +5441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5513,7 +5513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5535,7 +5535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5557,7 +5557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5595,7 +5595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5617,7 +5617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5636,7 +5636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5655,7 +5655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5674,7 +5674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5756,7 +5756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5825,7 +5825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5844,7 +5844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5863,7 +5863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5885,7 +5885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6012,7 +6012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6100,7 +6100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6125,7 +6125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6172,7 +6172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6218,7 +6218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6240,7 +6240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6262,7 +6262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6281,7 +6281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6300,7 +6300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6466,7 +6466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6488,7 +6488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6510,7 +6510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6532,7 +6532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6598,7 +6598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6655,7 +6655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6674,7 +6674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6699,7 +6699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6721,7 +6721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6743,7 +6743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6768,7 +6768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6818,7 +6818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6858,7 +6858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6877,7 +6877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6902,7 +6902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6924,7 +6924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7011,7 +7011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7033,7 +7033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7055,7 +7055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7077,7 +7077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7102,7 +7102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7127,7 +7127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7206,7 +7206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7228,7 +7228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7250,7 +7250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7269,7 +7269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7288,7 +7288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7313,7 +7313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7335,7 +7335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7357,7 +7357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7379,7 +7379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7401,7 +7401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7442,7 +7442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7464,7 +7464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7483,7 +7483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7502,7 +7502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7570,7 +7570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7592,7 +7592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7617,7 +7617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7639,7 +7639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7661,7 +7661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7683,7 +7683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7702,7 +7702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7740,7 +7740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7765,7 +7765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7787,7 +7787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7812,7 +7812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7831,7 +7831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7916,7 +7916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7959,7 +7959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8047,7 +8047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8114,7 +8114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8246,7 +8246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8293,7 +8293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8334,7 +8334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8353,7 +8353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8372,7 +8372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8391,7 +8391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8428,7 +8428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8471,7 +8471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8496,7 +8496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8539,7 +8539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8605,7 +8605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8648,7 +8648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8667,7 +8667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8689,7 +8689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8711,7 +8711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8733,7 +8733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8755,7 +8755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8777,7 +8777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8799,7 +8799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8818,7 +8818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8913,7 +8913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8938,7 +8938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8963,7 +8963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8988,7 +8988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9161,7 +9161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9248,7 +9248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9292,7 +9292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9336,7 +9336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9358,7 +9358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9380,7 +9380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9402,7 +9402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9424,7 +9424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9443,7 +9443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9462,7 +9462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9568,7 +9568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9590,7 +9590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9615,7 +9615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9637,7 +9637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9659,7 +9659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9769,7 +9769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9788,7 +9788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9807,7 +9807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9829,7 +9829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9851,7 +9851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9873,7 +9873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9895,7 +9895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9917,7 +9917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9942,7 +9942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9961,7 +9961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9980,7 +9980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9999,7 +9999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10018,7 +10018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10037,7 +10037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10096,7 +10096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10118,7 +10118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10143,7 +10143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10165,7 +10165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10206,7 +10206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10250,7 +10250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10272,7 +10272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10313,7 +10313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10332,7 +10332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10351,7 +10351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10370,7 +10370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10389,7 +10389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10414,7 +10414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10436,7 +10436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10458,7 +10458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10477,7 +10477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10496,7 +10496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10521,7 +10521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10546,7 +10546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10565,7 +10565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10634,7 +10634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10659,7 +10659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10681,7 +10681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10706,7 +10706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10728,7 +10728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10747,7 +10747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10769,7 +10769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10791,7 +10791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10813,7 +10813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10838,7 +10838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10925,7 +10925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10947,7 +10947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10969,7 +10969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10988,7 +10988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11007,7 +11007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11029,7 +11029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11114,7 +11114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11202,7 +11202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11224,7 +11224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11246,7 +11246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11265,7 +11265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11284,7 +11284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11334,7 +11334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11384,7 +11384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11528,7 +11528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11547,7 +11547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11566,7 +11566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11639,7 +11639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11683,7 +11683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11705,7 +11705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11724,7 +11724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11743,7 +11743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11765,7 +11765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11875,7 +11875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11900,7 +11900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11919,7 +11919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11938,7 +11938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11957,7 +11957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11982,7 +11982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12004,7 +12004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12044,7 +12044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12066,7 +12066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12085,7 +12085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12110,7 +12110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12129,7 +12129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12148,7 +12148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12170,7 +12170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12211,7 +12211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12233,7 +12233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12252,7 +12252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12290,7 +12290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12334,7 +12334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12359,7 +12359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12384,7 +12384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12409,7 +12409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12478,7 +12478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12497,7 +12497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12516,7 +12516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12535,7 +12535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12608,7 +12608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12630,7 +12630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12687,7 +12687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12709,7 +12709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12731,7 +12731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12750,7 +12750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12834,7 +12834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12872,7 +12872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12891,7 +12891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12913,7 +12913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12963,7 +12963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12985,7 +12985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13010,7 +13010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13139,7 +13139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13161,7 +13161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13180,7 +13180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13199,7 +13199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13221,7 +13221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13243,7 +13243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13265,7 +13265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13284,7 +13284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13303,7 +13303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13328,7 +13328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13353,7 +13353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13375,7 +13375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13397,7 +13397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13419,7 +13419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13441,7 +13441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13463,7 +13463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13485,7 +13485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13507,7 +13507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13529,7 +13529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13554,7 +13554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13573,7 +13573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13595,7 +13595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13620,7 +13620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13642,7 +13642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13664,7 +13664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13734,7 +13734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13813,7 +13813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13835,7 +13835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13857,7 +13857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13882,7 +13882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14199,7 +14199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14218,7 +14218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14281,7 +14281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14300,7 +14300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14349,7 +14349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14374,7 +14374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14399,7 +14399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14424,7 +14424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14449,7 +14449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14512,7 +14512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14531,7 +14531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14553,7 +14553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14575,7 +14575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14615,7 +14615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14634,7 +14634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14656,7 +14656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14675,7 +14675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14694,7 +14694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14716,7 +14716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14738,7 +14738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14757,7 +14757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14776,7 +14776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14795,7 +14795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14817,7 +14817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14836,7 +14836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14917,7 +14917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14939,7 +14939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15063,7 +15063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15085,7 +15085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15107,7 +15107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15151,7 +15151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15198,7 +15198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15223,7 +15223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15248,7 +15248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15273,7 +15273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15298,7 +15298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15323,7 +15323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15345,7 +15345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15367,7 +15367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15389,7 +15389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15411,7 +15411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15433,7 +15433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15455,7 +15455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15477,7 +15477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15502,7 +15502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15521,7 +15521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15543,7 +15543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15565,7 +15565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15590,7 +15590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15615,7 +15615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15640,7 +15640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15662,7 +15662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15681,7 +15681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15703,7 +15703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15725,7 +15725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15747,7 +15747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15769,7 +15769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15835,7 +15835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15920,7 +15920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15945,7 +15945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15964,7 +15964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15986,7 +15986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16030,7 +16030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16049,7 +16049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16074,7 +16074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16093,7 +16093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16118,7 +16118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16140,7 +16140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16181,7 +16181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16200,7 +16200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16266,7 +16266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16288,7 +16288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16310,7 +16310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16357,7 +16357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16382,7 +16382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16401,7 +16401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16439,7 +16439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16489,7 +16489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16508,7 +16508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16527,7 +16527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16546,7 +16546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16568,7 +16568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16590,7 +16590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16612,7 +16612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16634,7 +16634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16656,7 +16656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16728,7 +16728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16747,7 +16747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16772,7 +16772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16797,7 +16797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16822,7 +16822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16847,7 +16847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16872,7 +16872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16897,7 +16897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16922,7 +16922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16947,7 +16947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17038,7 +17038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17063,7 +17063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17104,7 +17104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17186,7 +17186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17208,7 +17208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17233,7 +17233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17255,7 +17255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17330,7 +17330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17379,7 +17379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17398,7 +17398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17417,7 +17417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17439,7 +17439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17461,7 +17461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17483,7 +17483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17508,7 +17508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17533,7 +17533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17552,7 +17552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17571,7 +17571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17593,7 +17593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17650,7 +17650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17715,7 +17715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17737,7 +17737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17777,7 +17777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17853,7 +17853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17875,7 +17875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17897,7 +17897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17919,7 +17919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17941,7 +17941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17963,7 +17963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17988,7 +17988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18013,7 +18013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18035,7 +18035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18057,7 +18057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18079,7 +18079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18122,7 +18122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18144,7 +18144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18166,7 +18166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18188,7 +18188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18213,7 +18213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18263,7 +18263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18285,7 +18285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18328,7 +18328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18350,7 +18350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18421,7 +18421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18530,7 +18530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18555,7 +18555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18577,7 +18577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18602,7 +18602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18627,7 +18627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18649,7 +18649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18671,7 +18671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18693,7 +18693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18740,7 +18740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18762,7 +18762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18784,7 +18784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18828,7 +18828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18850,7 +18850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18869,7 +18869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18894,7 +18894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18916,7 +18916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18941,7 +18941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18963,7 +18963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18982,7 +18982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19019,7 +19019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19044,7 +19044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19066,7 +19066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19091,7 +19091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19116,7 +19116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19138,7 +19138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19157,7 +19157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19197,7 +19197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19219,7 +19219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19244,7 +19244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19333,7 +19333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19415,7 +19415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19456,7 +19456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19481,7 +19481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19503,7 +19503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19522,7 +19522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19544,7 +19544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19563,7 +19563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19582,7 +19582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19601,7 +19601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19620,7 +19620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19639,7 +19639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19721,7 +19721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19759,7 +19759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19778,7 +19778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19818,7 +19818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19840,7 +19840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19859,7 +19859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19881,7 +19881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21042,18 +21042,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -21061,21 +21061,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/ingest#openobserve-api-ingest@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/ingest#openobserve-api-ingest@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
@@ -21083,27 +21083,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21122,12 +21122,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21173,7 +21173,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21204,25 +21204,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21230,36 +21230,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21268,31 +21268,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21303,15 +21303,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21320,7 +21320,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21330,7 +21330,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21341,7 +21341,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21357,55 +21357,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21415,33 +21415,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21452,24 +21452,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21478,17 +21478,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21498,7 +21498,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21507,48 +21507,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21556,25 +21556,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21582,10 +21582,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21597,9 +21597,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21607,16 +21607,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/management/openobserve-api-management.cdx.xml
+++ b/src/api/management/openobserve-api-management.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:87dee769-689d-4aaa-b8a0-b0e04ea73aef" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:56be328f-dac2-4302-ae88-bfec48408a04" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.038235000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.602358000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <name>openobserve-api-management</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0 bin-target-0">
           <name>openobserve_api_management</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../../org_storage</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <name>openobserve-sourcemaps</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://../../sourcemaps</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1822,7 +1822,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1831,7 +1831,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1840,7 +1840,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1849,7 +1849,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1859,7 +1859,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1947,7 +1947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1969,7 +1969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1991,7 +1991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -2013,7 +2013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2038,10 +2038,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2063,7 +2063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2088,7 +2088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2113,7 +2113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2210,7 +2210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2250,7 +2250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2272,7 +2272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2294,10 +2294,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2338,7 +2338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2382,7 +2382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2404,7 +2404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2426,7 +2426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2448,7 +2448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2470,7 +2470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2492,7 +2492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2514,7 +2514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2536,7 +2536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2558,7 +2558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2580,7 +2580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2602,7 +2602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2646,7 +2646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2712,7 +2712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2818,7 +2818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2837,7 +2837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2856,7 +2856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2875,7 +2875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2900,7 +2900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2919,7 +2919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2938,7 +2938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2963,7 +2963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2988,7 +2988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -3007,7 +3007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -3029,7 +3029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3048,7 +3048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3067,7 +3067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3086,7 +3086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3105,7 +3105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3127,7 +3127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3174,7 +3174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3193,7 +3193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3215,7 +3215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3234,7 +3234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3303,7 +3303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3322,7 +3322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3341,7 +3341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3360,7 +3360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3379,7 +3379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3398,7 +3398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3417,7 +3417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3436,7 +3436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3455,7 +3455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3474,7 +3474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3493,7 +3493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3512,7 +3512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3531,7 +3531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3550,7 +3550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3569,7 +3569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3588,7 +3588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3607,7 +3607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3728,7 +3728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3750,7 +3750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3769,7 +3769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3812,7 +3812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3859,7 +3859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3881,7 +3881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3925,7 +3925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3947,7 +3947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3972,7 +3972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3997,7 +3997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -4022,7 +4022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -4047,7 +4047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4072,7 +4072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4122,7 +4122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4190,7 +4190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4278,7 +4278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4339,7 +4339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4361,7 +4361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4383,7 +4383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4405,7 +4405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4430,7 +4430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4455,7 +4455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4480,7 +4480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4502,7 +4502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4524,7 +4524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4546,7 +4546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4565,7 +4565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4584,7 +4584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4609,7 +4609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4631,7 +4631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4674,7 +4674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4693,7 +4693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4739,7 +4739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4780,7 +4780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4805,7 +4805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4827,7 +4827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4871,7 +4871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4890,7 +4890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4915,7 +4915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -5000,7 +5000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5092,7 +5092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5114,7 +5114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5136,7 +5136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5201,7 +5201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5338,7 +5338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5363,7 +5363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5406,7 +5406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5431,7 +5431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5450,7 +5450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5469,7 +5469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5488,7 +5488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5507,7 +5507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5579,7 +5579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5601,7 +5601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5623,7 +5623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5661,7 +5661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5683,7 +5683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5702,7 +5702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5721,7 +5721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5740,7 +5740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5759,7 +5759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cookie</name>
       <version>0.18.1</version>
       <description>HTTP cookie parsing and cookie jar management. Supports signed and private (encrypted, authenticated) jars. </description>
@@ -5844,7 +5844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5913,7 +5913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5932,7 +5932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5951,7 +5951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5973,7 +5973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6100,7 +6100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6188,7 +6188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6213,7 +6213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6260,7 +6260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6306,7 +6306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6328,7 +6328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6350,7 +6350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6369,7 +6369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6388,7 +6388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6407,7 +6407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6426,7 +6426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6451,7 +6451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>debugid</name>
       <version>0.8.0</version>
       <description>Common reusable types for implementing the sentry.io protocol.</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
-      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <author>anatawa12 &lt;anatawa12@icloud.com></author>
       <name>deflate64</name>
       <version>0.1.11</version>
       <description>Deflate64 implementation based on .NET's implementation</description>
@@ -6582,7 +6582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6601,7 +6601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6623,7 +6623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6645,7 +6645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6667,7 +6667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6733,7 +6733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6790,7 +6790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6809,7 +6809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6878,7 +6878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6903,7 +6903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6928,7 +6928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6953,7 +6953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6993,7 +6993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -7012,7 +7012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -7037,7 +7037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -7059,7 +7059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7146,7 +7146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7168,7 +7168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7190,7 +7190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7212,7 +7212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7237,7 +7237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7262,7 +7262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7341,7 +7341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7363,7 +7363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7385,7 +7385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7404,7 +7404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7448,7 +7448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7470,7 +7470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7492,7 +7492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7514,7 +7514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7536,7 +7536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7558,7 +7558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7577,7 +7577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7599,7 +7599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7618,7 +7618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7637,7 +7637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7705,7 +7705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7727,7 +7727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7752,7 +7752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7774,7 +7774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7796,7 +7796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7818,7 +7818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7837,7 +7837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7875,7 +7875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7900,7 +7900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7922,7 +7922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7947,7 +7947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7966,7 +7966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -8051,7 +8051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -8094,7 +8094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8182,7 +8182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8249,7 +8249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8381,7 +8381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8428,7 +8428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8450,7 +8450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8469,7 +8469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8488,7 +8488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8507,7 +8507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8526,7 +8526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8563,7 +8563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8606,7 +8606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8631,7 +8631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers-core</name>
       <version>0.3.0</version>
       <description>typed HTTP headers core trait</description>
@@ -8653,7 +8653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>headers</name>
       <version>0.4.1</version>
       <description>typed HTTP headers</description>
@@ -8675,7 +8675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8718,7 +8718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8784,7 +8784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8827,7 +8827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8846,7 +8846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8868,7 +8868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8890,7 +8890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8912,7 +8912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8934,7 +8934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8956,7 +8956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8978,7 +8978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8997,7 +8997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -9092,7 +9092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -9117,7 +9117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -9142,7 +9142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9167,7 +9167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9340,7 +9340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9406,7 +9406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com></author>
       <name>if_chain</name>
       <version>1.0.3</version>
       <description>Macro for writing nested `if let` expressions.</description>
@@ -9449,7 +9449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9493,7 +9493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9537,7 +9537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9559,7 +9559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9581,7 +9581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9603,7 +9603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9625,7 +9625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9644,7 +9644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9663,7 +9663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9769,7 +9769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9791,7 +9791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9838,7 +9838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9860,7 +9860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9885,7 +9885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9904,7 +9904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9970,7 +9970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9989,7 +9989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -10008,7 +10008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -10030,7 +10030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -10052,7 +10052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -10074,7 +10074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -10096,7 +10096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -10118,7 +10118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -10143,7 +10143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -10162,7 +10162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10181,7 +10181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10200,7 +10200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10219,7 +10219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10238,7 +10238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10319,7 +10319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10344,7 +10344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10366,7 +10366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10407,7 +10407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10451,7 +10451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10473,7 +10473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10514,7 +10514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10533,7 +10533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10552,7 +10552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10571,7 +10571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10590,7 +10590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10615,7 +10615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10637,7 +10637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10680,7 +10680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10699,7 +10699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10718,7 +10718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10743,7 +10743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10768,7 +10768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10787,7 +10787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10856,7 +10856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10928,7 +10928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10950,7 +10950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10969,7 +10969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10991,7 +10991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -11013,7 +11013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -11035,7 +11035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -11060,7 +11060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -11103,7 +11103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -11125,7 +11125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -11147,7 +11147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11169,7 +11169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11191,7 +11191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11210,7 +11210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11229,7 +11229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11251,7 +11251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11336,7 +11336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11424,7 +11424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11446,7 +11446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11468,7 +11468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11487,7 +11487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11506,7 +11506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11556,7 +11556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11606,7 +11606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11750,7 +11750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11769,7 +11769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11788,7 +11788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11861,7 +11861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11905,7 +11905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11927,7 +11927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11946,7 +11946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11987,7 +11987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -12097,7 +12097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -12122,7 +12122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12141,7 +12141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12160,7 +12160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -12179,7 +12179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12204,7 +12204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12226,7 +12226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12266,7 +12266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12288,7 +12288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12307,7 +12307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12332,7 +12332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12351,7 +12351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12370,7 +12370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12392,7 +12392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12433,7 +12433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12477,7 +12477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12496,7 +12496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12578,7 +12578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12603,7 +12603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12628,7 +12628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12653,7 +12653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12722,7 +12722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12741,7 +12741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12760,7 +12760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12779,7 +12779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12852,7 +12852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12874,7 +12874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12931,7 +12931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12953,7 +12953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12975,7 +12975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12994,7 +12994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -13078,7 +13078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -13137,7 +13137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -13156,7 +13156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -13178,7 +13178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -13228,7 +13228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13250,7 +13250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13275,7 +13275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13347,7 +13347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13366,7 +13366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13385,7 +13385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13404,7 +13404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13426,7 +13426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13445,7 +13445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13464,7 +13464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13486,7 +13486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13508,7 +13508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13530,7 +13530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13549,7 +13549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13568,7 +13568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13593,7 +13593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13618,7 +13618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13640,7 +13640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13662,7 +13662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13684,7 +13684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13706,7 +13706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13728,7 +13728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13750,7 +13750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13772,7 +13772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13794,7 +13794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13819,7 +13819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13838,7 +13838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13860,7 +13860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13885,7 +13885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13907,7 +13907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13929,7 +13929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13999,7 +13999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -14078,7 +14078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -14100,7 +14100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -14122,7 +14122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -14147,7 +14147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14464,7 +14464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14483,7 +14483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14502,7 +14502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14524,7 +14524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14546,7 +14546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14565,7 +14565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14614,7 +14614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14639,7 +14639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14664,7 +14664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14689,7 +14689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14714,7 +14714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14736,7 +14736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14758,7 +14758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14777,7 +14777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14796,7 +14796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14818,7 +14818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14840,7 +14840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14880,7 +14880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14899,7 +14899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14921,7 +14921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14940,7 +14940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14959,7 +14959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14981,7 +14981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -15003,7 +15003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15022,7 +15022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -15041,7 +15041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -15060,7 +15060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -15082,7 +15082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -15101,7 +15101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -15182,7 +15182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15204,7 +15204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15328,7 +15328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15350,7 +15350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15372,7 +15372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15416,7 +15416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15463,7 +15463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15488,7 +15488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15513,7 +15513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15538,7 +15538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15563,7 +15563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15588,7 +15588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15610,7 +15610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15632,7 +15632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15654,7 +15654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15676,7 +15676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15698,7 +15698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15720,7 +15720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15742,7 +15742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15767,7 +15767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15786,7 +15786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15808,7 +15808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15830,7 +15830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15855,7 +15855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15880,7 +15880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15923,7 +15923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15945,7 +15945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15964,7 +15964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15986,7 +15986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -16008,7 +16008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -16030,7 +16030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -16052,7 +16052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -16118,7 +16118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -16203,7 +16203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -16228,7 +16228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -16247,7 +16247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -16269,7 +16269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16313,7 +16313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16357,7 +16357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16376,7 +16376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16401,7 +16401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16423,7 +16423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16464,7 +16464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16483,7 +16483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16505,7 +16505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16527,7 +16527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16549,7 +16549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16571,7 +16571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16593,7 +16593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16615,7 +16615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16640,7 +16640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16665,7 +16665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>sourcemap</name>
       <version>9.3.2</version>
       <description>Basic sourcemap handling for Rust</description>
@@ -16687,7 +16687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16706,7 +16706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16744,7 +16744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16794,7 +16794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16813,7 +16813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16832,7 +16832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16851,7 +16851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16873,7 +16873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16895,7 +16895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16917,7 +16917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16939,7 +16939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16961,7 +16961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -17033,7 +17033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -17052,7 +17052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -17077,7 +17077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -17102,7 +17102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17127,7 +17127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17152,7 +17152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17177,7 +17177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17202,7 +17202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17227,7 +17227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -17252,7 +17252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -17277,7 +17277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -17299,7 +17299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17321,7 +17321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17343,7 +17343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17368,7 +17368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17390,7 +17390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17409,7 +17409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17491,7 +17491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17513,7 +17513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17538,7 +17538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17560,7 +17560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17635,7 +17635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17684,7 +17684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17703,7 +17703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17722,7 +17722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17744,7 +17744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17766,7 +17766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17788,7 +17788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17813,7 +17813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17838,7 +17838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17857,7 +17857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17876,7 +17876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17898,7 +17898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17936,7 +17936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17955,7 +17955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17974,7 +17974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -18020,7 +18020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -18042,7 +18042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -18082,7 +18082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -18158,7 +18158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -18180,7 +18180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -18202,7 +18202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -18224,7 +18224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -18246,7 +18246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -18268,7 +18268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -18293,7 +18293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18318,7 +18318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18340,7 +18340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18362,7 +18362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18384,7 +18384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18427,7 +18427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18449,7 +18449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18471,7 +18471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18493,7 +18493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18518,7 +18518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18568,7 +18568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18590,7 +18590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
-      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <author>Chip Senkbeil &lt;chip@senkbeil.org></author>
       <name>typed-path</name>
       <version>0.12.3</version>
       <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
@@ -18612,7 +18612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18655,7 +18655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18677,7 +18677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18748,7 +18748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18791,7 +18791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18813,7 +18813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18857,7 +18857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18882,7 +18882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Boshen &lt;boshenc@gmail.com></author>
       <name>unicode-id-start</name>
       <version>1.4.0</version>
       <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18904,7 +18904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18926,7 +18926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18951,7 +18951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18976,7 +18976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18998,7 +18998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -19020,7 +19020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -19042,7 +19042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -19089,7 +19089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -19111,7 +19111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -19133,7 +19133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -19177,7 +19177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -19199,7 +19199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -19218,7 +19218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -19243,7 +19243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -19265,7 +19265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -19290,7 +19290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -19312,7 +19312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -19331,7 +19331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19368,7 +19368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19393,7 +19393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19415,7 +19415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19440,7 +19440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19465,7 +19465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19487,7 +19487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19506,7 +19506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19546,7 +19546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19568,7 +19568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19593,7 +19593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19682,7 +19682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19764,7 +19764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19805,7 +19805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19830,7 +19830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19852,7 +19852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19871,7 +19871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19893,7 +19893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19912,7 +19912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19931,7 +19931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19950,7 +19950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19969,7 +19969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19988,7 +19988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -20070,7 +20070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -20108,7 +20108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -20127,7 +20127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -20146,7 +20146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>8.2.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -20186,7 +20186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -20229,7 +20229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -20248,7 +20248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -20270,7 +20270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21431,18 +21431,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -21450,68 +21450,68 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/management#openobserve-api-management@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21520,18 +21520,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21550,36 +21550,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21625,7 +21625,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21656,25 +21656,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21682,36 +21682,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21720,31 +21720,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21755,10 +21755,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -21766,38 +21766,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21806,7 +21806,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21816,7 +21816,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21827,7 +21827,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21843,68 +21843,68 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21914,33 +21914,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21951,24 +21951,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21977,17 +21977,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21997,7 +21997,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -22006,48 +22006,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -22055,39 +22055,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -22095,10 +22095,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -22110,9 +22110,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -22120,16 +22120,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/management/openobserve-api-management.cdx.xml
+++ b/src/api/management/openobserve-api-management.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:87dee769-689d-4aaa-b8a0-b0e04ea73aef" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.038235000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+      <name>openobserve-api-management</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0 bin-target-0">
+          <name>openobserve_api_management</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-management@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,51 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <name>openobserve-api-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <name>openobserve-builtins</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1667,106 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <name>openobserve-org-storage</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../../org_storage</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1775,88 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+      <name>openobserve-sourcemaps</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://../../sourcemaps</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2937,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3347,6 +3664,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5">
+      <name>axum-extra</name>
+      <version>0.12.5</version>
+      <description>Extra utilities for axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-extra@0.12.5</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-macros@0.5.0">
       <name>axum-macros</name>
       <version>0.5.0</version>
@@ -3586,6 +3924,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3971,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +4018,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4454,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4670,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4911,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5506,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5622,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5203,6 +5720,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <author>rutrum &lt;dave@rutrum.net&gt;</author>
       <name>convert_case</name>
@@ -5219,6 +5755,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1">
+      <author>Sergio Benitez &lt;sb@sergio.bz&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>cookie</name>
+      <version>0.18.1</version>
+      <description>HTTP cookie parsing and cookie jar management. Supports signed and private (encrypted, authenticated) jars. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cookie@0.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cookie</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SergioBenitez/cookie-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5701,6 +6259,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -5932,6 +6515,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
+      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <name>debugid</name>
+      <version>0.8.0</version>
+      <description>Common reusable types for implementing the sentry.io protocol.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/debugid@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/debugid</url>
+        </reference>
+        <reference type="website">
+          <url>https://sentry.io/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/getsentry/rust-debugid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
+      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <name>deflate64</name>
+      <version>0.1.11</version>
+      <description>Deflate64 implementation based on .NET's implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/deflate64@0.1.11</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/anatawa12/deflate64-rs#readme</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/anatawa12/deflate64-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10">
       <author>RustCrypto Developers</author>
       <name>der</name>
@@ -6008,6 +6638,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +7055,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7513,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7633,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8270,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7819,6 +8584,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -7841,6 +8627,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/HdrHistogram/HdrHistogram_rust.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>headers-core</name>
+      <version>0.3.0</version>
+      <description>typed HTTP headers core trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/headers-core@0.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hyper.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/headers</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>headers</name>
+      <version>0.4.1</version>
+      <description>typed HTTP headers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/headers@0.4.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hyper.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/headers</url>
         </reference>
       </externalReferences>
     </component>
@@ -8575,6 +9405,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
+      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <name>if_chain</name>
+      <version>1.0.3</version>
+      <description>Macro for writing nested `if let` expressions.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/if_chain@1.0.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/if_chain</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/lambda-fairy/if_chain</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
       <version>2.14.0</version>
@@ -8772,6 +9624,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9837,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9900,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10513,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9683,6 +10655,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2">
+      <name>lzma-rust2</name>
+      <version>0.16.2</version>
+      <description>LZMA / LZMA2 / LZIP / XZ compression ported from 'tukaani xz for java'</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lzma-rust2@0.16.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/hasenbanck/lzma-rust2/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hasenbanck/lzma-rust2/</url>
         </reference>
       </externalReferences>
     </component>
@@ -9790,6 +10783,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11310,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11483,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +12033,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +12072,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11183,6 +12287,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
       <name>parking</name>
@@ -11331,6 +12454,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2">
+      <author>RustCrypto Developers</author>
+      <name>pbkdf2</name>
+      <version>0.12.2</version>
+      <description>Generic implementation of PBKDF2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pbkdf2@0.12.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pbkdf2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
       <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
       <name>pco</name>
@@ -11385,6 +12530,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11926,6 +13096,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0">
+      <name>ppmd-rust</name>
+      <version>1.4.0</version>
+      <description>PPMd compression / decompression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24</hash>
+      </hashes>
+      <licenses>
+        <expression>CC0-1.0 OR MIT-0</expression>
+      </licenses>
+      <purl>pkg:cargo/ppmd-rust@1.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/hasenbanck/ppmd-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hasenbanck/ppmd-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21">
       <author>The CryptoCorrosion Contributors</author>
       <name>ppv-lite86</name>
@@ -12127,6 +13318,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tikv/rust-prometheus</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +13837,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14365,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +15002,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +15119,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15487,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15525,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15653,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15763,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14355,6 +15904,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_html_form@0.2.8">
+      <name>serde_html_form</name>
+      <version>0.2.8</version>
+      <description>(De-)serialization support for the `application/x-www-form-urlencoded` format</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_html_form@0.2.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/jplatte/serde_html_form</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
       <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_json</name>
@@ -14377,6 +15944,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15982,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +16034,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +16268,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16353,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16526,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16583,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16661,47 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
+      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <name>sourcemap</name>
+      <version>9.3.2</version>
+      <description>Basic sourcemap handling for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">314d62a489431668f719ada776ca1d49b924db951b7450f8974c9ae51ab05ad7</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/sourcemap@9.3.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/getsentry/rust-sourcemap</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/getsentry/rust-sourcemap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +17126,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +17189,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17537,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17812,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +18060,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18405,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16647,6 +18517,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <author>Alexey Galakhov, Daniel Abramov</author>
       <name>tungstenite</name>
@@ -16691,6 +18586,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/shepmaster/twox-hash</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
+      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <name>typed-path</name>
+      <version>0.12.3</version>
+      <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/typed-path@0.12.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/chipsenkbeil/typed-path</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/chipsenkbeil/typed-path</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18722,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18769,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -16896,6 +18878,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/yeslogic/unicode-general-category</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <name>unicode-id-start</name>
+      <version>1.4.0</version>
+      <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007</hash>
+      </hashes>
+      <licenses>
+        <expression>(MIT OR Apache-2.0) AND Unicode-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unicode-id-start@1.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/unicode-id-start</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Boshen/unicode-id-start</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19414,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19483,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18072,6 +20145,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <name>zip</name>
+      <version>8.2.0</version>
+      <description>Library to support the reading and writing of zip files. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zip@8.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/zip-rs/zip2.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3">
       <name>zlib-rs</name>
       <version>0.6.3</version>
@@ -18112,6 +20204,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/zmij</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3">
+      <name>zopfli</name>
+      <version>0.8.3</version>
+      <description>A Rust implementation of the Zopfli compression algorithm.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/zopfli@0.8.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/zopfli-rs/zopfli</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zopfli-rs/zopfli</url>
         </reference>
       </externalReferences>
     </component>
@@ -18271,6 +20384,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -18769,6 +20889,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20991,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +21147,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21431,154 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/management#openobserve-api-management@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21656,142 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21806,140 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21950,191 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +22438,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20005,6 +22804,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-extra@0.12.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_html_form@0.2.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-macros@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20060,6 +22880,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22895,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22978,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +23007,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +23040,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +23155,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +23170,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,8 +23179,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cookie@0.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
@@ -20407,6 +23260,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
@@ -20460,6 +23319,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0" />
@@ -20481,6 +23345,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
@@ -20552,6 +23423,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +23498,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +23522,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23623,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20798,9 +23691,24 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#headers@0.4.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#headers-core@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
@@ -20959,6 +23867,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
@@ -20989,6 +23898,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23927,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23959,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +24092,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21173,6 +24137,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
@@ -21187,6 +24154,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +24245,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +24274,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +24366,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +24424,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21465,6 +24475,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
@@ -21474,6 +24488,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21563,6 +24581,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40" />
     </dependency>
@@ -21604,6 +24623,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -21725,6 +24753,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24863,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +25070,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +25109,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +25180,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +25200,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +25265,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +25289,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22197,6 +25312,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_html_form@0.2.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
@@ -22204,9 +25326,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +25397,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +25446,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +25461,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25694,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25705,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25771,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25807,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25865,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25999,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +26033,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22835,6 +26050,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
@@ -22854,10 +26070,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
@@ -22908,7 +26137,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
@@ -23119,8 +26358,35 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7" />
     </dependency>

--- a/src/api/pipelines/openobserve-api-pipelines.cdx.xml
+++ b/src/api/pipelines/openobserve-api-pipelines.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3e558b69-1f8c-4f4c-961b-aaa8f966f14b" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.159600000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+      <name>openobserve-api-pipelines</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0 bin-target-0">
+          <name>openobserve_api_pipelines</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,51 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <name>openobserve-api-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <name>openobserve-builtins</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1667,97 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1766,79 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2919,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3885,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3932,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3979,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4415,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4631,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4872,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5467,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5583,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5675,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6198,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6530,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6947,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7405,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7525,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8162,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8467,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9450,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9663,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9726,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10339,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10588,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11115,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11288,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11838,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11877,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12089,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12313,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13083,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13599,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14127,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14764,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14881,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15249,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15287,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15415,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15525,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15688,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15726,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15778,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +16012,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16097,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16270,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16327,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16405,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16848,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16911,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17259,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17534,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17782,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18127,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18236,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18422,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18469,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19092,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19161,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +20023,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20527,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20629,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20785,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21069,131 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21271,142 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21421,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21552,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +22026,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22447,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22462,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22545,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22574,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22607,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22722,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22737,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22746,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22821,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22903,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22980,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +23055,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +23079,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23180,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23247,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23442,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23471,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23503,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23636,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23695,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23786,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23815,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23907,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23965,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +24025,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24160,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24289,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24399,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24606,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24645,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24716,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24736,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24801,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24825,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24855,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24926,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24975,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24990,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25211,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25222,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25288,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25324,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25382,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25516,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25550,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25586,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25652,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/api/pipelines/openobserve-api-pipelines.cdx.xml
+++ b/src/api/pipelines/openobserve-api-pipelines.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3e558b69-1f8c-4f4c-961b-aaa8f966f14b" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:79615beb-0523-4505-bdcc-18d6b8e41c34" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.159600000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.708706000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <name>openobserve-api-pipelines</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0 bin-target-0">
           <name>openobserve_api_pipelines</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-pipelines@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../../builtins</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1822,7 +1822,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1831,7 +1831,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1841,7 +1841,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1929,7 +1929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1951,7 +1951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1973,7 +1973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1995,7 +1995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2020,10 +2020,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2045,7 +2045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2070,7 +2070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2095,7 +2095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2192,7 +2192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2232,7 +2232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2254,7 +2254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2276,10 +2276,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2320,7 +2320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2364,7 +2364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2386,7 +2386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2408,7 +2408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2430,7 +2430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2452,7 +2452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2474,7 +2474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2496,7 +2496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2518,7 +2518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2540,7 +2540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2562,7 +2562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2584,7 +2584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2606,7 +2606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2628,7 +2628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2650,7 +2650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2672,7 +2672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2694,7 +2694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2800,7 +2800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2819,7 +2819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2838,7 +2838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2857,7 +2857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2882,7 +2882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2901,7 +2901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2920,7 +2920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2945,7 +2945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2970,7 +2970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2989,7 +2989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -3011,7 +3011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3030,7 +3030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3049,7 +3049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3068,7 +3068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3087,7 +3087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3109,7 +3109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3156,7 +3156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3175,7 +3175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3197,7 +3197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3216,7 +3216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3285,7 +3285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3304,7 +3304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3323,7 +3323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3342,7 +3342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3361,7 +3361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3380,7 +3380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3399,7 +3399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3418,7 +3418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3437,7 +3437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3456,7 +3456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3475,7 +3475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3494,7 +3494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3513,7 +3513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3532,7 +3532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3551,7 +3551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3570,7 +3570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3589,7 +3589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3689,7 +3689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3711,7 +3711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3730,7 +3730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3773,7 +3773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3820,7 +3820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3842,7 +3842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3886,7 +3886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3908,7 +3908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3933,7 +3933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3958,7 +3958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3983,7 +3983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -4008,7 +4008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4033,7 +4033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4083,7 +4083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4151,7 +4151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4239,7 +4239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4300,7 +4300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4322,7 +4322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4344,7 +4344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4366,7 +4366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4391,7 +4391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4416,7 +4416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4441,7 +4441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4463,7 +4463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4485,7 +4485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4507,7 +4507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4526,7 +4526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4545,7 +4545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4570,7 +4570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4592,7 +4592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4635,7 +4635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4654,7 +4654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4700,7 +4700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4741,7 +4741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4766,7 +4766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4788,7 +4788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4832,7 +4832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4851,7 +4851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4876,7 +4876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4961,7 +4961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5031,7 +5031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5053,7 +5053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5075,7 +5075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5097,7 +5097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5162,7 +5162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5299,7 +5299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5324,7 +5324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5367,7 +5367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5392,7 +5392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5411,7 +5411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5430,7 +5430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5449,7 +5449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5468,7 +5468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5540,7 +5540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5562,7 +5562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5584,7 +5584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5622,7 +5622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5644,7 +5644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5663,7 +5663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5682,7 +5682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5701,7 +5701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5783,7 +5783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5852,7 +5852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5871,7 +5871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5890,7 +5890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5912,7 +5912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6039,7 +6039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6127,7 +6127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6152,7 +6152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6199,7 +6199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6245,7 +6245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6267,7 +6267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6289,7 +6289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6308,7 +6308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6327,7 +6327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6346,7 +6346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6365,7 +6365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6390,7 +6390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6474,7 +6474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6493,7 +6493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6515,7 +6515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6537,7 +6537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6559,7 +6559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6625,7 +6625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6682,7 +6682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6701,7 +6701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6726,7 +6726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6748,7 +6748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6770,7 +6770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6795,7 +6795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6820,7 +6820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6845,7 +6845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6885,7 +6885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6904,7 +6904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6929,7 +6929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6951,7 +6951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7038,7 +7038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7060,7 +7060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7082,7 +7082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7104,7 +7104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7129,7 +7129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7233,7 +7233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7255,7 +7255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7277,7 +7277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7296,7 +7296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7315,7 +7315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7340,7 +7340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7362,7 +7362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7384,7 +7384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7406,7 +7406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7428,7 +7428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7450,7 +7450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7469,7 +7469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7491,7 +7491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7510,7 +7510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7529,7 +7529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7597,7 +7597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7619,7 +7619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7644,7 +7644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7666,7 +7666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7688,7 +7688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7710,7 +7710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7729,7 +7729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7767,7 +7767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7792,7 +7792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7814,7 +7814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7839,7 +7839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7858,7 +7858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7943,7 +7943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7986,7 +7986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8074,7 +8074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8141,7 +8141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8273,7 +8273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8320,7 +8320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8342,7 +8342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8361,7 +8361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8380,7 +8380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8399,7 +8399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8418,7 +8418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8455,7 +8455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8498,7 +8498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8523,7 +8523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8566,7 +8566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8632,7 +8632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8675,7 +8675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8694,7 +8694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8716,7 +8716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8738,7 +8738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8760,7 +8760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8782,7 +8782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8804,7 +8804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8826,7 +8826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8845,7 +8845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8940,7 +8940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8965,7 +8965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8990,7 +8990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9015,7 +9015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9188,7 +9188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9275,7 +9275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9319,7 +9319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9363,7 +9363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9385,7 +9385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9451,7 +9451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9489,7 +9489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9595,7 +9595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9617,7 +9617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9642,7 +9642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9664,7 +9664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9686,7 +9686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9711,7 +9711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9730,7 +9730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9796,7 +9796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9815,7 +9815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9834,7 +9834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9856,7 +9856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9878,7 +9878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9900,7 +9900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9922,7 +9922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9944,7 +9944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9969,7 +9969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9988,7 +9988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10007,7 +10007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10026,7 +10026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10045,7 +10045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10064,7 +10064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10123,7 +10123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10145,7 +10145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10170,7 +10170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10192,7 +10192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10233,7 +10233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10277,7 +10277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10299,7 +10299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10340,7 +10340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10378,7 +10378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10397,7 +10397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10416,7 +10416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10441,7 +10441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10463,7 +10463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10485,7 +10485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10504,7 +10504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10523,7 +10523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10548,7 +10548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10573,7 +10573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10592,7 +10592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10661,7 +10661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10686,7 +10686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10708,7 +10708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10733,7 +10733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10755,7 +10755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10774,7 +10774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10796,7 +10796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10818,7 +10818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10840,7 +10840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10865,7 +10865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10908,7 +10908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10930,7 +10930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10952,7 +10952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10974,7 +10974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10996,7 +10996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11015,7 +11015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11056,7 +11056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11141,7 +11141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11229,7 +11229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11251,7 +11251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11273,7 +11273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11292,7 +11292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11311,7 +11311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11361,7 +11361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11555,7 +11555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11574,7 +11574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11593,7 +11593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11666,7 +11666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11710,7 +11710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11732,7 +11732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11751,7 +11751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11770,7 +11770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11792,7 +11792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11902,7 +11902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11927,7 +11927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11946,7 +11946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11984,7 +11984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12009,7 +12009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12031,7 +12031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12071,7 +12071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12093,7 +12093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12112,7 +12112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12137,7 +12137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12156,7 +12156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12175,7 +12175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12197,7 +12197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12238,7 +12238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12260,7 +12260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12279,7 +12279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12317,7 +12317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12361,7 +12361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12386,7 +12386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12411,7 +12411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12436,7 +12436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12505,7 +12505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12524,7 +12524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12543,7 +12543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12562,7 +12562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12635,7 +12635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12657,7 +12657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12714,7 +12714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12736,7 +12736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12758,7 +12758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12777,7 +12777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12861,7 +12861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12899,7 +12899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12918,7 +12918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12940,7 +12940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12990,7 +12990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13012,7 +13012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13037,7 +13037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13109,7 +13109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13128,7 +13128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13147,7 +13147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13166,7 +13166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13188,7 +13188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13207,7 +13207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13226,7 +13226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13248,7 +13248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13270,7 +13270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13292,7 +13292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13311,7 +13311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13330,7 +13330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13355,7 +13355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13380,7 +13380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13402,7 +13402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13424,7 +13424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13446,7 +13446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13468,7 +13468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13490,7 +13490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13512,7 +13512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13534,7 +13534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13556,7 +13556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13581,7 +13581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13600,7 +13600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13622,7 +13622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13647,7 +13647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13669,7 +13669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13691,7 +13691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13761,7 +13761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13840,7 +13840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13862,7 +13862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13884,7 +13884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13909,7 +13909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14226,7 +14226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14245,7 +14245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14264,7 +14264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14286,7 +14286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14308,7 +14308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14327,7 +14327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14376,7 +14376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14401,7 +14401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14426,7 +14426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14451,7 +14451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14476,7 +14476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14498,7 +14498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14520,7 +14520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14539,7 +14539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14558,7 +14558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14580,7 +14580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14602,7 +14602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14642,7 +14642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14661,7 +14661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14683,7 +14683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14702,7 +14702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14721,7 +14721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14743,7 +14743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14765,7 +14765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14784,7 +14784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14803,7 +14803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14822,7 +14822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14844,7 +14844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14863,7 +14863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14944,7 +14944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14966,7 +14966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15090,7 +15090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15112,7 +15112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15134,7 +15134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15178,7 +15178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15225,7 +15225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15250,7 +15250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15275,7 +15275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15300,7 +15300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15325,7 +15325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15350,7 +15350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15372,7 +15372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15394,7 +15394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15416,7 +15416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15438,7 +15438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15460,7 +15460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15482,7 +15482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15504,7 +15504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15529,7 +15529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15548,7 +15548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15570,7 +15570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15592,7 +15592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15617,7 +15617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15642,7 +15642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15667,7 +15667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15689,7 +15689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15708,7 +15708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15730,7 +15730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15752,7 +15752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15796,7 +15796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15862,7 +15862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15947,7 +15947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15972,7 +15972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15991,7 +15991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -16013,7 +16013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16057,7 +16057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16076,7 +16076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16101,7 +16101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16120,7 +16120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16145,7 +16145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16167,7 +16167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16208,7 +16208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16227,7 +16227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16249,7 +16249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16271,7 +16271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16293,7 +16293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16315,7 +16315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16337,7 +16337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16359,7 +16359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16384,7 +16384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16409,7 +16409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16428,7 +16428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16466,7 +16466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16516,7 +16516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16554,7 +16554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16573,7 +16573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16595,7 +16595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16617,7 +16617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16639,7 +16639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16661,7 +16661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16683,7 +16683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16755,7 +16755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16774,7 +16774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16799,7 +16799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16824,7 +16824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16849,7 +16849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16874,7 +16874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16899,7 +16899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16924,7 +16924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16949,7 +16949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16974,7 +16974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16999,7 +16999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -17021,7 +17021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17065,7 +17065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17090,7 +17090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17112,7 +17112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17131,7 +17131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17213,7 +17213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17235,7 +17235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17260,7 +17260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17282,7 +17282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17357,7 +17357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17406,7 +17406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17425,7 +17425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17444,7 +17444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17466,7 +17466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17488,7 +17488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17510,7 +17510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17535,7 +17535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17560,7 +17560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17579,7 +17579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17598,7 +17598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17620,7 +17620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17658,7 +17658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17677,7 +17677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17696,7 +17696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17742,7 +17742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17764,7 +17764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17804,7 +17804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17880,7 +17880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17902,7 +17902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17924,7 +17924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17946,7 +17946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17968,7 +17968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17990,7 +17990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -18015,7 +18015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18040,7 +18040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18062,7 +18062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18084,7 +18084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18106,7 +18106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18149,7 +18149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18171,7 +18171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18193,7 +18193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18215,7 +18215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18240,7 +18240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18290,7 +18290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18312,7 +18312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18355,7 +18355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18377,7 +18377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18448,7 +18448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18491,7 +18491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18513,7 +18513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18557,7 +18557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18582,7 +18582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18604,7 +18604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18629,7 +18629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18654,7 +18654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18676,7 +18676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18698,7 +18698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18720,7 +18720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18767,7 +18767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18789,7 +18789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18811,7 +18811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18855,7 +18855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18877,7 +18877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18896,7 +18896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18921,7 +18921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18943,7 +18943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18968,7 +18968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18990,7 +18990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -19009,7 +19009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19046,7 +19046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19071,7 +19071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19093,7 +19093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19118,7 +19118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19143,7 +19143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19165,7 +19165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19184,7 +19184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19224,7 +19224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19246,7 +19246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19271,7 +19271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19360,7 +19360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19442,7 +19442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19483,7 +19483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19508,7 +19508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19530,7 +19530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19549,7 +19549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19571,7 +19571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19590,7 +19590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19609,7 +19609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19628,7 +19628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19647,7 +19647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19666,7 +19666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19748,7 +19748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19786,7 +19786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19805,7 +19805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19845,7 +19845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19867,7 +19867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19886,7 +19886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19908,7 +19908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21069,18 +21069,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -21088,45 +21088,45 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/pipelines#openobserve-api-pipelines@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/pipelines#openobserve-api-pipelines@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21135,18 +21135,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21165,36 +21165,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21240,7 +21240,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21271,25 +21271,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21297,36 +21297,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21335,31 +21335,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21370,10 +21370,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -21381,38 +21381,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21421,7 +21421,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21431,7 +21431,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21442,7 +21442,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21458,55 +21458,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21516,33 +21516,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21553,24 +21553,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21579,17 +21579,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21599,7 +21599,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21608,48 +21608,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21657,25 +21657,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21683,10 +21683,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21698,9 +21698,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21708,16 +21708,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/search/openobserve-api-search.cdx.xml
+++ b/src/api/search/openobserve-api-search.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3a716796-17bf-41a3-bbc7-a044b73b5e5e" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:fbfe415a-1c39-4ec7-b9df-5d7452209292" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.178758000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.726965000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <name>openobserve-api-search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0 bin-target-0">
           <name>openobserve_api_search</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <name>openobserve-api-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1814,7 +1814,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1902,7 +1902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1924,7 +1924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1946,7 +1946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1968,7 +1968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1993,10 +1993,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2018,7 +2018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2043,7 +2043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2068,7 +2068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2165,7 +2165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2205,7 +2205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2227,7 +2227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2249,10 +2249,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2293,7 +2293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2337,7 +2337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2359,7 +2359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2381,7 +2381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2403,7 +2403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2425,7 +2425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2447,7 +2447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2469,7 +2469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2491,7 +2491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2513,7 +2513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2535,7 +2535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2557,7 +2557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2579,7 +2579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2601,7 +2601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2623,7 +2623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2645,7 +2645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2667,7 +2667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2773,7 +2773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2792,7 +2792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2811,7 +2811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2830,7 +2830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2855,7 +2855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2874,7 +2874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2893,7 +2893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2918,7 +2918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2943,7 +2943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2962,7 +2962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2984,7 +2984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3003,7 +3003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3022,7 +3022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3041,7 +3041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3060,7 +3060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3082,7 +3082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3129,7 +3129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3148,7 +3148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3170,7 +3170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3189,7 +3189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3258,7 +3258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3277,7 +3277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3296,7 +3296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3315,7 +3315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3334,7 +3334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3353,7 +3353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3372,7 +3372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3391,7 +3391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3410,7 +3410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3429,7 +3429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3448,7 +3448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3467,7 +3467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3505,7 +3505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3524,7 +3524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3543,7 +3543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3562,7 +3562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3662,7 +3662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3684,7 +3684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3703,7 +3703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3746,7 +3746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3793,7 +3793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3815,7 +3815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3859,7 +3859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3881,7 +3881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3906,7 +3906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3931,7 +3931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3956,7 +3956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3981,7 +3981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4006,7 +4006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4056,7 +4056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4124,7 +4124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4212,7 +4212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4273,7 +4273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4295,7 +4295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4317,7 +4317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4339,7 +4339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4364,7 +4364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4389,7 +4389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4436,7 +4436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4458,7 +4458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4480,7 +4480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4499,7 +4499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4518,7 +4518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4543,7 +4543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4565,7 +4565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4608,7 +4608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4627,7 +4627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4673,7 +4673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4714,7 +4714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4739,7 +4739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4761,7 +4761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4805,7 +4805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4824,7 +4824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4849,7 +4849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4934,7 +4934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5004,7 +5004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5026,7 +5026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5048,7 +5048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5135,7 +5135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5272,7 +5272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5297,7 +5297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5340,7 +5340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5365,7 +5365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5384,7 +5384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5403,7 +5403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5422,7 +5422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5441,7 +5441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5513,7 +5513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5535,7 +5535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5557,7 +5557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5595,7 +5595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5617,7 +5617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5636,7 +5636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5655,7 +5655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5674,7 +5674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5756,7 +5756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5825,7 +5825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5844,7 +5844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5863,7 +5863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5885,7 +5885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6012,7 +6012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6100,7 +6100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6125,7 +6125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6172,7 +6172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6218,7 +6218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6240,7 +6240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6262,7 +6262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6281,7 +6281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6300,7 +6300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6466,7 +6466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6488,7 +6488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6510,7 +6510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6532,7 +6532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6598,7 +6598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6655,7 +6655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6674,7 +6674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6699,7 +6699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6721,7 +6721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6743,7 +6743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6768,7 +6768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6818,7 +6818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6858,7 +6858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6877,7 +6877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6902,7 +6902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6924,7 +6924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7011,7 +7011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7033,7 +7033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7055,7 +7055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7077,7 +7077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7102,7 +7102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7127,7 +7127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7206,7 +7206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7228,7 +7228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7250,7 +7250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7269,7 +7269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7288,7 +7288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7313,7 +7313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7335,7 +7335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7357,7 +7357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7379,7 +7379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7401,7 +7401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7442,7 +7442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7464,7 +7464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7483,7 +7483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7502,7 +7502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7570,7 +7570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7592,7 +7592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7617,7 +7617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7639,7 +7639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7661,7 +7661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7683,7 +7683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7702,7 +7702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7740,7 +7740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7765,7 +7765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7787,7 +7787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7812,7 +7812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7831,7 +7831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7916,7 +7916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7959,7 +7959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8047,7 +8047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8114,7 +8114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8246,7 +8246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8293,7 +8293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8334,7 +8334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8353,7 +8353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8372,7 +8372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8391,7 +8391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8428,7 +8428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8471,7 +8471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8496,7 +8496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8539,7 +8539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8605,7 +8605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8648,7 +8648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8667,7 +8667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8689,7 +8689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8711,7 +8711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8733,7 +8733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8755,7 +8755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8777,7 +8777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8799,7 +8799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8818,7 +8818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8913,7 +8913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8938,7 +8938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8963,7 +8963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8988,7 +8988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9161,7 +9161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9248,7 +9248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9292,7 +9292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9336,7 +9336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9358,7 +9358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9380,7 +9380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9402,7 +9402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9424,7 +9424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9443,7 +9443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9462,7 +9462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9568,7 +9568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9590,7 +9590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9615,7 +9615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9637,7 +9637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9659,7 +9659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9769,7 +9769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9788,7 +9788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9807,7 +9807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9829,7 +9829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9851,7 +9851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9873,7 +9873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9895,7 +9895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9917,7 +9917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9942,7 +9942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9961,7 +9961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9980,7 +9980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9999,7 +9999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10018,7 +10018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10037,7 +10037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10096,7 +10096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10118,7 +10118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10143,7 +10143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10165,7 +10165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10206,7 +10206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10250,7 +10250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10272,7 +10272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10313,7 +10313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10332,7 +10332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10351,7 +10351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10370,7 +10370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10389,7 +10389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10414,7 +10414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10436,7 +10436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10458,7 +10458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10477,7 +10477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10496,7 +10496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10521,7 +10521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10546,7 +10546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10565,7 +10565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10634,7 +10634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10659,7 +10659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10681,7 +10681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10706,7 +10706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10728,7 +10728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10747,7 +10747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10769,7 +10769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10791,7 +10791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10813,7 +10813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10838,7 +10838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10925,7 +10925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10947,7 +10947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10969,7 +10969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10988,7 +10988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11007,7 +11007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11029,7 +11029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11114,7 +11114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11202,7 +11202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11224,7 +11224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11246,7 +11246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11265,7 +11265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11284,7 +11284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11334,7 +11334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11384,7 +11384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11528,7 +11528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11547,7 +11547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11566,7 +11566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11639,7 +11639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11683,7 +11683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11705,7 +11705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11724,7 +11724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11743,7 +11743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11765,7 +11765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11875,7 +11875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11900,7 +11900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11919,7 +11919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11938,7 +11938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11957,7 +11957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11982,7 +11982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12004,7 +12004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12044,7 +12044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12066,7 +12066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12085,7 +12085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12110,7 +12110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12129,7 +12129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12148,7 +12148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12170,7 +12170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12211,7 +12211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12233,7 +12233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12252,7 +12252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12290,7 +12290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12334,7 +12334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12359,7 +12359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12384,7 +12384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12409,7 +12409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12478,7 +12478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12497,7 +12497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12516,7 +12516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12535,7 +12535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12608,7 +12608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12630,7 +12630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12687,7 +12687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12709,7 +12709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12731,7 +12731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12750,7 +12750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12834,7 +12834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12872,7 +12872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12891,7 +12891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12913,7 +12913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12963,7 +12963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12985,7 +12985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13010,7 +13010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13139,7 +13139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13161,7 +13161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13180,7 +13180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13199,7 +13199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13221,7 +13221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13243,7 +13243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13265,7 +13265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13284,7 +13284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13303,7 +13303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13328,7 +13328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13353,7 +13353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13375,7 +13375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13397,7 +13397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13419,7 +13419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13441,7 +13441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13463,7 +13463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13485,7 +13485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13507,7 +13507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13529,7 +13529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13554,7 +13554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13573,7 +13573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13595,7 +13595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13620,7 +13620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13642,7 +13642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13664,7 +13664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13734,7 +13734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13813,7 +13813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13835,7 +13835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13857,7 +13857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13882,7 +13882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14199,7 +14199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14218,7 +14218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14281,7 +14281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14300,7 +14300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14349,7 +14349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14374,7 +14374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14399,7 +14399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14424,7 +14424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14449,7 +14449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14512,7 +14512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14531,7 +14531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14553,7 +14553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14575,7 +14575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14615,7 +14615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14634,7 +14634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14656,7 +14656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14675,7 +14675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14694,7 +14694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14716,7 +14716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14738,7 +14738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14757,7 +14757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14776,7 +14776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14795,7 +14795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14817,7 +14817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14836,7 +14836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14917,7 +14917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14939,7 +14939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15063,7 +15063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15085,7 +15085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15107,7 +15107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15151,7 +15151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15198,7 +15198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15223,7 +15223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15248,7 +15248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15273,7 +15273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15298,7 +15298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15323,7 +15323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15345,7 +15345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15367,7 +15367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15389,7 +15389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15411,7 +15411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15433,7 +15433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15455,7 +15455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15477,7 +15477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15502,7 +15502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15521,7 +15521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15543,7 +15543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15565,7 +15565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15590,7 +15590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15615,7 +15615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15640,7 +15640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15662,7 +15662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15681,7 +15681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15703,7 +15703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15725,7 +15725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15747,7 +15747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15769,7 +15769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15835,7 +15835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15920,7 +15920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15945,7 +15945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15964,7 +15964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15986,7 +15986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16030,7 +16030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16049,7 +16049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16074,7 +16074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16093,7 +16093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16118,7 +16118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16140,7 +16140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16181,7 +16181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16200,7 +16200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16266,7 +16266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16288,7 +16288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16310,7 +16310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16357,7 +16357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16382,7 +16382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16401,7 +16401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16439,7 +16439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16489,7 +16489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16508,7 +16508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16527,7 +16527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16546,7 +16546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16568,7 +16568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16590,7 +16590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16612,7 +16612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16634,7 +16634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16656,7 +16656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16728,7 +16728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16747,7 +16747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16772,7 +16772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16797,7 +16797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16822,7 +16822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16847,7 +16847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16872,7 +16872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16897,7 +16897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16922,7 +16922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16947,7 +16947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17038,7 +17038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17063,7 +17063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17104,7 +17104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17186,7 +17186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17208,7 +17208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17233,7 +17233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17255,7 +17255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17330,7 +17330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17379,7 +17379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17398,7 +17398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17417,7 +17417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17439,7 +17439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17461,7 +17461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17483,7 +17483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17508,7 +17508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17533,7 +17533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17552,7 +17552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17571,7 +17571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17593,7 +17593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17650,7 +17650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17715,7 +17715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17737,7 +17737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17777,7 +17777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17853,7 +17853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17875,7 +17875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17897,7 +17897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17919,7 +17919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17941,7 +17941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17963,7 +17963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17988,7 +17988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18013,7 +18013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18035,7 +18035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18057,7 +18057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18079,7 +18079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18122,7 +18122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18144,7 +18144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18166,7 +18166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18188,7 +18188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18213,7 +18213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18263,7 +18263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18285,7 +18285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18328,7 +18328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18350,7 +18350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18421,7 +18421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18530,7 +18530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18555,7 +18555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18577,7 +18577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18602,7 +18602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18627,7 +18627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18649,7 +18649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18671,7 +18671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18693,7 +18693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18740,7 +18740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18762,7 +18762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18784,7 +18784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18828,7 +18828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18850,7 +18850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18869,7 +18869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18894,7 +18894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18916,7 +18916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18941,7 +18941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18963,7 +18963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18982,7 +18982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19019,7 +19019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19044,7 +19044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19066,7 +19066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19091,7 +19091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19116,7 +19116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19138,7 +19138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19157,7 +19157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19197,7 +19197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19219,7 +19219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19244,7 +19244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19333,7 +19333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19415,7 +19415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19456,7 +19456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19481,7 +19481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19503,7 +19503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19522,7 +19522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19544,7 +19544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19563,7 +19563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19582,7 +19582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19601,7 +19601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19620,7 +19620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19639,7 +19639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19721,7 +19721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19759,7 +19759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19778,7 +19778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19818,7 +19818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19840,7 +19840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19859,7 +19859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19881,7 +19881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21042,18 +21042,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
@@ -21061,61 +21061,61 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/search#openobserve-api-search@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21134,12 +21134,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21185,7 +21185,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21216,25 +21216,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21242,36 +21242,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21280,31 +21280,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21315,15 +21315,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21332,7 +21332,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21342,7 +21342,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21353,7 +21353,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21369,55 +21369,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21427,33 +21427,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21464,24 +21464,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21490,17 +21490,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21510,7 +21510,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21519,48 +21519,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21568,25 +21568,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21594,10 +21594,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21609,9 +21609,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21619,16 +21619,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/api/search/openobserve-api-search.cdx.xml
+++ b/src/api/search/openobserve-api-search.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3a716796-17bf-41a3-bbc7-a044b73b5e5e" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.178758000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+      <name>openobserve-api-search</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0 bin-target-0">
+          <name>openobserve_api_search</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-api-search@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,33 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <name>openobserve-api-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-api-common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1555,7 +1649,88 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
+      <purl>pkg:cargo/config@0.1.0?download_url=file://../../config</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../../promql_service</purl>
     </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
@@ -1564,7 +1739,79 @@
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+      <purl>pkg:cargo/proto@0.1.0?download_url=file://../../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2892,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3858,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3905,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3952,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4388,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4604,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4845,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5440,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5556,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5648,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6171,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6503,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6920,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7378,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7498,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8135,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8440,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9423,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9636,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9699,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10312,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10561,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11088,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11261,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11811,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11850,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12062,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12286,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13056,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13572,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14100,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14737,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14854,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15222,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15260,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15388,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15498,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15661,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15699,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15751,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15985,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16070,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16243,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16300,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16378,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16821,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16884,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17232,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17507,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17755,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18100,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18209,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18395,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18442,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19065,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19134,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19996,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20500,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20602,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20758,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21042,103 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/search#openobserve-api-search@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/api/common#openobserve-api-common@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21216,108 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21332,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21463,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21937,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22358,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22373,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22456,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22485,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22518,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22633,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22648,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22657,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22732,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22814,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22891,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +22966,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +22990,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23091,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23158,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23353,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23382,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23414,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23547,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23606,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23697,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23726,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23818,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23876,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23936,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24071,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24200,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24310,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24517,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24556,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24627,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24647,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24712,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24736,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24766,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24837,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24886,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24901,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25122,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25133,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25199,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25235,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25293,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25427,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25461,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25497,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25563,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/audit/audit.cdx.xml
+++ b/src/audit/audit.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3e4a0337-c108-4468-bfb2-8075a7a4f89c" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.569261000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0 bin-target-0">
+          <name>audit</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/audit@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -2212,28 +2212,6 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/arrow-data@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -19265,6 +19243,15 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19341,20 +19328,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
-    </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19500,20 +19473,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />

--- a/src/audit/audit.cdx.xml
+++ b/src/audit/audit.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3e4a0337-c108-4468-bfb2-8075a7a4f89c" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:4382237b-fa91-4835-a194-89b764227b3e" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.569261000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.162097000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0 bin-target-0">
           <name>audit</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/audit@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2542,7 +2542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2709,7 +2709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2747,7 +2747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2766,7 +2766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2835,7 +2835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2854,7 +2854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2876,7 +2876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2895,7 +2895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2964,7 +2964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -2983,7 +2983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3002,7 +3002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3021,7 +3021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3040,7 +3040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3059,7 +3059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3097,7 +3097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3116,7 +3116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3135,7 +3135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3154,7 +3154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3173,7 +3173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3192,7 +3192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3211,7 +3211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3230,7 +3230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3368,7 +3368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3390,7 +3390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3409,7 +3409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3452,7 +3452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3499,7 +3499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3565,7 +3565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3690,7 +3690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3758,7 +3758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3846,7 +3846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3907,7 +3907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3929,7 +3929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4108,7 +4108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4127,7 +4127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4152,7 +4152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4217,7 +4217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4263,7 +4263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4505,7 +4505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4575,7 +4575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4597,7 +4597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4706,7 +4706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4843,7 +4843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4868,7 +4868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4911,7 +4911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4936,7 +4936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4974,7 +4974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -4993,7 +4993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5059,7 +5059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5081,7 +5081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5122,7 +5122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5163,7 +5163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5182,7 +5182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5264,7 +5264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5333,7 +5333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5352,7 +5352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5371,7 +5371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5520,7 +5520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5608,7 +5608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5701,7 +5701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5723,7 +5723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5745,7 +5745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5764,7 +5764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5783,7 +5783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5802,7 +5802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5821,7 +5821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5846,7 +5846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5930,7 +5930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5949,7 +5949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -5993,7 +5993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6135,7 +6135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6160,7 +6160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6182,7 +6182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6229,7 +6229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6279,7 +6279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6425,7 +6425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6620,7 +6620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6642,7 +6642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6702,7 +6702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6727,7 +6727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6749,7 +6749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6875,7 +6875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6937,7 +6937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6959,7 +6959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -6984,7 +6984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7006,7 +7006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7028,7 +7028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7050,7 +7050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7107,7 +7107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7132,7 +7132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7179,7 +7179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7198,7 +7198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7283,7 +7283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7481,7 +7481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7594,7 +7594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7641,7 +7641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7663,7 +7663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7701,7 +7701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7720,7 +7720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7739,7 +7739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7776,7 +7776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7823,7 +7823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7866,7 +7866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7932,7 +7932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7975,7 +7975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -7994,7 +7994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8016,7 +8016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8060,7 +8060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8145,7 +8145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8240,7 +8240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8265,7 +8265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8488,7 +8488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8575,7 +8575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8619,7 +8619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8663,7 +8663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8685,7 +8685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8729,7 +8729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8770,7 +8770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8876,7 +8876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8923,7 +8923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8970,7 +8970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9033,7 +9033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9052,7 +9052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9071,7 +9071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9093,7 +9093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9115,7 +9115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9137,7 +9137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9206,7 +9206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9225,7 +9225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9244,7 +9244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9263,7 +9263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9282,7 +9282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9360,7 +9360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9382,7 +9382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9514,7 +9514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9596,7 +9596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9621,7 +9621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9728,7 +9728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9753,7 +9753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9841,7 +9841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9863,7 +9863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9888,7 +9888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -9995,7 +9995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10020,7 +10020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10063,7 +10063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10085,7 +10085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10170,7 +10170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10189,7 +10189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10211,7 +10211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10271,7 +10271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10381,7 +10381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10403,7 +10403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10422,7 +10422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10522,7 +10522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10666,7 +10666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10685,7 +10685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10704,7 +10704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10777,7 +10777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10821,7 +10821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10843,7 +10843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10862,7 +10862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10971,7 +10971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -10996,7 +10996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11015,7 +11015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11053,7 +11053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11078,7 +11078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11140,7 +11140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11162,7 +11162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11187,7 +11187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11206,7 +11206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11225,7 +11225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11288,7 +11288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11310,7 +11310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11329,7 +11329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11386,7 +11386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11436,7 +11436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11461,7 +11461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11568,7 +11568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11587,7 +11587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11682,7 +11682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11802,7 +11802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11886,7 +11886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11943,7 +11943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12015,7 +12015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12037,7 +12037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12062,7 +12062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12166,7 +12166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12188,7 +12188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12207,7 +12207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12226,7 +12226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12248,7 +12248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12292,7 +12292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12311,7 +12311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12330,7 +12330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12355,7 +12355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12380,7 +12380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12424,7 +12424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12581,7 +12581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12642,7 +12642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12721,7 +12721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12790,7 +12790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13142,7 +13142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13164,7 +13164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13183,7 +13183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13232,7 +13232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13257,7 +13257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13307,7 +13307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13332,7 +13332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13376,7 +13376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13395,7 +13395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13414,7 +13414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13436,7 +13436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13498,7 +13498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13558,7 +13558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13577,7 +13577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13662,7 +13662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13746,7 +13746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13870,7 +13870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13958,7 +13958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14005,7 +14005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14030,7 +14030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14055,7 +14055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14124,7 +14124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14146,7 +14146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14168,7 +14168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14215,7 +14215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14334,7 +14334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14378,7 +14378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14400,7 +14400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14573,7 +14573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14598,7 +14598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14617,7 +14617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14661,7 +14661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14680,7 +14680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14705,7 +14705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14834,7 +14834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14878,7 +14878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14900,7 +14900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14925,7 +14925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14950,7 +14950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -14988,7 +14988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15038,7 +15038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15057,7 +15057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15076,7 +15076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15095,7 +15095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15117,7 +15117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15139,7 +15139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15161,7 +15161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15183,7 +15183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15277,7 +15277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15296,7 +15296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15321,7 +15321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15346,7 +15346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15371,7 +15371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15396,7 +15396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15421,7 +15421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15446,7 +15446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15471,7 +15471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15515,7 +15515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15537,7 +15537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15562,7 +15562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15584,7 +15584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15603,7 +15603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15685,7 +15685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15732,7 +15732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15807,7 +15807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15856,7 +15856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15875,7 +15875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15894,7 +15894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15916,7 +15916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15938,7 +15938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -15960,7 +15960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -15985,7 +15985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16004,7 +16004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16023,7 +16023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16045,7 +16045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16083,7 +16083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16102,7 +16102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16121,7 +16121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16167,7 +16167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16189,7 +16189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16211,7 +16211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16287,7 +16287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16309,7 +16309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16353,7 +16353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16375,7 +16375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16397,7 +16397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16422,7 +16422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16447,7 +16447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16491,7 +16491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16513,7 +16513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16651,7 +16651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16673,7 +16673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16716,7 +16716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16738,7 +16738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16784,7 +16784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16809,7 +16809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16853,7 +16853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16878,7 +16878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16900,7 +16900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16925,7 +16925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17063,7 +17063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17107,7 +17107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17151,7 +17151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17173,7 +17173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17192,7 +17192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17264,7 +17264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17286,7 +17286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17305,7 +17305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17367,7 +17367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17389,7 +17389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17411,7 +17411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17451,7 +17451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17473,7 +17473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17498,7 +17498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17587,7 +17587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17710,7 +17710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17735,7 +17735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17757,7 +17757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17776,7 +17776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17798,7 +17798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17817,7 +17817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17836,7 +17836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17855,7 +17855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17874,7 +17874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17893,7 +17893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -17975,7 +17975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18013,7 +18013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18032,7 +18032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18072,7 +18072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18094,7 +18094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18113,7 +18113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18135,7 +18135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19243,16 +19243,16 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19298,7 +19298,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19329,7 +19329,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/builtins/openobserve-builtins.cdx.xml
+++ b/src/builtins/openobserve-builtins.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d73683a1-71a5-477b-af61-184f0fc60364" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:6c69bda9-4963-40b1-81b4-cb90a12c9924" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.099138000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.655294000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0 bin-target-0">
           <name>openobserve_builtins</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1566,7 +1566,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1576,7 +1576,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1664,7 +1664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1686,7 +1686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1708,7 +1708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1730,7 +1730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1755,10 +1755,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1780,7 +1780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1805,7 +1805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1830,7 +1830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1927,7 +1927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1967,7 +1967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2011,10 +2011,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2055,7 +2055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2099,7 +2099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2121,7 +2121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2143,7 +2143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2165,7 +2165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2187,7 +2187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2209,7 +2209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2231,7 +2231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2253,7 +2253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2275,7 +2275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2297,7 +2297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2319,7 +2319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2341,7 +2341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2363,7 +2363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2385,7 +2385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2407,7 +2407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2513,7 +2513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2532,7 +2532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2551,7 +2551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2595,7 +2595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2614,7 +2614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2633,7 +2633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2658,7 +2658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2683,7 +2683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2702,7 +2702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2724,7 +2724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2743,7 +2743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2762,7 +2762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2781,7 +2781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2800,7 +2800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2822,7 +2822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2869,7 +2869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2888,7 +2888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2910,7 +2910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2998,7 +2998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3017,7 +3017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3036,7 +3036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3055,7 +3055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3074,7 +3074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3093,7 +3093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3112,7 +3112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3131,7 +3131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3150,7 +3150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3169,7 +3169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3188,7 +3188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3207,7 +3207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3226,7 +3226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3245,7 +3245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3264,7 +3264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3283,7 +3283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3302,7 +3302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3402,7 +3402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3424,7 +3424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3443,7 +3443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3533,7 +3533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3555,7 +3555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3599,7 +3599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3624,7 +3624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3649,7 +3649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3674,7 +3674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3724,7 +3724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3792,7 +3792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3880,7 +3880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3941,7 +3941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3963,7 +3963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3985,7 +3985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4007,7 +4007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4032,7 +4032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4057,7 +4057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4079,7 +4079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4101,7 +4101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4123,7 +4123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4142,7 +4142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4186,7 +4186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4208,7 +4208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4251,7 +4251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4297,7 +4297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4338,7 +4338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4363,7 +4363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4385,7 +4385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4429,7 +4429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4448,7 +4448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4539,7 +4539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4609,7 +4609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4631,7 +4631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4653,7 +4653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4675,7 +4675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4740,7 +4740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4877,7 +4877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4902,7 +4902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4945,7 +4945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4970,7 +4970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4989,7 +4989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5008,7 +5008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5027,7 +5027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5093,7 +5093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5115,7 +5115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5156,7 +5156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5178,7 +5178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5197,7 +5197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5216,7 +5216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5298,7 +5298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5367,7 +5367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5386,7 +5386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5405,7 +5405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5427,7 +5427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5554,7 +5554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5642,7 +5642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5667,7 +5667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5714,7 +5714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5760,7 +5760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5782,7 +5782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5804,7 +5804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5823,7 +5823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5842,7 +5842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5861,7 +5861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5880,7 +5880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5905,7 +5905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5989,7 +5989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6008,7 +6008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6030,7 +6030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6052,7 +6052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6118,7 +6118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6175,7 +6175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6194,7 +6194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6219,7 +6219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6241,7 +6241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6263,7 +6263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6288,7 +6288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6313,7 +6313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6378,7 +6378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6397,7 +6397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6422,7 +6422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6444,7 +6444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6531,7 +6531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6553,7 +6553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6575,7 +6575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6597,7 +6597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6622,7 +6622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6647,7 +6647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6726,7 +6726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6748,7 +6748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6770,7 +6770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6789,7 +6789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6808,7 +6808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6833,7 +6833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6855,7 +6855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6877,7 +6877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6899,7 +6899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6921,7 +6921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6940,7 +6940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6962,7 +6962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6981,7 +6981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7043,7 +7043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7065,7 +7065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7090,7 +7090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7112,7 +7112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7134,7 +7134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7156,7 +7156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7175,7 +7175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7213,7 +7213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7238,7 +7238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7260,7 +7260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7285,7 +7285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7304,7 +7304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7389,7 +7389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7432,7 +7432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7520,7 +7520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7587,7 +7587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7700,7 +7700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7747,7 +7747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7769,7 +7769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7788,7 +7788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7807,7 +7807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7826,7 +7826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7845,7 +7845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7882,7 +7882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7925,7 +7925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7950,7 +7950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7993,7 +7993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8059,7 +8059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8102,7 +8102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8121,7 +8121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8143,7 +8143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8165,7 +8165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8187,7 +8187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8209,7 +8209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8231,7 +8231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8253,7 +8253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8272,7 +8272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8367,7 +8367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8392,7 +8392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8417,7 +8417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8442,7 +8442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8615,7 +8615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8702,7 +8702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8746,7 +8746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8790,7 +8790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8812,7 +8812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8834,7 +8834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8856,7 +8856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8878,7 +8878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8897,7 +8897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9003,7 +9003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9025,7 +9025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9050,7 +9050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9072,7 +9072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9097,7 +9097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9160,7 +9160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9179,7 +9179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9198,7 +9198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9220,7 +9220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9242,7 +9242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9264,7 +9264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9286,7 +9286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9308,7 +9308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9333,7 +9333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9352,7 +9352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9371,7 +9371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9390,7 +9390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9409,7 +9409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9428,7 +9428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9487,7 +9487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9509,7 +9509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9534,7 +9534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9556,7 +9556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9597,7 +9597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9663,7 +9663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9704,7 +9704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9723,7 +9723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9748,7 +9748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9770,7 +9770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9792,7 +9792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9811,7 +9811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9830,7 +9830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9855,7 +9855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9880,7 +9880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9943,7 +9943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9968,7 +9968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10015,7 +10015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10037,7 +10037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10056,7 +10056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10078,7 +10078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10100,7 +10100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10122,7 +10122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10147,7 +10147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10190,7 +10190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10256,7 +10256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10278,7 +10278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10316,7 +10316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10338,7 +10338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10423,7 +10423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10511,7 +10511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10533,7 +10533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10555,7 +10555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10574,7 +10574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10593,7 +10593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10643,7 +10643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10693,7 +10693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10837,7 +10837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10856,7 +10856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10875,7 +10875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10948,7 +10948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10992,7 +10992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11014,7 +11014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11033,7 +11033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11052,7 +11052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11074,7 +11074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11142,7 +11142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11167,7 +11167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11186,7 +11186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11205,7 +11205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11224,7 +11224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11249,7 +11249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11271,7 +11271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11311,7 +11311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11333,7 +11333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11358,7 +11358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11377,7 +11377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11396,7 +11396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11418,7 +11418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11459,7 +11459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11481,7 +11481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11500,7 +11500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11557,7 +11557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11582,7 +11582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11607,7 +11607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11632,7 +11632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11701,7 +11701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11720,7 +11720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11758,7 +11758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11831,7 +11831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11853,7 +11853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11910,7 +11910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11932,7 +11932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11954,7 +11954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11973,7 +11973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12057,7 +12057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12095,7 +12095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12114,7 +12114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12136,7 +12136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12186,7 +12186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12208,7 +12208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12233,7 +12233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12280,7 +12280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12318,7 +12318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12337,7 +12337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12359,7 +12359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12378,7 +12378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12397,7 +12397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12419,7 +12419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12441,7 +12441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12463,7 +12463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12482,7 +12482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12501,7 +12501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12526,7 +12526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12551,7 +12551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12573,7 +12573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12595,7 +12595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12617,7 +12617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12639,7 +12639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12661,7 +12661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12683,7 +12683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12727,7 +12727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12752,7 +12752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12813,7 +12813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12892,7 +12892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12914,7 +12914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12936,7 +12936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12961,7 +12961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13253,7 +13253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13272,7 +13272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13291,7 +13291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13313,7 +13313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13335,7 +13335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13403,7 +13403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13428,7 +13428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13453,7 +13453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13478,7 +13478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13503,7 +13503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13525,7 +13525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13547,7 +13547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13566,7 +13566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13585,7 +13585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13607,7 +13607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13629,7 +13629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13669,7 +13669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13688,7 +13688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13710,7 +13710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13729,7 +13729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13748,7 +13748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13770,7 +13770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13792,7 +13792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13814,7 +13814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13833,7 +13833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13895,7 +13895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13917,7 +13917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14041,7 +14041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14063,7 +14063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14085,7 +14085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14129,7 +14129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14176,7 +14176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14201,7 +14201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14226,7 +14226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14251,7 +14251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14276,7 +14276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14301,7 +14301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14323,7 +14323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14345,7 +14345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14367,7 +14367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14389,7 +14389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14411,7 +14411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14433,7 +14433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14455,7 +14455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14480,7 +14480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14502,7 +14502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14524,7 +14524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14549,7 +14549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14574,7 +14574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14599,7 +14599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14621,7 +14621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14640,7 +14640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14662,7 +14662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14706,7 +14706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14728,7 +14728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14794,7 +14794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14879,7 +14879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14904,7 +14904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14923,7 +14923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14945,7 +14945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -14989,7 +14989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15008,7 +15008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15033,7 +15033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15058,7 +15058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15080,7 +15080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15140,7 +15140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15162,7 +15162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15184,7 +15184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15206,7 +15206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15228,7 +15228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15253,7 +15253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15278,7 +15278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15316,7 +15316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15366,7 +15366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15385,7 +15385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15404,7 +15404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15423,7 +15423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15445,7 +15445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15467,7 +15467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15489,7 +15489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15511,7 +15511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15533,7 +15533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15624,7 +15624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15649,7 +15649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15674,7 +15674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15699,7 +15699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15724,7 +15724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15749,7 +15749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15799,7 +15799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15821,7 +15821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15843,7 +15843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15865,7 +15865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15890,7 +15890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15912,7 +15912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15931,7 +15931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16013,7 +16013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16035,7 +16035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16060,7 +16060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16135,7 +16135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16184,7 +16184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16203,7 +16203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16266,7 +16266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16288,7 +16288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16313,7 +16313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16351,7 +16351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16373,7 +16373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16411,7 +16411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16430,7 +16430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16449,7 +16449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16495,7 +16495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16633,7 +16633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16655,7 +16655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16677,7 +16677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16699,7 +16699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16721,7 +16721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16743,7 +16743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16768,7 +16768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16793,7 +16793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16815,7 +16815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16837,7 +16837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16859,7 +16859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16902,7 +16902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16924,7 +16924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16946,7 +16946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16968,7 +16968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16993,7 +16993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17065,7 +17065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17108,7 +17108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17130,7 +17130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17176,7 +17176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17201,7 +17201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17245,7 +17245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17270,7 +17270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17292,7 +17292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17317,7 +17317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17364,7 +17364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17386,7 +17386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17408,7 +17408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17455,7 +17455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17477,7 +17477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17565,7 +17565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17584,7 +17584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17609,7 +17609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17656,7 +17656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17678,7 +17678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17734,7 +17734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17759,7 +17759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17781,7 +17781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17803,7 +17803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17843,7 +17843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17865,7 +17865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17890,7 +17890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18061,7 +18061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18102,7 +18102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18127,7 +18127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18149,7 +18149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18168,7 +18168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18190,7 +18190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18209,7 +18209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18228,7 +18228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18247,7 +18247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18266,7 +18266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18285,7 +18285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18367,7 +18367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18405,7 +18405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18424,7 +18424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18505,7 +18505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18527,7 +18527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19635,12 +19635,12 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19649,7 +19649,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19695,7 +19695,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19726,7 +19726,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -19736,7 +19736,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -19747,7 +19747,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -19763,7 +19763,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/builtins/openobserve-builtins.cdx.xml
+++ b/src/builtins/openobserve-builtins.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d73683a1-71a5-477b-af61-184f0fc60364" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.099138000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0 bin-target-0">
+          <name>openobserve_builtins</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -1557,6 +1557,15 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -2221,28 +2230,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2629,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5701,6 +5713,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6403,6 +6440,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7810,6 +7894,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -10292,6 +10397,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10570,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +14200,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14238,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14164,6 +14363,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SeaQL/sea-query</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14620,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14658,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14657,6 +14941,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/signal-hook</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +16538,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +16880,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +16989,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -19265,6 +19635,20 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +19726,42 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19500,20 +19907,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20062,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20407,6 +20830,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
@@ -20552,6 +20981,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20797,6 +21236,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21271,6 +21713,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +21742,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -22109,6 +22562,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +22582,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +22647,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22204,9 +22693,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22266,6 +22763,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22678,6 +23181,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23314,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23348,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />

--- a/src/cipher/openobserve-cipher.cdx.xml
+++ b/src/cipher/openobserve-cipher.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3ddc9fd2-03a3-43d5-a7bd-1ed484686137" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:95a2e5d2-09eb-439f-bfb1-263dd329d64b" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.747893000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.332481000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/cipher#openobserve-cipher@0.1.0">
       <name>openobserve-cipher</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-cipher@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/cipher#openobserve-cipher@0.1.0 bin-target-0">
           <name>openobserve_cipher</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-cipher@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -53,7 +53,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -78,7 +78,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -115,7 +115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -134,7 +134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -233,7 +233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -252,7 +252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -277,7 +277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -296,7 +296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -315,7 +315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -337,7 +337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -384,7 +384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -409,7 +409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -456,7 +456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -481,7 +481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -506,7 +506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -531,7 +531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -575,7 +575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -597,7 +597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -619,7 +619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -638,7 +638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -657,7 +657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -680,7 +680,7 @@
     </component>
   </components>
   <dependencies>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/cipher#openobserve-cipher@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />

--- a/src/cipher/openobserve-cipher.cdx.xml
+++ b/src/cipher/openobserve-cipher.cdx.xml
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3ddc9fd2-03a3-43d5-a7bd-1ed484686137" version="1">
+  <metadata>
+    <timestamp>2026-07-29T08:21:36.747893000Z</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cargo-cyclonedx</name>
+        <version>0.5.7</version>
+      </tool>
+    </tools>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0">
+      <name>openobserve-cipher</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-cipher@0.1.0?download_url=file://.</purl>
+      <components>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0 bin-target-0">
+          <name>openobserve_cipher</name>
+          <version>0.1.0</version>
+          <purl>pkg:cargo/openobserve-cipher@0.1.0?download_url=file://.#src/lib.rs</purl>
+        </component>
+      </components>
+    </component>
+    <properties>
+      <property name="cdx:rustc:sbom:target:triple">aarch64-apple-darwin</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>aho-corasick</name>
+      <version>1.1.4</version>
+      <description>Fast multiple substring searching.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/aho-corasick@1.1.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/aho-corasick</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/aho-corasick</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
+      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <name>allocator-api2</name>
+      <version>0.2.21</version>
+      <description>Mirror of Rust's allocator API</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/allocator-api2@0.2.21</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/allocator-api2</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zakarumych/allocator-api2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zakarumych/allocator-api2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>cfg-if</name>
+      <version>1.0.4</version>
+      <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cfg-if@1.0.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cfg-if</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2">
+      <name>equivalent</name>
+      <version>1.0.2</version>
+      <description>Traits for key comparison in maps.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/equivalent@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/indexmap-rs/equivalent</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
+      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <name>foldhash</name>
+      <version>0.2.0</version>
+      <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib</expression>
+      </licenses>
+      <purl>pkg:cargo/foldhash@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/orlp/foldhash</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>hashbrown</name>
+      <version>0.16.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
+      <name>indexmap</name>
+      <version>2.14.0</version>
+      <description>A hash table with consistent order and fast iteration.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/indexmap/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/indexmap-rs/indexmap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>itoa</name>
+      <version>1.0.17</version>
+      <description>Fast integer primitive to string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itoa@1.0.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itoa</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
+      <author>The Rust Project Developers</author>
+      <name>libc</name>
+      <version>0.2.186</version>
+      <description>Raw FFI bindings to platform libraries like libc.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/libc@0.2.186</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>lock_api</name>
+      <version>0.4.14</version>
+      <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lock_api@0.4.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <name>memchr</name>
+      <version>2.8.0</version>
+      <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memchr@2.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/memchr/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/memchr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/memchr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>parking_lot</name>
+      <version>0.12.5</version>
+      <description>More compact and efficient implementations of the standard synchronization primitives.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/parking_lot@0.12.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>parking_lot_core</name>
+      <version>0.9.12</version>
+      <description>An advanced API for creating custom synchronization primitives.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/parking_lot_core@0.9.12</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>proc-macro2</name>
+      <version>1.0.106</version>
+      <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro2@1.0.106</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proc-macro2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/proc-macro2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>quote</name>
+      <version>1.0.45</version>
+      <description>Quasi-quoting macro quote!(...)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/quote@1.0.45</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quote/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/quote</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>regex-automata</name>
+      <version>0.4.14</version>
+      <description>Automata construction and matching using regular expressions.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/regex-automata@0.4.14</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/regex-automata</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/regex/tree/master/regex-automata</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>regex-syntax</name>
+      <version>0.8.10</version>
+      <description>A regular expression parser.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/regex-syntax@0.8.10</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/regex-syntax</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/regex/tree/master/regex-syntax</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>regex</name>
+      <version>1.12.3</version>
+      <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/regex@1.12.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/regex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0">
+      <author>bluss</author>
+      <name>scopeguard</name>
+      <version>1.2.0</version>
+      <description>A RAII scope guard that will run a given closure when it goes out of scope, even if the code between panics (assuming unwinding panic).  Defines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as shorthands for guards with one of the implemented strategies. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/scopeguard@1.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/scopeguard/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bluss/scopeguard</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde</name>
+      <version>1.0.228</version>
+      <description>A generic serialization/deserialization framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_core</name>
+      <version>1.0.228</version>
+      <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_core@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_core</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_derive</name>
+      <version>1.0.228</version>
+      <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_derive@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://serde.rs/derive.html</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_json</name>
+      <version>1.0.149</version>
+      <description>A JSON serialization file format</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_json@1.0.149</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_json</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
+      <author>The Servo Project Developers</author>
+      <name>smallvec</name>
+      <version>1.15.1</version>
+      <description>'Small vector' optimization: store up to a small number of items on the stack</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/smallvec@1.15.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/smallvec/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>syn</name>
+      <version>2.0.117</version>
+      <description>Parser for Rust source code</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/syn@2.0.117</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/syn</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/syn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>unicode-ident</name>
+      <version>1.0.24</version>
+      <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75</hash>
+      </hashes>
+      <licenses>
+        <expression>(MIT OR Apache-2.0) AND Unicode-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unicode-ident@1.0.24</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/unicode-ident</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/unicode-ident</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <name>utoipa-gen</name>
+      <version>5.4.0</version>
+      <description>Code generation implementation for utoipa</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/utoipa-gen@5.4.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/juhaku/utoipa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <name>utoipa</name>
+      <version>5.4.0</version>
+      <description>Compile time generated OpenAPI documentation for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/utoipa@5.4.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/juhaku/utoipa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>zmij</name>
+      <version>1.0.21</version>
+      <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zmij@1.0.21</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/zmij</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/zmij</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/cipher#openobserve-cipher@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+  </dependencies>
+</bom>

--- a/src/common/common.cdx.xml
+++ b/src/common/common.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f4c56be6-9d04-42be-b1f6-c76276ef7ee5" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.629648000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0 bin-target-0">
+          <name>common</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/common@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1557,6 +1574,15 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1591,15 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2256,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2655,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5162,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5254,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5777,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6109,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6526,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +7989,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +8963,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9217,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10025,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10549,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10722,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11686,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +13968,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14434,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14472,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14600,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14710,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14873,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14911,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +14963,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15197,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15282,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +15970,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16033,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16860,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17202,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17311,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17494,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19580,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +19995,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20107,42 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20154,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20298,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20453,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21138,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21147,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21222,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21304,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21381,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21637,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +21831,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +21883,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22039,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22130,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22159,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22344,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +22885,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +22994,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23014,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23079,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23103,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23133,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23204,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22525,6 +23474,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23485,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23636,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23769,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23803,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +23838,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/common/common.cdx.xml
+++ b/src/common/common.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f4c56be6-9d04-42be-b1f6-c76276ef7ee5" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f2a631e1-2fef-4b96-9cb8-4840172fb8a6" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.629648000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.216766000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0 bin-target-0">
           <name>common</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/common@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1602,7 +1602,7 @@
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1690,7 +1690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1712,7 +1712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1734,7 +1734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1756,7 +1756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1781,10 +1781,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1806,7 +1806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1831,7 +1831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1856,7 +1856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1953,7 +1953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1993,7 +1993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2015,7 +2015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2037,10 +2037,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2081,7 +2081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2125,7 +2125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2147,7 +2147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2169,7 +2169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2191,7 +2191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2213,7 +2213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2235,7 +2235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2257,7 +2257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2279,7 +2279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2301,7 +2301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2323,7 +2323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2345,7 +2345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2367,7 +2367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2389,7 +2389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2411,7 +2411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2433,7 +2433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2539,7 +2539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2558,7 +2558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2577,7 +2577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2596,7 +2596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2621,7 +2621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2640,7 +2640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2659,7 +2659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2684,7 +2684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2709,7 +2709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2750,7 +2750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2769,7 +2769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2807,7 +2807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2826,7 +2826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2848,7 +2848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2895,7 +2895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2914,7 +2914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2936,7 +2936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2955,7 +2955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3024,7 +3024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3043,7 +3043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3062,7 +3062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3081,7 +3081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3100,7 +3100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3119,7 +3119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3138,7 +3138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3157,7 +3157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3176,7 +3176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3195,7 +3195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3214,7 +3214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3233,7 +3233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3252,7 +3252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3271,7 +3271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3290,7 +3290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3309,7 +3309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3328,7 +3328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3428,7 +3428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3450,7 +3450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3469,7 +3469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3512,7 +3512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3559,7 +3559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3581,7 +3581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3625,7 +3625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3650,7 +3650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3675,7 +3675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3700,7 +3700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3750,7 +3750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3818,7 +3818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3906,7 +3906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3967,7 +3967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3989,7 +3989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4011,7 +4011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4033,7 +4033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4058,7 +4058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4083,7 +4083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4105,7 +4105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4127,7 +4127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4149,7 +4149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4168,7 +4168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4187,7 +4187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4212,7 +4212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4234,7 +4234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4277,7 +4277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4323,7 +4323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4364,7 +4364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4389,7 +4389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4411,7 +4411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4455,7 +4455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4474,7 +4474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4565,7 +4565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4635,7 +4635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4657,7 +4657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4679,7 +4679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4701,7 +4701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4766,7 +4766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4903,7 +4903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4928,7 +4928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4971,7 +4971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4996,7 +4996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5015,7 +5015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5034,7 +5034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5053,7 +5053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5119,7 +5119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5141,7 +5141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5163,7 +5163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5201,7 +5201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5223,7 +5223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5242,7 +5242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5261,7 +5261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5280,7 +5280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5362,7 +5362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5431,7 +5431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5450,7 +5450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5469,7 +5469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5491,7 +5491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5618,7 +5618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5706,7 +5706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5731,7 +5731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5778,7 +5778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5824,7 +5824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5846,7 +5846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5868,7 +5868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5887,7 +5887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5906,7 +5906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5925,7 +5925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5944,7 +5944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5969,7 +5969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6053,7 +6053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6072,7 +6072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6094,7 +6094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6138,7 +6138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6261,7 +6261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6280,7 +6280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6305,7 +6305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6327,7 +6327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6349,7 +6349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6374,7 +6374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6399,7 +6399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6424,7 +6424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6464,7 +6464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6483,7 +6483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6508,7 +6508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6530,7 +6530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6617,7 +6617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6639,7 +6639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6661,7 +6661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6708,7 +6708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6733,7 +6733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6812,7 +6812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6875,7 +6875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6894,7 +6894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6919,7 +6919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6941,7 +6941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6963,7 +6963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6985,7 +6985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7007,7 +7007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7026,7 +7026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7048,7 +7048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7067,7 +7067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7129,7 +7129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7151,7 +7151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7176,7 +7176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7198,7 +7198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7220,7 +7220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7242,7 +7242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7261,7 +7261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7299,7 +7299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7324,7 +7324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7346,7 +7346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7371,7 +7371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7390,7 +7390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7475,7 +7475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7518,7 +7518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7606,7 +7606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7673,7 +7673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7786,7 +7786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7833,7 +7833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7855,7 +7855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7874,7 +7874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7893,7 +7893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7912,7 +7912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7931,7 +7931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7968,7 +7968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8011,7 +8011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8036,7 +8036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8079,7 +8079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8145,7 +8145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8188,7 +8188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8207,7 +8207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8229,7 +8229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8251,7 +8251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8273,7 +8273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8295,7 +8295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8317,7 +8317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8339,7 +8339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8358,7 +8358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8453,7 +8453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8478,7 +8478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8503,7 +8503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8528,7 +8528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8701,7 +8701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8788,7 +8788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8832,7 +8832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8876,7 +8876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8920,7 +8920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8942,7 +8942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8964,7 +8964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -8983,7 +8983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9002,7 +9002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9108,7 +9108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9130,7 +9130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9155,7 +9155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9177,7 +9177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9202,7 +9202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9221,7 +9221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9287,7 +9287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9306,7 +9306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9325,7 +9325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9347,7 +9347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9369,7 +9369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9391,7 +9391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9413,7 +9413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9435,7 +9435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9460,7 +9460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9479,7 +9479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9498,7 +9498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9517,7 +9517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9555,7 +9555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9614,7 +9614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9636,7 +9636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9661,7 +9661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9683,7 +9683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9724,7 +9724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9768,7 +9768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9790,7 +9790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9831,7 +9831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9850,7 +9850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9875,7 +9875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9897,7 +9897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9919,7 +9919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9938,7 +9938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9957,7 +9957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9982,7 +9982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10007,7 +10007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10026,7 +10026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10095,7 +10095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10120,7 +10120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10142,7 +10142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10167,7 +10167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10189,7 +10189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10208,7 +10208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10230,7 +10230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10252,7 +10252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10274,7 +10274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10299,7 +10299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10342,7 +10342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10364,7 +10364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10386,7 +10386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10408,7 +10408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10430,7 +10430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10449,7 +10449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10468,7 +10468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10490,7 +10490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10575,7 +10575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10663,7 +10663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10685,7 +10685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10707,7 +10707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10726,7 +10726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10745,7 +10745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10795,7 +10795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10845,7 +10845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10989,7 +10989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11008,7 +11008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11027,7 +11027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11144,7 +11144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11166,7 +11166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11185,7 +11185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11204,7 +11204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11226,7 +11226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11294,7 +11294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11319,7 +11319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11338,7 +11338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11357,7 +11357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11376,7 +11376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11401,7 +11401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11423,7 +11423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11463,7 +11463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11485,7 +11485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11510,7 +11510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11529,7 +11529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11548,7 +11548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11570,7 +11570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11611,7 +11611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11633,7 +11633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11652,7 +11652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11690,7 +11690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11734,7 +11734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11759,7 +11759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11784,7 +11784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11809,7 +11809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11878,7 +11878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11897,7 +11897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11916,7 +11916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11935,7 +11935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12008,7 +12008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12030,7 +12030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12087,7 +12087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12131,7 +12131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12150,7 +12150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12234,7 +12234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12272,7 +12272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12291,7 +12291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12313,7 +12313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12363,7 +12363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12385,7 +12385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12410,7 +12410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12457,7 +12457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12476,7 +12476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12495,7 +12495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12514,7 +12514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12536,7 +12536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12555,7 +12555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12574,7 +12574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12596,7 +12596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12618,7 +12618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12640,7 +12640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12659,7 +12659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12678,7 +12678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12703,7 +12703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12728,7 +12728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12750,7 +12750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12772,7 +12772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12794,7 +12794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12816,7 +12816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12838,7 +12838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12860,7 +12860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12882,7 +12882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12904,7 +12904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12929,7 +12929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12990,7 +12990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13069,7 +13069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13091,7 +13091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13113,7 +13113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13138,7 +13138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13430,7 +13430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13449,7 +13449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13468,7 +13468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13490,7 +13490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13512,7 +13512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13531,7 +13531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13580,7 +13580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13605,7 +13605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13630,7 +13630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13655,7 +13655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13680,7 +13680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13702,7 +13702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13743,7 +13743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13762,7 +13762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13784,7 +13784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13806,7 +13806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13846,7 +13846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13865,7 +13865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13887,7 +13887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13906,7 +13906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13925,7 +13925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13947,7 +13947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13969,7 +13969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -13988,7 +13988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14007,7 +14007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14026,7 +14026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14048,7 +14048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14067,7 +14067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14129,7 +14129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14151,7 +14151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14275,7 +14275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14297,7 +14297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14319,7 +14319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14363,7 +14363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14410,7 +14410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14435,7 +14435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14460,7 +14460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14485,7 +14485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14510,7 +14510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14535,7 +14535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14557,7 +14557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14579,7 +14579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14601,7 +14601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14623,7 +14623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14645,7 +14645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14667,7 +14667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14689,7 +14689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14714,7 +14714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14733,7 +14733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14755,7 +14755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14777,7 +14777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14802,7 +14802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14827,7 +14827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14852,7 +14852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14874,7 +14874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14893,7 +14893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14915,7 +14915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14937,7 +14937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14959,7 +14959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14981,7 +14981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15047,7 +15047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15132,7 +15132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15157,7 +15157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15176,7 +15176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15198,7 +15198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15242,7 +15242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15261,7 +15261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15286,7 +15286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15305,7 +15305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15330,7 +15330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15352,7 +15352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15393,7 +15393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15412,7 +15412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15434,7 +15434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15456,7 +15456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15478,7 +15478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15500,7 +15500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15525,7 +15525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15550,7 +15550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15588,7 +15588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15638,7 +15638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15657,7 +15657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15676,7 +15676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15695,7 +15695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15717,7 +15717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15739,7 +15739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15761,7 +15761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15783,7 +15783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15805,7 +15805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15877,7 +15877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15896,7 +15896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15921,7 +15921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15946,7 +15946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15971,7 +15971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15996,7 +15996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16021,7 +16021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16046,7 +16046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16071,7 +16071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16096,7 +16096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16121,7 +16121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16143,7 +16143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16165,7 +16165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16187,7 +16187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16212,7 +16212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16234,7 +16234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16253,7 +16253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16335,7 +16335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16357,7 +16357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16382,7 +16382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16457,7 +16457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16506,7 +16506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16525,7 +16525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16544,7 +16544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16566,7 +16566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16588,7 +16588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16610,7 +16610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16635,7 +16635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16654,7 +16654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16673,7 +16673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16695,7 +16695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16733,7 +16733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16752,7 +16752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16771,7 +16771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16817,7 +16817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16839,7 +16839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16879,7 +16879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16955,7 +16955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16977,7 +16977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16999,7 +16999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17021,7 +17021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17065,7 +17065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17090,7 +17090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17115,7 +17115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17137,7 +17137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17159,7 +17159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17181,7 +17181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17224,7 +17224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17246,7 +17246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17268,7 +17268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17290,7 +17290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17315,7 +17315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17365,7 +17365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17387,7 +17387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17430,7 +17430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17452,7 +17452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17523,7 +17523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17548,7 +17548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17592,7 +17592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17617,7 +17617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17639,7 +17639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17664,7 +17664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17689,7 +17689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17711,7 +17711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17733,7 +17733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17755,7 +17755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17802,7 +17802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17824,7 +17824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17846,7 +17846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17890,7 +17890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17912,7 +17912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17931,7 +17931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17956,7 +17956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17978,7 +17978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18003,7 +18003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18025,7 +18025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18044,7 +18044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18081,7 +18081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18106,7 +18106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18128,7 +18128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18150,7 +18150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18190,7 +18190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18212,7 +18212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18237,7 +18237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18326,7 +18326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18408,7 +18408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18449,7 +18449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18474,7 +18474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18496,7 +18496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18515,7 +18515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18537,7 +18537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18556,7 +18556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18575,7 +18575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18594,7 +18594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18613,7 +18613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18632,7 +18632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18714,7 +18714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18752,7 +18752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18771,7 +18771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18811,7 +18811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18833,7 +18833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18852,7 +18852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18874,7 +18874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19995,18 +19995,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20025,12 +20025,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20076,7 +20076,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20107,7 +20107,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20117,7 +20117,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20128,7 +20128,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20144,7 +20144,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20155,9 +20155,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />

--- a/src/compaction/compaction.cdx.xml
+++ b/src/compaction/compaction.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:efbb0187-908c-4220-a564-ee307ddb2c03" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.078275000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0 bin-target-0">
+          <name>compaction</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/compaction@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -978,6 +993,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1153,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1599,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1617,51 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1670,69 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2642,6 +2810,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5317,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5409,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5932,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6264,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6681,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8144,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +9118,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9331,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9394,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10202,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10726,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10899,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11863,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +13124,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13642,6 +14264,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14730,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14768,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14896,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15006,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15169,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15207,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15259,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15493,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15578,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15751,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15808,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16310,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16373,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15750,6 +16718,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/myrrlyn/tap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +17222,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17564,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17673,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17856,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19351,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18863,6 +19949,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19005,6 +20104,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +20388,65 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +20524,37 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +20569,70 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +20643,163 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21103,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21788,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21797,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21872,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21954,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22031,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +22287,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +22481,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +22510,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +22542,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22698,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22789,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22818,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +23003,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21724,6 +23257,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -22011,6 +23572,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23681,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23701,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23766,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23790,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23820,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23891,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23940,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23954,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +24170,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +24181,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +24247,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22677,6 +24332,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +24466,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24500,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +24535,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/compaction/compaction.cdx.xml
+++ b/src/compaction/compaction.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:efbb0187-908c-4220-a564-ee307ddb2c03" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:baac7727-a18c-414f-8aa7-a1674007509a" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.078275000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.638020000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0 bin-target-0">
           <name>compaction</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/compaction@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -815,7 +815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -837,7 +837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -845,7 +845,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -859,7 +859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -867,7 +867,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -888,7 +888,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -899,7 +899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -907,7 +907,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -921,7 +921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -929,7 +929,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -947,7 +947,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -965,7 +965,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -983,7 +983,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -994,24 +994,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1019,7 +1019,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1030,7 +1030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1038,7 +1038,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1049,7 +1049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1057,7 +1057,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1068,7 +1068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1076,7 +1076,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1087,7 +1087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1095,7 +1095,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1106,7 +1106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1114,7 +1114,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1125,7 +1125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1133,7 +1133,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1144,7 +1144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1152,7 +1152,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1163,7 +1163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1171,7 +1171,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1182,7 +1182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1190,7 +1190,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1201,7 +1201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1209,7 +1209,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1220,7 +1220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1228,7 +1228,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1239,7 +1239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1247,7 +1247,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1258,7 +1258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1266,7 +1266,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1277,7 +1277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1285,7 +1285,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1296,7 +1296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1304,7 +1304,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1315,7 +1315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1323,7 +1323,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1334,7 +1334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1342,7 +1342,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1353,7 +1353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1361,7 +1361,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1372,7 +1372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1380,7 +1380,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1391,7 +1391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1399,7 +1399,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1410,7 +1410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1418,7 +1418,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1429,7 +1429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1437,7 +1437,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1448,7 +1448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1456,7 +1456,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1467,7 +1467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1475,7 +1475,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1486,7 +1486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1494,7 +1494,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1505,7 +1505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1513,7 +1513,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1524,7 +1524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1532,7 +1532,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1543,7 +1543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1551,7 +1551,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1562,7 +1562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1570,7 +1570,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1581,7 +1581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1589,7 +1589,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1599,7 +1599,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1608,7 +1608,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1617,7 +1617,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1626,7 +1626,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1635,7 +1635,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1644,7 +1644,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1653,7 +1653,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1662,7 +1662,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1671,7 +1671,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1680,7 +1680,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1689,7 +1689,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1698,7 +1698,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1707,7 +1707,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1716,7 +1716,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1725,7 +1725,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1735,7 +1735,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1823,7 +1823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1845,7 +1845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1867,7 +1867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1889,7 +1889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1914,10 +1914,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1939,7 +1939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1964,7 +1964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2086,7 +2086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2126,7 +2126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2148,7 +2148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2170,10 +2170,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2214,7 +2214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2258,7 +2258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2280,7 +2280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2302,7 +2302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2324,7 +2324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2346,7 +2346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2368,7 +2368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2390,7 +2390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2412,7 +2412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2434,7 +2434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2456,7 +2456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2478,7 +2478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2500,7 +2500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2522,7 +2522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2544,7 +2544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2566,7 +2566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2588,7 +2588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2694,7 +2694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2713,7 +2713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2732,7 +2732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2751,7 +2751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2776,7 +2776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2795,7 +2795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2814,7 +2814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2839,7 +2839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2864,7 +2864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2883,7 +2883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2905,7 +2905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2924,7 +2924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2943,7 +2943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2962,7 +2962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2981,7 +2981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3003,7 +3003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3050,7 +3050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3091,7 +3091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3110,7 +3110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3179,7 +3179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3198,7 +3198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3217,7 +3217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3236,7 +3236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3255,7 +3255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3274,7 +3274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3293,7 +3293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3312,7 +3312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3331,7 +3331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3350,7 +3350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3369,7 +3369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3388,7 +3388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3407,7 +3407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3426,7 +3426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3445,7 +3445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3464,7 +3464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3483,7 +3483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3583,7 +3583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3605,7 +3605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3624,7 +3624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3667,7 +3667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3714,7 +3714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3736,7 +3736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3780,7 +3780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3805,7 +3805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3830,7 +3830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3855,7 +3855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3905,7 +3905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4061,7 +4061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4122,7 +4122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4144,7 +4144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4166,7 +4166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4188,7 +4188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4213,7 +4213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4238,7 +4238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4260,7 +4260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4282,7 +4282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4323,7 +4323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4342,7 +4342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4367,7 +4367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4389,7 +4389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4432,7 +4432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4478,7 +4478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4519,7 +4519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4544,7 +4544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4566,7 +4566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4610,7 +4610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4629,7 +4629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4720,7 +4720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4790,7 +4790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4812,7 +4812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4834,7 +4834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4856,7 +4856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4921,7 +4921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5058,7 +5058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5083,7 +5083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5126,7 +5126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5151,7 +5151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5170,7 +5170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5189,7 +5189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5208,7 +5208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5274,7 +5274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5296,7 +5296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5318,7 +5318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5356,7 +5356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5378,7 +5378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5397,7 +5397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5416,7 +5416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5435,7 +5435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5517,7 +5517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5586,7 +5586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5605,7 +5605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5624,7 +5624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5646,7 +5646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5773,7 +5773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5861,7 +5861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5886,7 +5886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5933,7 +5933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5979,7 +5979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6001,7 +6001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6023,7 +6023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6042,7 +6042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6061,7 +6061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6080,7 +6080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6099,7 +6099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6124,7 +6124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6208,7 +6208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6227,7 +6227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6249,7 +6249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6271,7 +6271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6293,7 +6293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6359,7 +6359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6416,7 +6416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6435,7 +6435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6460,7 +6460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6482,7 +6482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6504,7 +6504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6529,7 +6529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6554,7 +6554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6579,7 +6579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6619,7 +6619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6638,7 +6638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6663,7 +6663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6685,7 +6685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6772,7 +6772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6794,7 +6794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6816,7 +6816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6838,7 +6838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6863,7 +6863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6888,7 +6888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6967,7 +6967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6989,7 +6989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7011,7 +7011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7030,7 +7030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7049,7 +7049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7074,7 +7074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7096,7 +7096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7118,7 +7118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7140,7 +7140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7162,7 +7162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7181,7 +7181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7203,7 +7203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7222,7 +7222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7284,7 +7284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7306,7 +7306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7331,7 +7331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7353,7 +7353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7375,7 +7375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7397,7 +7397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7416,7 +7416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7454,7 +7454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7479,7 +7479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7501,7 +7501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7526,7 +7526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7545,7 +7545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7630,7 +7630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7673,7 +7673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7761,7 +7761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7828,7 +7828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7941,7 +7941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7988,7 +7988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8010,7 +8010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8029,7 +8029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8048,7 +8048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8067,7 +8067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8086,7 +8086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8123,7 +8123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8166,7 +8166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8191,7 +8191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8234,7 +8234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8300,7 +8300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8343,7 +8343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8362,7 +8362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8384,7 +8384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8406,7 +8406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8428,7 +8428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8450,7 +8450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8472,7 +8472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8494,7 +8494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8513,7 +8513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8608,7 +8608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8633,7 +8633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8658,7 +8658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8683,7 +8683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8856,7 +8856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8943,7 +8943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8987,7 +8987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9031,7 +9031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9053,7 +9053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9075,7 +9075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9097,7 +9097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9119,7 +9119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9138,7 +9138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9157,7 +9157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9263,7 +9263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9285,7 +9285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9310,7 +9310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9332,7 +9332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9354,7 +9354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9379,7 +9379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9398,7 +9398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9464,7 +9464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9483,7 +9483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9502,7 +9502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9524,7 +9524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9546,7 +9546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9568,7 +9568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9590,7 +9590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9612,7 +9612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9637,7 +9637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9656,7 +9656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9675,7 +9675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9694,7 +9694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9713,7 +9713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9732,7 +9732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9791,7 +9791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9813,7 +9813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9838,7 +9838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9860,7 +9860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9901,7 +9901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9945,7 +9945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9967,7 +9967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10008,7 +10008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10027,7 +10027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10052,7 +10052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10074,7 +10074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10096,7 +10096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10115,7 +10115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10134,7 +10134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10159,7 +10159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10184,7 +10184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10203,7 +10203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10272,7 +10272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10319,7 +10319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10344,7 +10344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10366,7 +10366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10385,7 +10385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10407,7 +10407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10429,7 +10429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10451,7 +10451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10476,7 +10476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10519,7 +10519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10541,7 +10541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10563,7 +10563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10585,7 +10585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10607,7 +10607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10626,7 +10626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10645,7 +10645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10667,7 +10667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10752,7 +10752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10840,7 +10840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10862,7 +10862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10884,7 +10884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10922,7 +10922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10972,7 +10972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11022,7 +11022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11166,7 +11166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11185,7 +11185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11204,7 +11204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11277,7 +11277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11321,7 +11321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11343,7 +11343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11362,7 +11362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11381,7 +11381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11403,7 +11403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11471,7 +11471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11496,7 +11496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11515,7 +11515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11534,7 +11534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11553,7 +11553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11578,7 +11578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11600,7 +11600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11640,7 +11640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11662,7 +11662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11687,7 +11687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11706,7 +11706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11725,7 +11725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11747,7 +11747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11788,7 +11788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11810,7 +11810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11829,7 +11829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11867,7 +11867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11911,7 +11911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11936,7 +11936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11961,7 +11961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11986,7 +11986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12055,7 +12055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12074,7 +12074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12093,7 +12093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12112,7 +12112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12185,7 +12185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12207,7 +12207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12264,7 +12264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12286,7 +12286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12308,7 +12308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12327,7 +12327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12411,7 +12411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12449,7 +12449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12540,7 +12540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12562,7 +12562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12587,7 +12587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12634,7 +12634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12653,7 +12653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12672,7 +12672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12691,7 +12691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12713,7 +12713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12732,7 +12732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12751,7 +12751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12773,7 +12773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12795,7 +12795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12817,7 +12817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12836,7 +12836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12855,7 +12855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12880,7 +12880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12905,7 +12905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12927,7 +12927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12949,7 +12949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12971,7 +12971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12993,7 +12993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13015,7 +13015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13037,7 +13037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13059,7 +13059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13081,7 +13081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13106,7 +13106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13125,7 +13125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13147,7 +13147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13172,7 +13172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13194,7 +13194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13216,7 +13216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13286,7 +13286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13365,7 +13365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13387,7 +13387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13409,7 +13409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13434,7 +13434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13726,7 +13726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13745,7 +13745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13764,7 +13764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13786,7 +13786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13808,7 +13808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13827,7 +13827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13876,7 +13876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13901,7 +13901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13926,7 +13926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13951,7 +13951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13976,7 +13976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13998,7 +13998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14020,7 +14020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14039,7 +14039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14058,7 +14058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14142,7 +14142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14161,7 +14161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14183,7 +14183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14202,7 +14202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14221,7 +14221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14243,7 +14243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14265,7 +14265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14303,7 +14303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14322,7 +14322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14344,7 +14344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14363,7 +14363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14425,7 +14425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14447,7 +14447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14571,7 +14571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14593,7 +14593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14615,7 +14615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14659,7 +14659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14706,7 +14706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14731,7 +14731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14756,7 +14756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14781,7 +14781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14806,7 +14806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14831,7 +14831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14853,7 +14853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14875,7 +14875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14897,7 +14897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14919,7 +14919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14941,7 +14941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14963,7 +14963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14985,7 +14985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15010,7 +15010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15029,7 +15029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15051,7 +15051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15073,7 +15073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15098,7 +15098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15123,7 +15123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15148,7 +15148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15170,7 +15170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15189,7 +15189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15211,7 +15211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15233,7 +15233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15255,7 +15255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15277,7 +15277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15343,7 +15343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15428,7 +15428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15453,7 +15453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15472,7 +15472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15494,7 +15494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15538,7 +15538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15557,7 +15557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15582,7 +15582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15601,7 +15601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15626,7 +15626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15648,7 +15648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15689,7 +15689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15708,7 +15708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15730,7 +15730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15752,7 +15752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15796,7 +15796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15818,7 +15818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15840,7 +15840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15865,7 +15865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15890,7 +15890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15928,7 +15928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15978,7 +15978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15997,7 +15997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16016,7 +16016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16035,7 +16035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16057,7 +16057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16079,7 +16079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16101,7 +16101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16123,7 +16123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16145,7 +16145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16217,7 +16217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16236,7 +16236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16261,7 +16261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16286,7 +16286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16311,7 +16311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16336,7 +16336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16361,7 +16361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16386,7 +16386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16411,7 +16411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16436,7 +16436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16461,7 +16461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16483,7 +16483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16505,7 +16505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16527,7 +16527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16552,7 +16552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16574,7 +16574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16593,7 +16593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16675,7 +16675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16697,7 +16697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16722,7 +16722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -16744,7 +16744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16819,7 +16819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16868,7 +16868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16887,7 +16887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16906,7 +16906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16928,7 +16928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16997,7 +16997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17035,7 +17035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17057,7 +17057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17095,7 +17095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17114,7 +17114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17133,7 +17133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17179,7 +17179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17201,7 +17201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17241,7 +17241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17317,7 +17317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17339,7 +17339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17361,7 +17361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17383,7 +17383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17405,7 +17405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17427,7 +17427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17452,7 +17452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17477,7 +17477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17521,7 +17521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17586,7 +17586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17608,7 +17608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17630,7 +17630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17652,7 +17652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17677,7 +17677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17727,7 +17727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17749,7 +17749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17792,7 +17792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17814,7 +17814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17885,7 +17885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17910,7 +17910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17954,7 +17954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18001,7 +18001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18026,7 +18026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18051,7 +18051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18073,7 +18073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18095,7 +18095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18117,7 +18117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18164,7 +18164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18186,7 +18186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18208,7 +18208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18252,7 +18252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18274,7 +18274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18293,7 +18293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18318,7 +18318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18340,7 +18340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18365,7 +18365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18387,7 +18387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18406,7 +18406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18443,7 +18443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18468,7 +18468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18490,7 +18490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18512,7 +18512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18552,7 +18552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18574,7 +18574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18599,7 +18599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18688,7 +18688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18770,7 +18770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18811,7 +18811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18836,7 +18836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18858,7 +18858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18877,7 +18877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18899,7 +18899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18918,7 +18918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18937,7 +18937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18956,7 +18956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18975,7 +18975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18994,7 +18994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19076,7 +19076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19114,7 +19114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19133,7 +19133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19173,7 +19173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19195,7 +19195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19214,7 +19214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19236,7 +19236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20388,18 +20388,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20418,36 +20418,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20493,7 +20493,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20524,24 +20524,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20552,15 +20552,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -20569,7 +20569,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20579,7 +20579,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20590,7 +20590,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20606,34 +20606,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20644,24 +20644,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -20670,17 +20670,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -20690,7 +20690,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20699,48 +20699,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -20748,11 +20748,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -20760,10 +20760,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -20775,9 +20775,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20785,16 +20785,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/config/config.cdx.xml
+++ b/src/config/config.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:e5b85076-46bc-4ef3-acdc-9dcc9579bf9e" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:8c3e46a6-62c0-483b-adbe-516293d68640" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.587786000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.178812000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0 bin-target-0">
           <name>config</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/config@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1558,7 +1558,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1646,7 +1646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1668,7 +1668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1690,7 +1690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1712,7 +1712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1737,10 +1737,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1762,7 +1762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1787,7 +1787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1812,7 +1812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1909,7 +1909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1949,7 +1949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1971,7 +1971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -1993,10 +1993,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2037,7 +2037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2081,7 +2081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2103,7 +2103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2125,7 +2125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2147,7 +2147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2169,7 +2169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2191,7 +2191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2213,7 +2213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2235,7 +2235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2257,7 +2257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2279,7 +2279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2301,7 +2301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2323,7 +2323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2345,7 +2345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2367,7 +2367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2389,7 +2389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2495,7 +2495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2514,7 +2514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2533,7 +2533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2552,7 +2552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2577,7 +2577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2596,7 +2596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2615,7 +2615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2640,7 +2640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2659,7 +2659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2681,7 +2681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2700,7 +2700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2719,7 +2719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2738,7 +2738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2757,7 +2757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2779,7 +2779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2826,7 +2826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2845,7 +2845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2867,7 +2867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2886,7 +2886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2955,7 +2955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -2974,7 +2974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -2993,7 +2993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3012,7 +3012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3031,7 +3031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3050,7 +3050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3088,7 +3088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3107,7 +3107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3126,7 +3126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3145,7 +3145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3164,7 +3164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3183,7 +3183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3202,7 +3202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3221,7 +3221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3240,7 +3240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3259,7 +3259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3359,7 +3359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3381,7 +3381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3400,7 +3400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3443,7 +3443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3490,7 +3490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3512,7 +3512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3556,7 +3556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3581,7 +3581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3606,7 +3606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3631,7 +3631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3681,7 +3681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3749,7 +3749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3837,7 +3837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3898,7 +3898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3920,7 +3920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3942,7 +3942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3964,7 +3964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -3989,7 +3989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4014,7 +4014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4036,7 +4036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4058,7 +4058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4080,7 +4080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4099,7 +4099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4118,7 +4118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4143,7 +4143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4165,7 +4165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4208,7 +4208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4254,7 +4254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4295,7 +4295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4320,7 +4320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4342,7 +4342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4386,7 +4386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4405,7 +4405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4496,7 +4496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4566,7 +4566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4588,7 +4588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4610,7 +4610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4632,7 +4632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4697,7 +4697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4834,7 +4834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4859,7 +4859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4902,7 +4902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4927,7 +4927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4946,7 +4946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4965,7 +4965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -4984,7 +4984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5050,7 +5050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5072,7 +5072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5113,7 +5113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5135,7 +5135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5154,7 +5154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5173,7 +5173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5255,7 +5255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5324,7 +5324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5343,7 +5343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5362,7 +5362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5384,7 +5384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5511,7 +5511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5599,7 +5599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5624,7 +5624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5692,7 +5692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5714,7 +5714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5736,7 +5736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5755,7 +5755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5774,7 +5774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5793,7 +5793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5812,7 +5812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5837,7 +5837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5921,7 +5921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5940,7 +5940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5962,7 +5962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -5984,7 +5984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6050,7 +6050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6107,7 +6107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6126,7 +6126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6151,7 +6151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6173,7 +6173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6195,7 +6195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6220,7 +6220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6245,7 +6245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6270,7 +6270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6310,7 +6310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6329,7 +6329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6354,7 +6354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6416,7 +6416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6438,7 +6438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6460,7 +6460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6482,7 +6482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6507,7 +6507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6532,7 +6532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6611,7 +6611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6633,7 +6633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6655,7 +6655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6674,7 +6674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6693,7 +6693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6718,7 +6718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6740,7 +6740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6762,7 +6762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6784,7 +6784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6806,7 +6806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6825,7 +6825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6847,7 +6847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6866,7 +6866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6928,7 +6928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6950,7 +6950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -6975,7 +6975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -6997,7 +6997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7019,7 +7019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7041,7 +7041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7060,7 +7060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7098,7 +7098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7123,7 +7123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7145,7 +7145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7170,7 +7170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7189,7 +7189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7274,7 +7274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7317,7 +7317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7405,7 +7405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7472,7 +7472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7585,7 +7585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7632,7 +7632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7654,7 +7654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7673,7 +7673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7692,7 +7692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7711,7 +7711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7730,7 +7730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7767,7 +7767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7789,7 +7789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7814,7 +7814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7857,7 +7857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7923,7 +7923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7966,7 +7966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -7985,7 +7985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8007,7 +8007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8029,7 +8029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8051,7 +8051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8073,7 +8073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8095,7 +8095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8117,7 +8117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8136,7 +8136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8231,7 +8231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8256,7 +8256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8281,7 +8281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8306,7 +8306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8479,7 +8479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8566,7 +8566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8610,7 +8610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8654,7 +8654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8676,7 +8676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8698,7 +8698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8720,7 +8720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8742,7 +8742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8761,7 +8761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8867,7 +8867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8889,7 +8889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8914,7 +8914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8936,7 +8936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8961,7 +8961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9024,7 +9024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9043,7 +9043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9062,7 +9062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9084,7 +9084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9106,7 +9106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9128,7 +9128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9150,7 +9150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9172,7 +9172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9197,7 +9197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9216,7 +9216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9235,7 +9235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9254,7 +9254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9273,7 +9273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9292,7 +9292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9351,7 +9351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9373,7 +9373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9398,7 +9398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9420,7 +9420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9461,7 +9461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9505,7 +9505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9527,7 +9527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9568,7 +9568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9587,7 +9587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9612,7 +9612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9634,7 +9634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9656,7 +9656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9675,7 +9675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9694,7 +9694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9719,7 +9719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9744,7 +9744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9807,7 +9807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9832,7 +9832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9854,7 +9854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9879,7 +9879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9901,7 +9901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9920,7 +9920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9942,7 +9942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9964,7 +9964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -9986,7 +9986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10011,7 +10011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10054,7 +10054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10076,7 +10076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10098,7 +10098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10120,7 +10120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10142,7 +10142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10161,7 +10161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10180,7 +10180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10202,7 +10202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10262,7 +10262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10350,7 +10350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10372,7 +10372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10394,7 +10394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10413,7 +10413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10463,7 +10463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10513,7 +10513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10657,7 +10657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10676,7 +10676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10695,7 +10695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10768,7 +10768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10812,7 +10812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10834,7 +10834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10853,7 +10853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10872,7 +10872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10894,7 +10894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10962,7 +10962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -10987,7 +10987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11006,7 +11006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11025,7 +11025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11044,7 +11044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11069,7 +11069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11091,7 +11091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11131,7 +11131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11153,7 +11153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11178,7 +11178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11197,7 +11197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11216,7 +11216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11238,7 +11238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11279,7 +11279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11301,7 +11301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11320,7 +11320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11377,7 +11377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11402,7 +11402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11427,7 +11427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11452,7 +11452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11521,7 +11521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11540,7 +11540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11559,7 +11559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11578,7 +11578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11651,7 +11651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11673,7 +11673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11730,7 +11730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11752,7 +11752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11774,7 +11774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11793,7 +11793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11877,7 +11877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11915,7 +11915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11934,7 +11934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11956,7 +11956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12006,7 +12006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12028,7 +12028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12053,7 +12053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12100,7 +12100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12119,7 +12119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12138,7 +12138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12157,7 +12157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12179,7 +12179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12198,7 +12198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12217,7 +12217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12239,7 +12239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12261,7 +12261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12283,7 +12283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12302,7 +12302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12321,7 +12321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12346,7 +12346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12371,7 +12371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12393,7 +12393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12415,7 +12415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12437,7 +12437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12459,7 +12459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12481,7 +12481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12503,7 +12503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12525,7 +12525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12547,7 +12547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12572,7 +12572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12633,7 +12633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12712,7 +12712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12734,7 +12734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12756,7 +12756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12781,7 +12781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13073,7 +13073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13092,7 +13092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13111,7 +13111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13133,7 +13133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13155,7 +13155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13174,7 +13174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13223,7 +13223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13248,7 +13248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13273,7 +13273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13298,7 +13298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13323,7 +13323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13345,7 +13345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13367,7 +13367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13386,7 +13386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13405,7 +13405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13427,7 +13427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13449,7 +13449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13489,7 +13489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13508,7 +13508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13530,7 +13530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13549,7 +13549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13568,7 +13568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13590,7 +13590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13612,7 +13612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13634,7 +13634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13653,7 +13653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13715,7 +13715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13737,7 +13737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13861,7 +13861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13883,7 +13883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13905,7 +13905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13949,7 +13949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -13996,7 +13996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14021,7 +14021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14046,7 +14046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14071,7 +14071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14093,7 +14093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14115,7 +14115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14137,7 +14137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14159,7 +14159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14181,7 +14181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14206,7 +14206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14228,7 +14228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14250,7 +14250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14275,7 +14275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14300,7 +14300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14325,7 +14325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14347,7 +14347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14369,7 +14369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14391,7 +14391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14413,7 +14413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14479,7 +14479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14564,7 +14564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14589,7 +14589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14608,7 +14608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14652,7 +14652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14671,7 +14671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14696,7 +14696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14721,7 +14721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14743,7 +14743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14784,7 +14784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14803,7 +14803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14825,7 +14825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14847,7 +14847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14869,7 +14869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14891,7 +14891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14916,7 +14916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14941,7 +14941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -14979,7 +14979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15029,7 +15029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15048,7 +15048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15067,7 +15067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15086,7 +15086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15108,7 +15108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15130,7 +15130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15152,7 +15152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15174,7 +15174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15196,7 +15196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15268,7 +15268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15287,7 +15287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15312,7 +15312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15337,7 +15337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15362,7 +15362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15387,7 +15387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15412,7 +15412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15437,7 +15437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15462,7 +15462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15484,7 +15484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15506,7 +15506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15528,7 +15528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15553,7 +15553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15575,7 +15575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15594,7 +15594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15676,7 +15676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15698,7 +15698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15723,7 +15723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15798,7 +15798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15847,7 +15847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15866,7 +15866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15885,7 +15885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15907,7 +15907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15929,7 +15929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -15951,7 +15951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -15976,7 +15976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -15995,7 +15995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16014,7 +16014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16036,7 +16036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16074,7 +16074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16093,7 +16093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16112,7 +16112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16158,7 +16158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16180,7 +16180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16202,7 +16202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16278,7 +16278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16300,7 +16300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16322,7 +16322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16344,7 +16344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16366,7 +16366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16388,7 +16388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16413,7 +16413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16438,7 +16438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16460,7 +16460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16482,7 +16482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16504,7 +16504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16526,7 +16526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16548,7 +16548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16570,7 +16570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16592,7 +16592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16642,7 +16642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16664,7 +16664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16707,7 +16707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16729,7 +16729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16775,7 +16775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16800,7 +16800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16844,7 +16844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16869,7 +16869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16891,7 +16891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16916,7 +16916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16941,7 +16941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -16963,7 +16963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -16985,7 +16985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17007,7 +17007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17054,7 +17054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17076,7 +17076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17098,7 +17098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17142,7 +17142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17164,7 +17164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17183,7 +17183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17208,7 +17208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17230,7 +17230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17255,7 +17255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17277,7 +17277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17296,7 +17296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17333,7 +17333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17358,7 +17358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17380,7 +17380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17402,7 +17402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17442,7 +17442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17464,7 +17464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17489,7 +17489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17578,7 +17578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17660,7 +17660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17701,7 +17701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17726,7 +17726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17748,7 +17748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17767,7 +17767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17789,7 +17789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17808,7 +17808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17827,7 +17827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17846,7 +17846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17865,7 +17865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17884,7 +17884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -17966,7 +17966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18004,7 +18004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18023,7 +18023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18063,7 +18063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18085,7 +18085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18104,7 +18104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18126,7 +18126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19234,7 +19234,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19280,7 +19280,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19311,7 +19311,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/config/config.cdx.xml
+++ b/src/config/config.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:e1874bd0-1bd4-463b-ba12-961e75010836" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:e5b85076-46bc-4ef3-acdc-9dcc9579bf9e" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.226490000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.587786000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0 bin-target-0">
           <name>config</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/config@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -125,7 +157,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -485,19 +1908,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -547,25 +1970,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -635,19 +2080,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -657,19 +2102,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -679,19 +2124,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -701,19 +2146,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -723,19 +2168,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -745,19 +2190,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -767,19 +2212,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -789,19 +2234,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -811,19 +2256,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -833,19 +2278,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -855,19 +2300,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -877,19 +2322,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -899,19 +2344,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -921,19 +2366,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1087,6 +2532,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1112,6 +2576,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1128,6 +2611,50 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1150,6 +2677,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1427,19 +2973,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1674,19 +3220,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1728,6 +3274,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -1947,6 +3511,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -1969,6 +3552,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2010,6 +3618,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2150,6 +3783,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2552,6 +4207,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2618,6 +4338,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2823,25 +4565,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -2973,6 +4696,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3042,6 +4790,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3236,6 +5002,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3299,6 +5090,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3422,6 +5232,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation</name>
+      <version>0.9.4</version>
+      <description>Bindings to Core Foundation for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core-foundation@0.9.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/core_detect</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
       <author>RustCrypto Developers</author>
       <name>cpufeatures</name>
@@ -3435,6 +5292,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3568,18 +5447,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3666,6 +5545,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3766,6 +5667,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/block-modes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -3936,729 +5858,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4801,6 +6018,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5070,6 +6309,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5248,6 +6506,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5409,6 +6717,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5447,6 +6821,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5770,6 +7166,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6216,28 +7631,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6349,6 +7742,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6724,6 +8135,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6748,27 +8184,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -6846,31 +8280,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -6893,31 +8302,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7160,18 +8544,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7416,6 +8800,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7479,6 +8885,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7548,6 +8979,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7608,6 +9061,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7630,19 +9105,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -7812,22 +9331,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8045,19 +9586,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8092,25 +9633,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8171,6 +9775,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8274,6 +9900,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8293,6 +9938,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8343,19 +10010,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8493,22 +10160,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8531,6 +10220,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8638,6 +10346,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8904,6 +10656,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
       <name>num_threads</name>
@@ -8974,24 +10764,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9080,6 +10852,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9149,18 +10940,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9339,31 +11130,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9449,19 +11215,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9531,6 +11297,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -9988,6 +11773,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10201,44 +12027,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10414,7 +12202,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -10823,6 +12611,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -10848,18 +12657,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -10993,19 +12802,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11193,28 +13002,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11617,6 +13426,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11736,19 +13567,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -11972,60 +13803,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12185,28 +13995,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12232,19 +14020,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12257,19 +14045,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12414,25 +14202,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -12750,6 +14519,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -12929,19 +14720,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -12989,6 +14780,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13105,19 +14915,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13130,44 +14940,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13193,19 +14978,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -13830,6 +15615,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -13852,77 +15675,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -13942,116 +15694,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14177,6 +15819,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14445,49 +16111,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -14559,19 +16201,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -14883,27 +16525,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
-      <description>OpenTelemetry integration for tracing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -15064,19 +16685,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15184,7 +16804,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -15712,19 +17332,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16383,6 +18003,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -16510,6 +18149,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -16526,7 +18175,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -16538,12 +18187,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -16561,23 +18210,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16585,7 +19257,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -16593,66 +19265,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
@@ -16714,16 +19379,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -16731,40 +19397,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16774,41 +19440,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -16818,58 +19485,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -16912,22 +19580,63 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -16953,7 +19662,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -16972,7 +19681,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -16980,7 +19689,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -16988,7 +19697,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17009,7 +19718,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17019,9 +19728,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17031,7 +19740,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17049,7 +19758,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17067,7 +19776,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17086,7 +19795,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17099,7 +19808,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17114,35 +19823,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17156,23 +19859,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17182,7 +19885,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17192,10 +19895,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17211,7 +19914,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17221,9 +19924,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17266,7 +19974,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17284,6 +19992,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17292,10 +20001,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -17317,10 +20041,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -17390,16 +20116,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -17433,10 +20176,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -17454,6 +20193,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -17471,6 +20215,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -17482,7 +20229,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -17508,6 +20255,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -17517,6 +20265,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -17530,10 +20279,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -17551,10 +20308,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -17565,7 +20322,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -17587,6 +20347,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -17631,511 +20397,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18170,6 +20432,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18178,10 +20445,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18191,8 +20458,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18213,16 +20480,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
@@ -18242,6 +20510,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18259,7 +20535,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18271,12 +20547,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18304,7 +20598,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -18320,6 +20614,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -18373,21 +20670,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -18398,19 +20695,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18418,9 +20702,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -18447,6 +20731,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -18466,7 +20755,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -18496,15 +20785,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -18513,7 +20799,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18522,7 +20808,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -18534,31 +20820,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -18574,11 +20843,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -18634,9 +20900,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -18669,9 +20935,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -18679,12 +20948,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -18701,10 +20976,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -18728,13 +21008,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -18748,8 +21044,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18778,10 +21074,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -18800,21 +21099,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -18824,27 +21132,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18853,7 +21173,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18863,7 +21183,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -18876,13 +21196,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
@@ -18894,6 +21222,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
@@ -18940,48 +21277,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18991,8 +21307,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19003,7 +21322,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19039,9 +21358,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19050,17 +21366,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19068,18 +21384,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19090,6 +21406,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19116,12 +21438,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19163,11 +21485,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19199,16 +21526,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19223,7 +21540,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19245,14 +21562,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19351,14 +21668,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -19372,21 +21693,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -19397,13 +21718,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19428,9 +21749,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -19471,7 +21791,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -19493,7 +21813,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -19502,7 +21822,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19511,7 +21831,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -19537,7 +21857,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -19546,6 +21866,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -19553,7 +21908,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -19566,19 +21921,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -19590,7 +21945,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -19632,12 +21987,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
@@ -19646,21 +22001,19 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -19668,7 +22021,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -19676,7 +22029,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -19690,18 +22043,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19709,7 +22058,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19717,10 +22066,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19731,7 +22081,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19741,7 +22091,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -19760,29 +22110,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19795,6 +22139,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19811,14 +22156,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19839,12 +22184,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19856,7 +22206,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19865,12 +22215,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -19894,20 +22255,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19933,7 +22291,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19946,11 +22304,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -19969,7 +22327,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20017,7 +22375,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20053,7 +22411,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20075,7 +22433,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20088,7 +22446,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20151,7 +22509,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20160,100 +22518,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -20267,6 +22545,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20299,7 +22578,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -20318,48 +22597,43 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -20404,9 +22678,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20426,13 +22700,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20440,11 +22714,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20462,14 +22736,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20511,7 +22777,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20554,6 +22820,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -20568,7 +22835,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -20577,7 +22844,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20623,7 +22890,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -20678,13 +22945,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -20784,6 +23051,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/core/openobserve-core.cdx.xml
+++ b/src/core/openobserve-core.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:24516b89-8ce7-4a48-abcd-c847859c5866" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.810049000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0 bin-target-0">
+          <name>openobserve_core</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1642,78 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1722,78 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2874,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3840,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3887,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3934,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4370,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4586,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4827,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5422,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5538,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5630,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6153,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6485,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6902,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7360,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7480,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8117,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8422,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9405,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9618,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9681,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10294,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10543,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11070,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11243,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11793,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11832,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12044,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12268,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13038,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13554,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14082,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14719,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14836,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15204,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15242,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15370,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15480,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15643,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15681,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15733,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15967,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16052,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16225,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16282,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16360,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16803,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16866,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17214,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17489,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17737,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18082,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18191,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18377,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18424,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19047,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19116,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19978,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20482,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20584,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20740,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21024,50 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21145,108 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21261,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21392,177 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21866,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22287,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22302,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22385,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22414,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22447,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22562,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22577,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22586,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22661,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22743,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22820,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +22895,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +22919,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23020,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23087,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23282,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23311,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23343,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23476,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23535,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23626,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23655,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23747,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23805,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23865,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24000,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24129,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24239,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24446,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24485,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24556,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24576,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24641,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24665,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24695,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24766,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24815,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24830,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25051,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25062,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25128,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25164,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25222,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25356,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25390,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25426,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25492,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/core/openobserve-core.cdx.xml
+++ b/src/core/openobserve-core.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:24516b89-8ce7-4a48-abcd-c847859c5866" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:82ead9b9-ef97-425c-a453-ccf0c41b24a1" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.810049000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.391975000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0 bin-target-0">
           <name>openobserve_core</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1796,7 +1796,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1884,7 +1884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1906,7 +1906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1928,7 +1928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1950,7 +1950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1975,10 +1975,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2000,7 +2000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2025,7 +2025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2050,7 +2050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2147,7 +2147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2187,7 +2187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2209,7 +2209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2231,10 +2231,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2275,7 +2275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2319,7 +2319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2341,7 +2341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2363,7 +2363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2385,7 +2385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2407,7 +2407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2429,7 +2429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2451,7 +2451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2473,7 +2473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2495,7 +2495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2517,7 +2517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2539,7 +2539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2583,7 +2583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2627,7 +2627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2755,7 +2755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2774,7 +2774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2793,7 +2793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2812,7 +2812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2837,7 +2837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2856,7 +2856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2875,7 +2875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2900,7 +2900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2925,7 +2925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2944,7 +2944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2966,7 +2966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2985,7 +2985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3004,7 +3004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3023,7 +3023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3042,7 +3042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3064,7 +3064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3111,7 +3111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3130,7 +3130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3152,7 +3152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3171,7 +3171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3240,7 +3240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3259,7 +3259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3278,7 +3278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3297,7 +3297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3316,7 +3316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3335,7 +3335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3354,7 +3354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3373,7 +3373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3392,7 +3392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3411,7 +3411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3430,7 +3430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3449,7 +3449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3468,7 +3468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3487,7 +3487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3506,7 +3506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3525,7 +3525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3544,7 +3544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3644,7 +3644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3666,7 +3666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3685,7 +3685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3728,7 +3728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3775,7 +3775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3797,7 +3797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3841,7 +3841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3863,7 +3863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3888,7 +3888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3913,7 +3913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3938,7 +3938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3963,7 +3963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3988,7 +3988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4038,7 +4038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4106,7 +4106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4194,7 +4194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4255,7 +4255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4277,7 +4277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4299,7 +4299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4321,7 +4321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4346,7 +4346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4371,7 +4371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4396,7 +4396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4418,7 +4418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4440,7 +4440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4462,7 +4462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4481,7 +4481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4500,7 +4500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4525,7 +4525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4547,7 +4547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4590,7 +4590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4609,7 +4609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4655,7 +4655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4696,7 +4696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4721,7 +4721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4743,7 +4743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4787,7 +4787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4806,7 +4806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4831,7 +4831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4916,7 +4916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4986,7 +4986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5008,7 +5008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5030,7 +5030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5052,7 +5052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5117,7 +5117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5254,7 +5254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5279,7 +5279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5322,7 +5322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5347,7 +5347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5366,7 +5366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5385,7 +5385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5404,7 +5404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5423,7 +5423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5495,7 +5495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5517,7 +5517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5539,7 +5539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5577,7 +5577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5599,7 +5599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5618,7 +5618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5637,7 +5637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5656,7 +5656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5738,7 +5738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5807,7 +5807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5826,7 +5826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5845,7 +5845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5867,7 +5867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5994,7 +5994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6082,7 +6082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6107,7 +6107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6154,7 +6154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6200,7 +6200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6222,7 +6222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6244,7 +6244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6263,7 +6263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6282,7 +6282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6301,7 +6301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6320,7 +6320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6345,7 +6345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6429,7 +6429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6448,7 +6448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6470,7 +6470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6492,7 +6492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6514,7 +6514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6580,7 +6580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6637,7 +6637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6656,7 +6656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6681,7 +6681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6703,7 +6703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6725,7 +6725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6750,7 +6750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6775,7 +6775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6800,7 +6800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6840,7 +6840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6859,7 +6859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6884,7 +6884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6906,7 +6906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6993,7 +6993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7015,7 +7015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7037,7 +7037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7059,7 +7059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7084,7 +7084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7109,7 +7109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7188,7 +7188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7210,7 +7210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7232,7 +7232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7251,7 +7251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7270,7 +7270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7295,7 +7295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7317,7 +7317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7339,7 +7339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7361,7 +7361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7383,7 +7383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7405,7 +7405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7424,7 +7424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7446,7 +7446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7465,7 +7465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7484,7 +7484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7552,7 +7552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7574,7 +7574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7599,7 +7599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7621,7 +7621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7643,7 +7643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7665,7 +7665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7684,7 +7684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7722,7 +7722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7747,7 +7747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7769,7 +7769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7794,7 +7794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7813,7 +7813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7898,7 +7898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7941,7 +7941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8029,7 +8029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8096,7 +8096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8228,7 +8228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8275,7 +8275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8297,7 +8297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8316,7 +8316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8335,7 +8335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8354,7 +8354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8373,7 +8373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8410,7 +8410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8453,7 +8453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8478,7 +8478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8521,7 +8521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8587,7 +8587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8630,7 +8630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8649,7 +8649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8671,7 +8671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8693,7 +8693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8715,7 +8715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8737,7 +8737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8759,7 +8759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8781,7 +8781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8800,7 +8800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8895,7 +8895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8920,7 +8920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8970,7 +8970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9143,7 +9143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9230,7 +9230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9274,7 +9274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9318,7 +9318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9340,7 +9340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9362,7 +9362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9384,7 +9384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9406,7 +9406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9425,7 +9425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9444,7 +9444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9550,7 +9550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9572,7 +9572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9597,7 +9597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9619,7 +9619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9666,7 +9666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9685,7 +9685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9751,7 +9751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9770,7 +9770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9789,7 +9789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9811,7 +9811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9833,7 +9833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9855,7 +9855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9877,7 +9877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9899,7 +9899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9924,7 +9924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9943,7 +9943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9962,7 +9962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9981,7 +9981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10000,7 +10000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10019,7 +10019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10078,7 +10078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10100,7 +10100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10125,7 +10125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10147,7 +10147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10188,7 +10188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10232,7 +10232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10254,7 +10254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10295,7 +10295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10314,7 +10314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10333,7 +10333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10352,7 +10352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10371,7 +10371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10396,7 +10396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10418,7 +10418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10440,7 +10440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10459,7 +10459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10478,7 +10478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10503,7 +10503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10528,7 +10528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10547,7 +10547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10616,7 +10616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10641,7 +10641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10663,7 +10663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10688,7 +10688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10710,7 +10710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10729,7 +10729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10751,7 +10751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10773,7 +10773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10795,7 +10795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10820,7 +10820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10863,7 +10863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10885,7 +10885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10907,7 +10907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10929,7 +10929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10951,7 +10951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10970,7 +10970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10989,7 +10989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11011,7 +11011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11096,7 +11096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11184,7 +11184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11206,7 +11206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11228,7 +11228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11266,7 +11266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11316,7 +11316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11366,7 +11366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11510,7 +11510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11529,7 +11529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11548,7 +11548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11621,7 +11621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11665,7 +11665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11687,7 +11687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11706,7 +11706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11725,7 +11725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11747,7 +11747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11857,7 +11857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11882,7 +11882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11901,7 +11901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11920,7 +11920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11939,7 +11939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11964,7 +11964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11986,7 +11986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12026,7 +12026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12048,7 +12048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12067,7 +12067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12092,7 +12092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12111,7 +12111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12130,7 +12130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12152,7 +12152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12193,7 +12193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12215,7 +12215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12234,7 +12234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12272,7 +12272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12316,7 +12316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12341,7 +12341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12366,7 +12366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12391,7 +12391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12460,7 +12460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12479,7 +12479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12498,7 +12498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12517,7 +12517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12590,7 +12590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12612,7 +12612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12669,7 +12669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12691,7 +12691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12713,7 +12713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12732,7 +12732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12816,7 +12816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12854,7 +12854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12873,7 +12873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12895,7 +12895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12945,7 +12945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12967,7 +12967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12992,7 +12992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13064,7 +13064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13083,7 +13083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13102,7 +13102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13121,7 +13121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13143,7 +13143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13162,7 +13162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13181,7 +13181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13203,7 +13203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13225,7 +13225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13247,7 +13247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13266,7 +13266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13285,7 +13285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13310,7 +13310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13335,7 +13335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13357,7 +13357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13379,7 +13379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13401,7 +13401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13423,7 +13423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13445,7 +13445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13467,7 +13467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13489,7 +13489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13511,7 +13511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13536,7 +13536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13555,7 +13555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13577,7 +13577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13602,7 +13602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13624,7 +13624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13646,7 +13646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13716,7 +13716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13795,7 +13795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13817,7 +13817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13839,7 +13839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13864,7 +13864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14181,7 +14181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14200,7 +14200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14219,7 +14219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14241,7 +14241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14263,7 +14263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14282,7 +14282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14331,7 +14331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14381,7 +14381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14406,7 +14406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14431,7 +14431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14453,7 +14453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14475,7 +14475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14494,7 +14494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14513,7 +14513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14535,7 +14535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14557,7 +14557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14597,7 +14597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14616,7 +14616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14638,7 +14638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14657,7 +14657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14676,7 +14676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14698,7 +14698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14720,7 +14720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14739,7 +14739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14758,7 +14758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14777,7 +14777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14799,7 +14799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14818,7 +14818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14899,7 +14899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14921,7 +14921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15045,7 +15045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15067,7 +15067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15089,7 +15089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15133,7 +15133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15180,7 +15180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15230,7 +15230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15255,7 +15255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15280,7 +15280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15305,7 +15305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15327,7 +15327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15349,7 +15349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15371,7 +15371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15393,7 +15393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15415,7 +15415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15437,7 +15437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15459,7 +15459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15484,7 +15484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15503,7 +15503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15525,7 +15525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15547,7 +15547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15572,7 +15572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15597,7 +15597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15622,7 +15622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15644,7 +15644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15663,7 +15663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15685,7 +15685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15729,7 +15729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15751,7 +15751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15817,7 +15817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15902,7 +15902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15927,7 +15927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15946,7 +15946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15968,7 +15968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16012,7 +16012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16031,7 +16031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16056,7 +16056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16075,7 +16075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16100,7 +16100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16122,7 +16122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16163,7 +16163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16182,7 +16182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16204,7 +16204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16226,7 +16226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16248,7 +16248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16270,7 +16270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16292,7 +16292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16314,7 +16314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16339,7 +16339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16364,7 +16364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16383,7 +16383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16421,7 +16421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16471,7 +16471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16490,7 +16490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16509,7 +16509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16528,7 +16528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16550,7 +16550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16572,7 +16572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16594,7 +16594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16616,7 +16616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16638,7 +16638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16710,7 +16710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16729,7 +16729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16754,7 +16754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16779,7 +16779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16804,7 +16804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16829,7 +16829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16854,7 +16854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16879,7 +16879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16904,7 +16904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16929,7 +16929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16954,7 +16954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16976,7 +16976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16998,7 +16998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17020,7 +17020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17045,7 +17045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17067,7 +17067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17086,7 +17086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17168,7 +17168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17190,7 +17190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17215,7 +17215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17237,7 +17237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17312,7 +17312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17361,7 +17361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17380,7 +17380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17399,7 +17399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17421,7 +17421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17443,7 +17443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17465,7 +17465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17490,7 +17490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17515,7 +17515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17534,7 +17534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17553,7 +17553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17575,7 +17575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17613,7 +17613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17632,7 +17632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17651,7 +17651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17719,7 +17719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17759,7 +17759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17835,7 +17835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17857,7 +17857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17879,7 +17879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17901,7 +17901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17923,7 +17923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17945,7 +17945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17970,7 +17970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17995,7 +17995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18017,7 +18017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18039,7 +18039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18061,7 +18061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18104,7 +18104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18126,7 +18126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18148,7 +18148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18170,7 +18170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18195,7 +18195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18245,7 +18245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18267,7 +18267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18310,7 +18310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18332,7 +18332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18403,7 +18403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18446,7 +18446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18468,7 +18468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18512,7 +18512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18537,7 +18537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18559,7 +18559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18584,7 +18584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18609,7 +18609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18631,7 +18631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18653,7 +18653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18675,7 +18675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18722,7 +18722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18744,7 +18744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18766,7 +18766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18810,7 +18810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18832,7 +18832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18851,7 +18851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18876,7 +18876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18898,7 +18898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18923,7 +18923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18945,7 +18945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18964,7 +18964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19001,7 +19001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19026,7 +19026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19048,7 +19048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19073,7 +19073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19098,7 +19098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19120,7 +19120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19139,7 +19139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19179,7 +19179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19201,7 +19201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19226,7 +19226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19315,7 +19315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19397,7 +19397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19438,7 +19438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19463,7 +19463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19485,7 +19485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19504,7 +19504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19526,7 +19526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19545,7 +19545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19564,7 +19564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19583,7 +19583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19602,7 +19602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19621,7 +19621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19703,7 +19703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19741,7 +19741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19760,7 +19760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19800,7 +19800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19822,7 +19822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19841,7 +19841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19863,7 +19863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21024,27 +21024,27 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21063,12 +21063,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21114,7 +21114,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21145,25 +21145,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21171,36 +21171,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21209,31 +21209,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21244,15 +21244,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21261,7 +21261,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21271,7 +21271,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21282,7 +21282,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21298,55 +21298,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21356,33 +21356,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21393,24 +21393,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21419,17 +21419,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21439,7 +21439,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21448,48 +21448,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21497,25 +21497,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21523,10 +21523,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21538,9 +21538,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21548,16 +21548,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/db/db.cdx.xml
+++ b/src/db/db.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:85fcd2f8-a27c-4b8b-bbd2-87d7207f1868" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.700960000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0 bin-target-0">
+          <name>db</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/db@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,24 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1609,24 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2283,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2682,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5189,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5281,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5804,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6136,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6553,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8016,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +8990,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9244,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10052,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10576,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10749,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11713,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +13995,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14461,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14499,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14627,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14737,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14900,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14938,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +14990,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15224,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15309,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15482,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15539,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16041,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16104,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16931,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17273,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17382,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17565,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19651,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20066,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20178,93 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20276,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20429,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20584,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21269,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21278,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21353,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21435,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21512,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21768,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +21962,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +22014,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22170,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22261,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22290,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22475,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +23016,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23125,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23145,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23210,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23234,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23264,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23335,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23384,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23398,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +23614,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23625,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23776,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23909,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23943,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +23978,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/db/db.cdx.xml
+++ b/src/db/db.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:85fcd2f8-a27c-4b8b-bbd2-87d7207f1868" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:4c777c04-2e3a-4cf7-a035-9be8a86536af" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.700960000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.286796000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0 bin-target-0">
           <name>db</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/db@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1610,7 +1610,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1619,7 +1619,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1629,7 +1629,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1717,7 +1717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1739,7 +1739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1761,7 +1761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1783,7 +1783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1808,10 +1808,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1833,7 +1833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1858,7 +1858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1883,7 +1883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2020,7 +2020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2042,7 +2042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2064,10 +2064,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2108,7 +2108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2152,7 +2152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2174,7 +2174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2196,7 +2196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2218,7 +2218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2240,7 +2240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2262,7 +2262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2284,7 +2284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2306,7 +2306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2328,7 +2328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2350,7 +2350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2372,7 +2372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2394,7 +2394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2416,7 +2416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2438,7 +2438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2460,7 +2460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2566,7 +2566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2585,7 +2585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2604,7 +2604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2623,7 +2623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2648,7 +2648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2667,7 +2667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2686,7 +2686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2711,7 +2711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2736,7 +2736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2755,7 +2755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2777,7 +2777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2796,7 +2796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2815,7 +2815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2834,7 +2834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2853,7 +2853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2875,7 +2875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2922,7 +2922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2941,7 +2941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2963,7 +2963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2982,7 +2982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3051,7 +3051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3070,7 +3070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3089,7 +3089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3108,7 +3108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3127,7 +3127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3146,7 +3146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3165,7 +3165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3184,7 +3184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3203,7 +3203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3222,7 +3222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3241,7 +3241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3260,7 +3260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3279,7 +3279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3298,7 +3298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3317,7 +3317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3336,7 +3336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3355,7 +3355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3455,7 +3455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3477,7 +3477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3496,7 +3496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3539,7 +3539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3586,7 +3586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3608,7 +3608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3652,7 +3652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3677,7 +3677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3702,7 +3702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3727,7 +3727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3777,7 +3777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3845,7 +3845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3933,7 +3933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3994,7 +3994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4016,7 +4016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4038,7 +4038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4060,7 +4060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4085,7 +4085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4110,7 +4110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4132,7 +4132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4154,7 +4154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4176,7 +4176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4195,7 +4195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4214,7 +4214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4239,7 +4239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4261,7 +4261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4350,7 +4350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4391,7 +4391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4416,7 +4416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4438,7 +4438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4482,7 +4482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4501,7 +4501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4592,7 +4592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4662,7 +4662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4684,7 +4684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4706,7 +4706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4728,7 +4728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4793,7 +4793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4930,7 +4930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4998,7 +4998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5023,7 +5023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5042,7 +5042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5061,7 +5061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5080,7 +5080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5146,7 +5146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5168,7 +5168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5190,7 +5190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5228,7 +5228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5250,7 +5250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5269,7 +5269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5288,7 +5288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5307,7 +5307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5389,7 +5389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5458,7 +5458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5477,7 +5477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5496,7 +5496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5518,7 +5518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5645,7 +5645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5733,7 +5733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5758,7 +5758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5805,7 +5805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5851,7 +5851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5873,7 +5873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5895,7 +5895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5914,7 +5914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5933,7 +5933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5952,7 +5952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5996,7 +5996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6080,7 +6080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6099,7 +6099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6121,7 +6121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6143,7 +6143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6165,7 +6165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6231,7 +6231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6288,7 +6288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6307,7 +6307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6332,7 +6332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6354,7 +6354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6376,7 +6376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6401,7 +6401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6426,7 +6426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6451,7 +6451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6510,7 +6510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6535,7 +6535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6557,7 +6557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6644,7 +6644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6666,7 +6666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6688,7 +6688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6710,7 +6710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6735,7 +6735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6760,7 +6760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6839,7 +6839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6861,7 +6861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6883,7 +6883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6902,7 +6902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6921,7 +6921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6946,7 +6946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6968,7 +6968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6990,7 +6990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7012,7 +7012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7034,7 +7034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7053,7 +7053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7075,7 +7075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7094,7 +7094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7156,7 +7156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7178,7 +7178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7203,7 +7203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7225,7 +7225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7247,7 +7247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7269,7 +7269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7288,7 +7288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7351,7 +7351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7373,7 +7373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7398,7 +7398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7417,7 +7417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7502,7 +7502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7545,7 +7545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7633,7 +7633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7700,7 +7700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7813,7 +7813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7860,7 +7860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7882,7 +7882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7901,7 +7901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7920,7 +7920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7939,7 +7939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7958,7 +7958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7995,7 +7995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8063,7 +8063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8106,7 +8106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8172,7 +8172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8215,7 +8215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8234,7 +8234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8256,7 +8256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8278,7 +8278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8300,7 +8300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8322,7 +8322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8344,7 +8344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8366,7 +8366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8385,7 +8385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8480,7 +8480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8505,7 +8505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8530,7 +8530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8555,7 +8555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8728,7 +8728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8815,7 +8815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8859,7 +8859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8903,7 +8903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8925,7 +8925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8947,7 +8947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8969,7 +8969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8991,7 +8991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9010,7 +9010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9029,7 +9029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9135,7 +9135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9157,7 +9157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9182,7 +9182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9204,7 +9204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9229,7 +9229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9248,7 +9248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9314,7 +9314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9333,7 +9333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9352,7 +9352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9374,7 +9374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9396,7 +9396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9418,7 +9418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9440,7 +9440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9462,7 +9462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9487,7 +9487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9506,7 +9506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9525,7 +9525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9544,7 +9544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9563,7 +9563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9582,7 +9582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9663,7 +9663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9688,7 +9688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9710,7 +9710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9751,7 +9751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9795,7 +9795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9817,7 +9817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9858,7 +9858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9877,7 +9877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9902,7 +9902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9924,7 +9924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9946,7 +9946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9965,7 +9965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9984,7 +9984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10009,7 +10009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10034,7 +10034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10053,7 +10053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10122,7 +10122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10147,7 +10147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10169,7 +10169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10194,7 +10194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10216,7 +10216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10235,7 +10235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10257,7 +10257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10279,7 +10279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10301,7 +10301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10326,7 +10326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10369,7 +10369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10391,7 +10391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10413,7 +10413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10435,7 +10435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10457,7 +10457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10476,7 +10476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10495,7 +10495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10517,7 +10517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10602,7 +10602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10690,7 +10690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10712,7 +10712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10734,7 +10734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10753,7 +10753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10772,7 +10772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10822,7 +10822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10872,7 +10872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11016,7 +11016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11035,7 +11035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11054,7 +11054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11127,7 +11127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11171,7 +11171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11193,7 +11193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11212,7 +11212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11231,7 +11231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11253,7 +11253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11321,7 +11321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11346,7 +11346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11365,7 +11365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11384,7 +11384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11403,7 +11403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11428,7 +11428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11450,7 +11450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11490,7 +11490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11512,7 +11512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11537,7 +11537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11556,7 +11556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11575,7 +11575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11597,7 +11597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11638,7 +11638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11679,7 +11679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11717,7 +11717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11786,7 +11786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11811,7 +11811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11836,7 +11836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11905,7 +11905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11943,7 +11943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11962,7 +11962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12035,7 +12035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12057,7 +12057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12114,7 +12114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12136,7 +12136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12158,7 +12158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12177,7 +12177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12261,7 +12261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12318,7 +12318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12340,7 +12340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12390,7 +12390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12412,7 +12412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12437,7 +12437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12484,7 +12484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12503,7 +12503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12522,7 +12522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12541,7 +12541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12563,7 +12563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12582,7 +12582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12601,7 +12601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12623,7 +12623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12645,7 +12645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12667,7 +12667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12686,7 +12686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12730,7 +12730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12755,7 +12755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12777,7 +12777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12799,7 +12799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12821,7 +12821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12843,7 +12843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12865,7 +12865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12887,7 +12887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12909,7 +12909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12931,7 +12931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12956,7 +12956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13017,7 +13017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13096,7 +13096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13118,7 +13118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13140,7 +13140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13165,7 +13165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13457,7 +13457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13476,7 +13476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13495,7 +13495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13558,7 +13558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13607,7 +13607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13632,7 +13632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13657,7 +13657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13682,7 +13682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13707,7 +13707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13729,7 +13729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13751,7 +13751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13770,7 +13770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13789,7 +13789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13811,7 +13811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13833,7 +13833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13873,7 +13873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13933,7 +13933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13952,7 +13952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13974,7 +13974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13996,7 +13996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14015,7 +14015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14034,7 +14034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14053,7 +14053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14075,7 +14075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14094,7 +14094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14156,7 +14156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14178,7 +14178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14302,7 +14302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14324,7 +14324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14346,7 +14346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14390,7 +14390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14437,7 +14437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14462,7 +14462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14487,7 +14487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14512,7 +14512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14537,7 +14537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14562,7 +14562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14584,7 +14584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14606,7 +14606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14628,7 +14628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14650,7 +14650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14672,7 +14672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14694,7 +14694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14716,7 +14716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14741,7 +14741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14760,7 +14760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14782,7 +14782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14804,7 +14804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14829,7 +14829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14854,7 +14854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14879,7 +14879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14901,7 +14901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14920,7 +14920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14942,7 +14942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14964,7 +14964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14986,7 +14986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15008,7 +15008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15074,7 +15074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15159,7 +15159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15184,7 +15184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15203,7 +15203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15225,7 +15225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15269,7 +15269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15288,7 +15288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15313,7 +15313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15332,7 +15332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15357,7 +15357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15379,7 +15379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15420,7 +15420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15439,7 +15439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15461,7 +15461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15483,7 +15483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15505,7 +15505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15527,7 +15527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15549,7 +15549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15571,7 +15571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15596,7 +15596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15621,7 +15621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15659,7 +15659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15709,7 +15709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15728,7 +15728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15747,7 +15747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15766,7 +15766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15788,7 +15788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15810,7 +15810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15832,7 +15832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15854,7 +15854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15876,7 +15876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15948,7 +15948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15967,7 +15967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15992,7 +15992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16017,7 +16017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16042,7 +16042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16067,7 +16067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16092,7 +16092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16117,7 +16117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16142,7 +16142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16167,7 +16167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16192,7 +16192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16214,7 +16214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16236,7 +16236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16258,7 +16258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16283,7 +16283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16305,7 +16305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16324,7 +16324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16406,7 +16406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16428,7 +16428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16453,7 +16453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16528,7 +16528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16577,7 +16577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16596,7 +16596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16615,7 +16615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16637,7 +16637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16659,7 +16659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16681,7 +16681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16706,7 +16706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16725,7 +16725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16744,7 +16744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16766,7 +16766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16804,7 +16804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16823,7 +16823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16842,7 +16842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16888,7 +16888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16910,7 +16910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17026,7 +17026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17048,7 +17048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17070,7 +17070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17092,7 +17092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17114,7 +17114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17136,7 +17136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17161,7 +17161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17186,7 +17186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17208,7 +17208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17230,7 +17230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17252,7 +17252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17295,7 +17295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17317,7 +17317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17339,7 +17339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17361,7 +17361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17386,7 +17386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17436,7 +17436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17458,7 +17458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17501,7 +17501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17523,7 +17523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17594,7 +17594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17619,7 +17619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17663,7 +17663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17688,7 +17688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17710,7 +17710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17735,7 +17735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17760,7 +17760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17782,7 +17782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17804,7 +17804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17826,7 +17826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17873,7 +17873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17895,7 +17895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17917,7 +17917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17961,7 +17961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17983,7 +17983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18002,7 +18002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18027,7 +18027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18049,7 +18049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18074,7 +18074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18096,7 +18096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18115,7 +18115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18152,7 +18152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18177,7 +18177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18199,7 +18199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18221,7 +18221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18261,7 +18261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18283,7 +18283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18308,7 +18308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18397,7 +18397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18479,7 +18479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18520,7 +18520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18545,7 +18545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18567,7 +18567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18586,7 +18586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18608,7 +18608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18627,7 +18627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18646,7 +18646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18665,7 +18665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18684,7 +18684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18703,7 +18703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18785,7 +18785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18823,7 +18823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18842,7 +18842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18882,7 +18882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18904,7 +18904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18923,7 +18923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18945,7 +18945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20066,18 +20066,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20096,12 +20096,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20147,7 +20147,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20178,24 +20178,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20206,10 +20206,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20219,7 +20219,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20230,7 +20230,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20246,27 +20246,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20277,9 +20277,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20287,9 +20287,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/enrichment_data/enrichment-data.cdx.xml
+++ b/src/enrichment_data/enrichment-data.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:70d4b187-7eeb-4405-876a-5b1ec19c78f1" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:401392b2-940b-4410-803c-5d1dbcc6246e" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.059764000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.620231000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0 bin-target-0">
           <name>enrichment_data</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -815,7 +815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -837,7 +837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -845,7 +845,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -859,7 +859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -867,7 +867,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -888,7 +888,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -899,7 +899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -907,7 +907,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -921,7 +921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -929,7 +929,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -947,7 +947,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -965,7 +965,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -983,7 +983,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -994,24 +994,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1019,7 +1019,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1030,7 +1030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1038,7 +1038,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1049,7 +1049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1057,7 +1057,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1068,7 +1068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1076,7 +1076,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1087,7 +1087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1095,7 +1095,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1106,7 +1106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1114,7 +1114,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1125,7 +1125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1133,7 +1133,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1144,7 +1144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1152,7 +1152,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1163,7 +1163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1171,7 +1171,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1182,7 +1182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1190,7 +1190,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1201,7 +1201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1209,7 +1209,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1220,7 +1220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1228,7 +1228,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1239,7 +1239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1247,7 +1247,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1258,7 +1258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1266,7 +1266,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1277,7 +1277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1285,7 +1285,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1296,7 +1296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1304,7 +1304,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1315,7 +1315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1323,7 +1323,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1334,7 +1334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1342,7 +1342,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1353,7 +1353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1361,7 +1361,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1372,7 +1372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1380,7 +1380,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1391,7 +1391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1399,7 +1399,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1410,7 +1410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1418,7 +1418,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1429,7 +1429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1437,7 +1437,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1448,7 +1448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1456,7 +1456,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1467,7 +1467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1475,7 +1475,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1486,7 +1486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1494,7 +1494,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1505,7 +1505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1513,7 +1513,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1524,7 +1524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1532,7 +1532,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1543,7 +1543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1551,7 +1551,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1562,7 +1562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1570,7 +1570,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1581,7 +1581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1589,7 +1589,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1599,7 +1599,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1608,7 +1608,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1617,7 +1617,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1626,7 +1626,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1635,7 +1635,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1644,7 +1644,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1653,7 +1653,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1662,7 +1662,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1671,7 +1671,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1680,7 +1680,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1689,7 +1689,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1698,7 +1698,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1707,7 +1707,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1716,7 +1716,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1725,7 +1725,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1734,7 +1734,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1744,7 +1744,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1832,7 +1832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1854,7 +1854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1876,7 +1876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1898,7 +1898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1923,10 +1923,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1948,7 +1948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1973,7 +1973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1998,7 +1998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2095,7 +2095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2135,7 +2135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2157,7 +2157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2179,10 +2179,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2223,7 +2223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2267,7 +2267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2289,7 +2289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2311,7 +2311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2333,7 +2333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2355,7 +2355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2377,7 +2377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2399,7 +2399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2421,7 +2421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2443,7 +2443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2465,7 +2465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2487,7 +2487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2509,7 +2509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2531,7 +2531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2553,7 +2553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2575,7 +2575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2597,7 +2597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2703,7 +2703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2722,7 +2722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2741,7 +2741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2760,7 +2760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2785,7 +2785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2804,7 +2804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2823,7 +2823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2848,7 +2848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2873,7 +2873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2892,7 +2892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2914,7 +2914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2933,7 +2933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2952,7 +2952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2971,7 +2971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2990,7 +2990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3012,7 +3012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3059,7 +3059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3100,7 +3100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3119,7 +3119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3188,7 +3188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3207,7 +3207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3226,7 +3226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3245,7 +3245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3264,7 +3264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3283,7 +3283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3302,7 +3302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3321,7 +3321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3340,7 +3340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3359,7 +3359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3378,7 +3378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3397,7 +3397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3416,7 +3416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3435,7 +3435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3454,7 +3454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3473,7 +3473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3492,7 +3492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3592,7 +3592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3614,7 +3614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3633,7 +3633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3676,7 +3676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3723,7 +3723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3745,7 +3745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3789,7 +3789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3814,7 +3814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3839,7 +3839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3864,7 +3864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3914,7 +3914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3982,7 +3982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4070,7 +4070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4131,7 +4131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4153,7 +4153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4175,7 +4175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4197,7 +4197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4222,7 +4222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4247,7 +4247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4269,7 +4269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4291,7 +4291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4313,7 +4313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4332,7 +4332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4376,7 +4376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4398,7 +4398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4441,7 +4441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4487,7 +4487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4528,7 +4528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4553,7 +4553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4575,7 +4575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4638,7 +4638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4729,7 +4729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4799,7 +4799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4821,7 +4821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4843,7 +4843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4865,7 +4865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4930,7 +4930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5067,7 +5067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5092,7 +5092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5135,7 +5135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5160,7 +5160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5179,7 +5179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5198,7 +5198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5217,7 +5217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5283,7 +5283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5305,7 +5305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5327,7 +5327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5365,7 +5365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5387,7 +5387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5406,7 +5406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5425,7 +5425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5444,7 +5444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5526,7 +5526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5595,7 +5595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5614,7 +5614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5655,7 +5655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5782,7 +5782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5870,7 +5870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5895,7 +5895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5942,7 +5942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5988,7 +5988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6010,7 +6010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6032,7 +6032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6051,7 +6051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6070,7 +6070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6089,7 +6089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6108,7 +6108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6133,7 +6133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6217,7 +6217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6236,7 +6236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6258,7 +6258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6280,7 +6280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6302,7 +6302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6368,7 +6368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6425,7 +6425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6444,7 +6444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6513,7 +6513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6538,7 +6538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6563,7 +6563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6588,7 +6588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6628,7 +6628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6647,7 +6647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6672,7 +6672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6694,7 +6694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6781,7 +6781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6803,7 +6803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6825,7 +6825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6847,7 +6847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6872,7 +6872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6897,7 +6897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6976,7 +6976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6998,7 +6998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7020,7 +7020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7039,7 +7039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7058,7 +7058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7083,7 +7083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7105,7 +7105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7127,7 +7127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7149,7 +7149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7171,7 +7171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7190,7 +7190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7212,7 +7212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7231,7 +7231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7293,7 +7293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7315,7 +7315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7340,7 +7340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7362,7 +7362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7384,7 +7384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7406,7 +7406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7425,7 +7425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7463,7 +7463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7488,7 +7488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7510,7 +7510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7535,7 +7535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7554,7 +7554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7639,7 +7639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7770,7 +7770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7837,7 +7837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7950,7 +7950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7997,7 +7997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8019,7 +8019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8057,7 +8057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8076,7 +8076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8095,7 +8095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8132,7 +8132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8175,7 +8175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8200,7 +8200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8243,7 +8243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8309,7 +8309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8352,7 +8352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8371,7 +8371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8393,7 +8393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8415,7 +8415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8437,7 +8437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8459,7 +8459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8481,7 +8481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8503,7 +8503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8522,7 +8522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8617,7 +8617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8642,7 +8642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8667,7 +8667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8692,7 +8692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8865,7 +8865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8952,7 +8952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8996,7 +8996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9040,7 +9040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9062,7 +9062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9084,7 +9084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9106,7 +9106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9128,7 +9128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9147,7 +9147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9166,7 +9166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9272,7 +9272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9294,7 +9294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9319,7 +9319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9341,7 +9341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9363,7 +9363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9388,7 +9388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9473,7 +9473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9492,7 +9492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9511,7 +9511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9533,7 +9533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9555,7 +9555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9599,7 +9599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9621,7 +9621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9646,7 +9646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9722,7 +9722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9741,7 +9741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9800,7 +9800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9822,7 +9822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9847,7 +9847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9869,7 +9869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9954,7 +9954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9976,7 +9976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10017,7 +10017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10036,7 +10036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10061,7 +10061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10083,7 +10083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10105,7 +10105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10124,7 +10124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10143,7 +10143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10168,7 +10168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10193,7 +10193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10281,7 +10281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10306,7 +10306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10328,7 +10328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10353,7 +10353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10375,7 +10375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10394,7 +10394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10416,7 +10416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10438,7 +10438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10460,7 +10460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10485,7 +10485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10528,7 +10528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10550,7 +10550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10572,7 +10572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10594,7 +10594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10616,7 +10616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10635,7 +10635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10654,7 +10654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10676,7 +10676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10761,7 +10761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10849,7 +10849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10871,7 +10871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10893,7 +10893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10912,7 +10912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10931,7 +10931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10981,7 +10981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11031,7 +11031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11175,7 +11175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11194,7 +11194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11213,7 +11213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11286,7 +11286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11330,7 +11330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11352,7 +11352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11371,7 +11371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11390,7 +11390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11412,7 +11412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11480,7 +11480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11505,7 +11505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11524,7 +11524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11543,7 +11543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11562,7 +11562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11587,7 +11587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11609,7 +11609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11649,7 +11649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11671,7 +11671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11696,7 +11696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11715,7 +11715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11734,7 +11734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11756,7 +11756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11797,7 +11797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11819,7 +11819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11838,7 +11838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11876,7 +11876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11920,7 +11920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11945,7 +11945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11970,7 +11970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11995,7 +11995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12064,7 +12064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12083,7 +12083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12102,7 +12102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12121,7 +12121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12194,7 +12194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12216,7 +12216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12273,7 +12273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12295,7 +12295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12317,7 +12317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12336,7 +12336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12420,7 +12420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12458,7 +12458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12477,7 +12477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12499,7 +12499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12549,7 +12549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12571,7 +12571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12596,7 +12596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12643,7 +12643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12662,7 +12662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12681,7 +12681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12700,7 +12700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12722,7 +12722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12741,7 +12741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12760,7 +12760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12782,7 +12782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12804,7 +12804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12826,7 +12826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12845,7 +12845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12864,7 +12864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12889,7 +12889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12914,7 +12914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12936,7 +12936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12958,7 +12958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12980,7 +12980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13002,7 +13002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13024,7 +13024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13046,7 +13046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13068,7 +13068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13090,7 +13090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13115,7 +13115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13134,7 +13134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13156,7 +13156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13181,7 +13181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13203,7 +13203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13225,7 +13225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13295,7 +13295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13374,7 +13374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13396,7 +13396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13418,7 +13418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13443,7 +13443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13735,7 +13735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13754,7 +13754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13773,7 +13773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13795,7 +13795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13817,7 +13817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13836,7 +13836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13885,7 +13885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13910,7 +13910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13935,7 +13935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13960,7 +13960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13985,7 +13985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14007,7 +14007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14029,7 +14029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14048,7 +14048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14067,7 +14067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14089,7 +14089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14111,7 +14111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14151,7 +14151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14170,7 +14170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14192,7 +14192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14211,7 +14211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14230,7 +14230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14252,7 +14252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14274,7 +14274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14293,7 +14293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14312,7 +14312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14331,7 +14331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14353,7 +14353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14372,7 +14372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14434,7 +14434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14456,7 +14456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14580,7 +14580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14602,7 +14602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14624,7 +14624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14668,7 +14668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14715,7 +14715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14740,7 +14740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14765,7 +14765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14790,7 +14790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14815,7 +14815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14840,7 +14840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14862,7 +14862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14884,7 +14884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14906,7 +14906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14928,7 +14928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14950,7 +14950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14972,7 +14972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14994,7 +14994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15019,7 +15019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15038,7 +15038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15060,7 +15060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15082,7 +15082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15107,7 +15107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15132,7 +15132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15157,7 +15157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15179,7 +15179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15198,7 +15198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15220,7 +15220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15242,7 +15242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15264,7 +15264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15286,7 +15286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15352,7 +15352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15437,7 +15437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15462,7 +15462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15481,7 +15481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15503,7 +15503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15547,7 +15547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15566,7 +15566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15591,7 +15591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15610,7 +15610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15635,7 +15635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15657,7 +15657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15698,7 +15698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15717,7 +15717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15739,7 +15739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15761,7 +15761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15783,7 +15783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15805,7 +15805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15827,7 +15827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15849,7 +15849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15874,7 +15874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15899,7 +15899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15937,7 +15937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15987,7 +15987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16006,7 +16006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16025,7 +16025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16044,7 +16044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16066,7 +16066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16088,7 +16088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16110,7 +16110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16132,7 +16132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16154,7 +16154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16226,7 +16226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16245,7 +16245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16270,7 +16270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16295,7 +16295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16320,7 +16320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16345,7 +16345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16370,7 +16370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16395,7 +16395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16420,7 +16420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16445,7 +16445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16470,7 +16470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16492,7 +16492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16514,7 +16514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16536,7 +16536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16561,7 +16561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16583,7 +16583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16602,7 +16602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16684,7 +16684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16706,7 +16706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16731,7 +16731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -16753,7 +16753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16828,7 +16828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16877,7 +16877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16896,7 +16896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16915,7 +16915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16937,7 +16937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16959,7 +16959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16981,7 +16981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17006,7 +17006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17025,7 +17025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17044,7 +17044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17066,7 +17066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17104,7 +17104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17123,7 +17123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17142,7 +17142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17188,7 +17188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17210,7 +17210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17250,7 +17250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17326,7 +17326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17348,7 +17348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17370,7 +17370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17392,7 +17392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17414,7 +17414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17436,7 +17436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17461,7 +17461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17486,7 +17486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17508,7 +17508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17530,7 +17530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17552,7 +17552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17595,7 +17595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17617,7 +17617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17639,7 +17639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17661,7 +17661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17686,7 +17686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17736,7 +17736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17758,7 +17758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17801,7 +17801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17823,7 +17823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17894,7 +17894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17919,7 +17919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17963,7 +17963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17988,7 +17988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18010,7 +18010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18035,7 +18035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18060,7 +18060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18082,7 +18082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18104,7 +18104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18126,7 +18126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18173,7 +18173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18195,7 +18195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18217,7 +18217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18261,7 +18261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18283,7 +18283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18302,7 +18302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18327,7 +18327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18349,7 +18349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18374,7 +18374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18396,7 +18396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18415,7 +18415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18452,7 +18452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18477,7 +18477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18499,7 +18499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18521,7 +18521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18561,7 +18561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18583,7 +18583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18608,7 +18608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18697,7 +18697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18779,7 +18779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18820,7 +18820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18845,7 +18845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18867,7 +18867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18886,7 +18886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18908,7 +18908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18927,7 +18927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18946,7 +18946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18965,7 +18965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18984,7 +18984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19003,7 +19003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19085,7 +19085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19123,7 +19123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19142,7 +19142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19182,7 +19182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19204,7 +19204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19223,7 +19223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19245,7 +19245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20397,18 +20397,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20427,36 +20427,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20502,7 +20502,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20533,24 +20533,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20561,10 +20561,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -20572,38 +20572,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -20612,7 +20612,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20622,7 +20622,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20633,7 +20633,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20649,34 +20649,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20687,24 +20687,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -20713,17 +20713,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -20733,7 +20733,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20742,48 +20742,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -20791,11 +20791,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -20803,10 +20803,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -20818,9 +20818,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20828,16 +20828,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/enrichment_data/enrichment-data.cdx.xml
+++ b/src/enrichment_data/enrichment-data.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:70d4b187-7eeb-4405-876a-5b1ec19c78f1" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.059764000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0 bin-target-0">
+          <name>enrichment_data</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -978,6 +993,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1153,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1599,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1626,51 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1679,69 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2642,6 +2819,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5326,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5418,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5941,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6273,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6690,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8153,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +9127,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9340,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9403,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10211,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10735,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10908,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11872,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +13133,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13642,6 +14273,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14739,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14777,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14905,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15015,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15178,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15216,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15268,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15502,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15587,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15760,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15817,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16319,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16382,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15750,6 +16727,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/myrrlyn/tap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +17231,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17573,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17682,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17865,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19360,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18863,6 +19958,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19005,6 +20113,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +20397,65 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +20533,71 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +20612,70 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +20686,163 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21146,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21831,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21840,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21915,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21997,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22074,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +22330,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +22524,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +22553,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +22585,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22741,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22832,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22861,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +23046,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21724,6 +23300,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -22011,6 +23615,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23724,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23744,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23809,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23833,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23863,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23934,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23983,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23997,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +24213,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +24224,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +24290,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22677,6 +24375,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +24509,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24543,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +24578,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/flight/flight.cdx.xml
+++ b/src/flight/flight.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:64d71522-fb9c-41ae-89d4-dd2073508fa1" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.478692000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0 bin-target-0">
           <name>flight</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2420,7 +2420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2526,7 +2526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2545,7 +2545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2564,7 +2564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2583,7 +2583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2608,7 +2608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2627,7 +2627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2646,7 +2646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2671,7 +2671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2712,7 +2712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2731,7 +2731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2750,7 +2750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2769,7 +2769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2810,7 +2810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2857,7 +2857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2876,7 +2876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2898,7 +2898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2917,7 +2917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2986,7 +2986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3005,7 +3005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3024,7 +3024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3043,7 +3043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3062,7 +3062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3081,7 +3081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3100,7 +3100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3119,7 +3119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3138,7 +3138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3157,7 +3157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3176,7 +3176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3195,7 +3195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3214,7 +3214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3233,7 +3233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3252,7 +3252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3271,7 +3271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3290,7 +3290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3390,7 +3390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3412,7 +3412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3431,7 +3431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3474,7 +3474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3543,7 +3543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3587,7 +3587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3612,7 +3612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3637,7 +3637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3662,7 +3662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3712,7 +3712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3780,7 +3780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3868,7 +3868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3929,7 +3929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3995,7 +3995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4020,7 +4020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4111,7 +4111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4130,7 +4130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4149,7 +4149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4196,7 +4196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4239,7 +4239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4285,7 +4285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4326,7 +4326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4373,7 +4373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4417,7 +4417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4436,7 +4436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4527,7 +4527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4597,7 +4597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4663,7 +4663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4728,7 +4728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4865,7 +4865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4890,7 +4890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4933,7 +4933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4958,7 +4958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4977,7 +4977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4996,7 +4996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5015,7 +5015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5081,7 +5081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5103,7 +5103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5166,7 +5166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5185,7 +5185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5204,7 +5204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5286,7 +5286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5355,7 +5355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5374,7 +5374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5415,7 +5415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5542,7 +5542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5630,7 +5630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5655,7 +5655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5723,7 +5723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5745,7 +5745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5767,7 +5767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5786,7 +5786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5805,7 +5805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5824,7 +5824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5843,7 +5843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5868,7 +5868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5952,7 +5952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5993,7 +5993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6015,7 +6015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6081,7 +6081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6138,7 +6138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6157,7 +6157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6182,7 +6182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6226,7 +6226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6251,7 +6251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6276,7 +6276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6301,7 +6301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6341,7 +6341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6360,7 +6360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6385,7 +6385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6513,7 +6513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6538,7 +6538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6563,7 +6563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6642,7 +6642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6686,7 +6686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6705,7 +6705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6724,7 +6724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6749,7 +6749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6837,7 +6837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6878,7 +6878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6897,7 +6897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6959,7 +6959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6981,7 +6981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7006,7 +7006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7028,7 +7028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7050,7 +7050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7072,7 +7072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7091,7 +7091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7129,7 +7129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7176,7 +7176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7201,7 +7201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7220,7 +7220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7305,7 +7305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7348,7 +7348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7436,7 +7436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7503,7 +7503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7616,7 +7616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7663,7 +7663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7685,7 +7685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7704,7 +7704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7723,7 +7723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7742,7 +7742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7761,7 +7761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7820,7 +7820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7845,7 +7845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7888,7 +7888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7954,7 +7954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7997,7 +7997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8016,7 +8016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8060,7 +8060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8148,7 +8148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8167,7 +8167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8262,7 +8262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8287,7 +8287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8312,7 +8312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8337,7 +8337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8510,7 +8510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8597,7 +8597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8641,7 +8641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8685,7 +8685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8729,7 +8729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8773,7 +8773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8792,7 +8792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8920,7 +8920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8967,7 +8967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8992,7 +8992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9055,7 +9055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9074,7 +9074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9093,7 +9093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9115,7 +9115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9137,7 +9137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9203,7 +9203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9228,7 +9228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9247,7 +9247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9266,7 +9266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9285,7 +9285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9304,7 +9304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9323,7 +9323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9382,7 +9382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9404,7 +9404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9451,7 +9451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9492,7 +9492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9558,7 +9558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9599,7 +9599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9618,7 +9618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9687,7 +9687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9706,7 +9706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9725,7 +9725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9750,7 +9750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9775,7 +9775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9838,7 +9838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9863,7 +9863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9885,7 +9885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9932,7 +9932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9995,7 +9995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10017,7 +10017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10042,7 +10042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10085,7 +10085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10173,7 +10173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10192,7 +10192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10211,7 +10211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10233,7 +10233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10293,7 +10293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10381,7 +10381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10403,7 +10403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10425,7 +10425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10444,7 +10444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10494,7 +10494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10544,7 +10544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10688,7 +10688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10707,7 +10707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10726,7 +10726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10799,7 +10799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10843,7 +10843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10865,7 +10865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10884,7 +10884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10925,7 +10925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10993,7 +10993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11018,7 +11018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11037,7 +11037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11056,7 +11056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11075,7 +11075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11122,7 +11122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11162,7 +11162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11184,7 +11184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11209,7 +11209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11228,7 +11228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11269,7 +11269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11310,7 +11310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11332,7 +11332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11351,7 +11351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11408,7 +11408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11433,7 +11433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11458,7 +11458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11483,7 +11483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11552,7 +11552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11571,7 +11571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11590,7 +11590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11609,7 +11609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11682,7 +11682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11704,7 +11704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11805,7 +11805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11824,7 +11824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11908,7 +11908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11946,7 +11946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11987,7 +11987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12037,7 +12037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12059,7 +12059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12084,7 +12084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12131,7 +12131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12150,7 +12150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12169,7 +12169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12188,7 +12188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12210,7 +12210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12229,7 +12229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12248,7 +12248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12292,7 +12292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12314,7 +12314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12333,7 +12333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12352,7 +12352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12377,7 +12377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12424,7 +12424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12578,7 +12578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12603,7 +12603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12664,7 +12664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12787,7 +12787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12812,7 +12812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13104,7 +13104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13123,7 +13123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13142,7 +13142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13164,7 +13164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13186,7 +13186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13205,7 +13205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13254,7 +13254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13279,7 +13279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13304,7 +13304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13329,7 +13329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13376,7 +13376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13398,7 +13398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13417,7 +13417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13436,7 +13436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13480,7 +13480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13520,7 +13520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13561,7 +13561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13580,7 +13580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13665,7 +13665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13684,7 +13684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13746,7 +13746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13768,7 +13768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13936,7 +13936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13980,7 +13980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14027,7 +14027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14052,7 +14052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14077,7 +14077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14124,7 +14124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14146,7 +14146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14168,7 +14168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14212,7 +14212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14281,7 +14281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14306,7 +14306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14331,7 +14331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14378,7 +14378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14400,7 +14400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14444,7 +14444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14510,7 +14510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14595,7 +14595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14620,7 +14620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14639,7 +14639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14683,7 +14683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14702,7 +14702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14727,7 +14727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14774,7 +14774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14815,7 +14815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14834,7 +14834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14878,7 +14878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14900,7 +14900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14922,7 +14922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14947,7 +14947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14972,7 +14972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15010,7 +15010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15060,7 +15060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15079,7 +15079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15098,7 +15098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15117,7 +15117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15139,7 +15139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15161,7 +15161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15183,7 +15183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15227,7 +15227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15299,7 +15299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15318,7 +15318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15343,7 +15343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15368,7 +15368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15393,7 +15393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15418,7 +15418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15443,7 +15443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15468,7 +15468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15515,7 +15515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15537,7 +15537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15559,7 +15559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15584,7 +15584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15606,7 +15606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15625,7 +15625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15729,7 +15729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15754,7 +15754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15829,7 +15829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15878,7 +15878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15897,7 +15897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15916,7 +15916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15938,7 +15938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15960,7 +15960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -15982,7 +15982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16007,7 +16007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16026,7 +16026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16045,7 +16045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16067,7 +16067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16105,7 +16105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16124,7 +16124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16143,7 +16143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16189,7 +16189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16211,7 +16211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16233,7 +16233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16309,7 +16309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16353,7 +16353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16375,7 +16375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16397,7 +16397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16419,7 +16419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16444,7 +16444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16491,7 +16491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16513,7 +16513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16623,7 +16623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16673,7 +16673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16695,7 +16695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16738,7 +16738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16760,7 +16760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16806,7 +16806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16831,7 +16831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16875,7 +16875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16900,7 +16900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16922,7 +16922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16947,7 +16947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17038,7 +17038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17107,7 +17107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17129,7 +17129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17173,7 +17173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17195,7 +17195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17214,7 +17214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17261,7 +17261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17286,7 +17286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17308,7 +17308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17327,7 +17327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17364,7 +17364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17389,7 +17389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17411,7 +17411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17433,7 +17433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17473,7 +17473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17495,7 +17495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17520,7 +17520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17609,7 +17609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17691,7 +17691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17732,7 +17732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17757,7 +17757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17779,7 +17779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17798,7 +17798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17820,7 +17820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17839,7 +17839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17858,7 +17858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17877,7 +17877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17896,7 +17896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17915,7 +17915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -17997,7 +17997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18035,7 +18035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18054,7 +18054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18094,7 +18094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18116,7 +18116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18135,7 +18135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18157,7 +18157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19265,7 +19265,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19311,7 +19311,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19342,12 +19342,12 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -19356,7 +19356,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/infra/infra.cdx.xml
+++ b/src/infra/infra.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:5f4d9026-7307-4093-b3bd-43318ec9561a" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:4de46111-de9d-4cbb-9dde-d0e6b7ab4921" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.250233000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.647877000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0 bin-target-0">
           <name>infra</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/infra@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -125,7 +157,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -134,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -494,19 +1917,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -556,25 +1979,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -644,19 +2089,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -666,19 +2111,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -688,19 +2133,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -710,19 +2155,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -732,19 +2177,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -754,19 +2199,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -776,19 +2221,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -798,19 +2243,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -820,19 +2265,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -842,19 +2287,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -864,19 +2309,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -886,19 +2331,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -908,19 +2353,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -930,19 +2375,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1096,6 +2541,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1121,6 +2585,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1140,19 +2623,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
       <name>async-nats</name>
-      <version>0.46.0</version>
+      <version>0.47.0</version>
       <description>A async Rust NATS client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0</hash>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/async-nats@0.46.0</purl>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/async-nats</url>
@@ -1162,6 +2645,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1184,6 +2711,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1461,19 +3007,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1708,19 +3254,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1762,6 +3308,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -1981,6 +3545,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -2003,6 +3586,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2044,6 +3652,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2184,6 +3817,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2586,6 +4241,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2652,6 +4372,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2857,25 +4599,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -3007,6 +4730,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3076,6 +4824,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3270,6 +5036,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3333,6 +5124,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3478,6 +5288,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/core_detect</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
       <author>RustCrypto Developers</author>
       <name>cpufeatures</name>
@@ -3491,6 +5326,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3624,18 +5481,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3722,6 +5579,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3847,6 +5726,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -4017,729 +5917,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4882,6 +6077,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5151,6 +6368,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5376,6 +6612,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5537,6 +6823,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5575,6 +6927,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5898,6 +7272,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6344,28 +7737,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6477,6 +7848,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6873,6 +8262,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6897,27 +8311,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -6995,31 +8407,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -7042,31 +8429,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7309,18 +8671,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7565,6 +8927,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7628,6 +9012,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7697,6 +9106,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7757,6 +9188,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7779,19 +9232,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -7961,22 +9458,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8194,19 +9713,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8241,25 +9760,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8320,6 +9902,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8423,6 +10027,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8442,6 +10065,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8492,19 +10137,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8642,22 +10287,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8680,6 +10347,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8812,6 +10498,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -9097,6 +10827,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
       <name>num_threads</name>
@@ -9167,24 +10935,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9273,6 +11023,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9342,18 +11111,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9532,31 +11301,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9642,19 +11386,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9724,6 +11468,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -10181,6 +11944,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10394,44 +12198,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10607,7 +12373,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -11016,6 +12782,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -11041,18 +12828,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -11186,19 +12973,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11386,28 +13173,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11810,6 +13597,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11929,19 +13738,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -12120,27 +13929,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <name>rustls-native-certs</name>
-      <version>0.7.3</version>
-      <description>rustls-native-certs allows rustls to use the platform native certificate store</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-native-certs@0.7.3</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <name>rustls-native-certs</name>
       <version>0.8.3</version>
@@ -12159,27 +13947,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <name>rustls-pemfile</name>
-      <version>2.2.0</version>
-      <description>Basic .pem file parser for keys and certificates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-pemfile@2.2.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/pemfile</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/pemfile</url>
         </reference>
       </externalReferences>
     </component>
@@ -12207,78 +13974,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <name>rustls-webpki</name>
-      <version>0.102.8</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.102.8</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12438,28 +14166,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12485,19 +14191,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-cli</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad</hash>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-cli@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12510,19 +14216,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12535,19 +14241,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-migration</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4</hash>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-migration@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12560,19 +14266,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12739,31 +14445,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
-      <name>security-framework</name>
-      <version>2.11.1</version>
-      <description>Security.framework bindings for macOS and iOS</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/security-framework@2.11.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/security_framework</url>
-        </reference>
-        <reference type="website">
-          <url>https://lib.rs/crates/security_framework</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>security-framework</name>
@@ -12786,25 +14467,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -13163,6 +14825,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -13364,19 +15048,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -13424,6 +15108,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13540,19 +15243,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13565,44 +15268,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13628,19 +15306,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -14265,6 +15943,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -14287,77 +16003,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -14377,116 +16022,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14612,6 +16147,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14880,49 +16439,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -15012,19 +16547,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -15336,18 +16871,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
       <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
+      <version>0.33.0</version>
       <description>OpenTelemetry integration for tracing</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
@@ -15542,19 +17077,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15662,7 +17196,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -16190,19 +17724,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16861,6 +18395,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -16988,6 +18541,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -17004,7 +18567,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -17016,12 +18579,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -17039,23 +18602,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17063,7 +19649,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -17071,106 +19657,96 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
@@ -17232,16 +19808,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -17249,40 +19826,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17292,41 +19869,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -17336,58 +19914,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -17430,41 +20009,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
@@ -17473,10 +20070,32 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -17502,7 +20121,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -17521,7 +20140,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17529,7 +20148,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -17537,7 +20156,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17558,7 +20177,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17568,9 +20187,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17580,7 +20199,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17598,7 +20217,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17616,7 +20235,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17635,7 +20254,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17648,7 +20267,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17663,35 +20282,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17705,23 +20318,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17731,7 +20344,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17741,10 +20354,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17760,7 +20373,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17770,9 +20383,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17815,7 +20433,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17833,6 +20451,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17841,10 +20460,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -17866,10 +20500,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -17939,16 +20575,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -17982,10 +20635,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -18003,6 +20652,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -18020,6 +20674,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -18031,7 +20688,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -18057,6 +20714,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -18066,6 +20724,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -18079,14 +20738,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -18104,10 +20767,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -18118,7 +20781,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -18146,6 +20812,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -18190,511 +20862,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18729,6 +20897,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18737,10 +20910,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18750,8 +20923,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18772,16 +20945,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
@@ -18811,6 +20985,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18828,7 +21010,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18840,12 +21022,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18873,7 +21073,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -18889,6 +21089,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -18942,21 +21145,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -18967,19 +21170,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18987,9 +21177,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -19016,6 +21206,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -19038,7 +21233,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -19068,15 +21263,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19085,7 +21277,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19094,7 +21286,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -19106,31 +21298,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -19146,11 +21321,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -19206,9 +21378,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -19241,9 +21413,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -19251,12 +21426,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19273,10 +21454,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -19300,13 +21486,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -19320,8 +21522,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19350,10 +21552,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -19372,21 +21577,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -19396,27 +21610,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -19425,7 +21651,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19435,7 +21661,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -19448,13 +21674,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
@@ -19474,6 +21708,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
@@ -19523,48 +21766,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19574,8 +21796,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19586,7 +21811,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19622,9 +21847,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19633,17 +21855,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19651,18 +21873,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19673,6 +21895,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19699,12 +21927,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19746,11 +21974,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19782,16 +22015,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19806,7 +22029,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19828,14 +22051,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19934,14 +22157,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -19955,21 +22182,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -19980,13 +22207,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20011,9 +22238,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -20054,7 +22280,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20076,7 +22302,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -20085,7 +22311,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -20094,7 +22320,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -20120,7 +22346,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20129,6 +22355,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -20136,7 +22397,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -20149,19 +22410,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -20173,7 +22434,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -20215,47 +22476,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -20263,7 +22510,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -20271,7 +22518,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -20285,18 +22532,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
@@ -20304,12 +22547,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20317,17 +22560,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20335,10 +22578,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20349,7 +22593,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20359,7 +22603,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -20378,7 +22622,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20396,31 +22640,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20433,6 +22664,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20457,14 +22689,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20485,12 +22717,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -20502,7 +22739,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
@@ -20517,12 +22754,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20546,20 +22794,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20585,7 +22830,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -20598,11 +22843,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -20621,7 +22866,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20669,7 +22914,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20705,7 +22950,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20727,7 +22972,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20740,7 +22985,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20803,7 +23048,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20812,100 +23057,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -20919,6 +23084,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20951,7 +23117,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -20970,32 +23136,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -21007,26 +23168,26 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -21071,9 +23232,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -21093,13 +23254,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21107,11 +23268,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21130,8 +23291,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -21166,7 +23327,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21182,7 +23343,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -21225,6 +23386,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -21239,7 +23401,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -21248,7 +23410,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -21294,7 +23456,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -21349,13 +23511,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -21455,6 +23617,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/infra/infra.cdx.xml
+++ b/src/infra/infra.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:4de46111-de9d-4cbb-9dde-d0e6b7ab4921" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:1f9949ea-c651-4989-8332-0f817c0ac686" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.647877000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.235482000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0 bin-target-0">
           <name>infra</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/infra@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2542,7 +2542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2674,7 +2674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2693,7 +2693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2715,7 +2715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2734,7 +2734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2753,7 +2753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2772,7 +2772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2791,7 +2791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2813,7 +2813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2860,7 +2860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2879,7 +2879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2901,7 +2901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2920,7 +2920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2989,7 +2989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3008,7 +3008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3027,7 +3027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3046,7 +3046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3065,7 +3065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3084,7 +3084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3103,7 +3103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3122,7 +3122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3141,7 +3141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3160,7 +3160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3179,7 +3179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3198,7 +3198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3217,7 +3217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3236,7 +3236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3255,7 +3255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3274,7 +3274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3293,7 +3293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3393,7 +3393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3415,7 +3415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3434,7 +3434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3477,7 +3477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3524,7 +3524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3546,7 +3546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3665,7 +3665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3715,7 +3715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3783,7 +3783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3871,7 +3871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3932,7 +3932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3954,7 +3954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3976,7 +3976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4048,7 +4048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4070,7 +4070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4092,7 +4092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4114,7 +4114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4133,7 +4133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4152,7 +4152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4177,7 +4177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4199,7 +4199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4242,7 +4242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4288,7 +4288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4354,7 +4354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4376,7 +4376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4420,7 +4420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4439,7 +4439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4530,7 +4530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4600,7 +4600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4622,7 +4622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4644,7 +4644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4666,7 +4666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4731,7 +4731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4868,7 +4868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4893,7 +4893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4936,7 +4936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4961,7 +4961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4980,7 +4980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4999,7 +4999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5018,7 +5018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5084,7 +5084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5106,7 +5106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5147,7 +5147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5169,7 +5169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5188,7 +5188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5207,7 +5207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5289,7 +5289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5358,7 +5358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5377,7 +5377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5396,7 +5396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5418,7 +5418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5545,7 +5545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5658,7 +5658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5705,7 +5705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5751,7 +5751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5773,7 +5773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5795,7 +5795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5814,7 +5814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5833,7 +5833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5852,7 +5852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5871,7 +5871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5896,7 +5896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5980,7 +5980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5999,7 +5999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6021,7 +6021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6043,7 +6043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6109,7 +6109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6166,7 +6166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6185,7 +6185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6210,7 +6210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6232,7 +6232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6279,7 +6279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6304,7 +6304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6329,7 +6329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6369,7 +6369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6388,7 +6388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6413,7 +6413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6435,7 +6435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6522,7 +6522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6544,7 +6544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6566,7 +6566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6588,7 +6588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6613,7 +6613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6638,7 +6638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6717,7 +6717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6739,7 +6739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6761,7 +6761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6780,7 +6780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6799,7 +6799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6824,7 +6824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6846,7 +6846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6868,7 +6868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6890,7 +6890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6912,7 +6912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6931,7 +6931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6953,7 +6953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6972,7 +6972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7034,7 +7034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7056,7 +7056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7081,7 +7081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7103,7 +7103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7125,7 +7125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7147,7 +7147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7166,7 +7166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7204,7 +7204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7229,7 +7229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7251,7 +7251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7276,7 +7276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7295,7 +7295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7380,7 +7380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7511,7 +7511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7578,7 +7578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7691,7 +7691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7738,7 +7738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7760,7 +7760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7779,7 +7779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7817,7 +7817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7836,7 +7836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7873,7 +7873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7916,7 +7916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7941,7 +7941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7984,7 +7984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8050,7 +8050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8093,7 +8093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8112,7 +8112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8134,7 +8134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8156,7 +8156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8178,7 +8178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8200,7 +8200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8222,7 +8222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8244,7 +8244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8263,7 +8263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8358,7 +8358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8383,7 +8383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8408,7 +8408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8433,7 +8433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8606,7 +8606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8693,7 +8693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8737,7 +8737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8781,7 +8781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8803,7 +8803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8825,7 +8825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8847,7 +8847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8869,7 +8869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8888,7 +8888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8994,7 +8994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9016,7 +9016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9041,7 +9041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9063,7 +9063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9088,7 +9088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9151,7 +9151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9170,7 +9170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9189,7 +9189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9211,7 +9211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9233,7 +9233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9255,7 +9255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9277,7 +9277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9299,7 +9299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9324,7 +9324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9343,7 +9343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9362,7 +9362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9381,7 +9381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9400,7 +9400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9419,7 +9419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9478,7 +9478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9500,7 +9500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9525,7 +9525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9547,7 +9547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9588,7 +9588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9632,7 +9632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9654,7 +9654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9695,7 +9695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9714,7 +9714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9739,7 +9739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9761,7 +9761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9783,7 +9783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9802,7 +9802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9821,7 +9821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9846,7 +9846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9871,7 +9871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9934,7 +9934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9959,7 +9959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9981,7 +9981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10006,7 +10006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10028,7 +10028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10047,7 +10047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10069,7 +10069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10091,7 +10091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10113,7 +10113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10138,7 +10138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10181,7 +10181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10203,7 +10203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10225,7 +10225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10247,7 +10247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10269,7 +10269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10288,7 +10288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10307,7 +10307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10329,7 +10329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10414,7 +10414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10502,7 +10502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10524,7 +10524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10546,7 +10546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10565,7 +10565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10584,7 +10584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10634,7 +10634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10684,7 +10684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10828,7 +10828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10847,7 +10847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10866,7 +10866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10939,7 +10939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10983,7 +10983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11005,7 +11005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11024,7 +11024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11043,7 +11043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11065,7 +11065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11133,7 +11133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11158,7 +11158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11177,7 +11177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11196,7 +11196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11215,7 +11215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11240,7 +11240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11262,7 +11262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11302,7 +11302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11324,7 +11324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11349,7 +11349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11368,7 +11368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11387,7 +11387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11409,7 +11409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11450,7 +11450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11472,7 +11472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11491,7 +11491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11548,7 +11548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11573,7 +11573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11598,7 +11598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11623,7 +11623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11692,7 +11692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11711,7 +11711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11730,7 +11730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11749,7 +11749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11822,7 +11822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11844,7 +11844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11901,7 +11901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11923,7 +11923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11945,7 +11945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11964,7 +11964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12048,7 +12048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12086,7 +12086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12105,7 +12105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12127,7 +12127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12177,7 +12177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12199,7 +12199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12224,7 +12224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12271,7 +12271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12290,7 +12290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12309,7 +12309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12328,7 +12328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12350,7 +12350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12369,7 +12369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12388,7 +12388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12410,7 +12410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12432,7 +12432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12454,7 +12454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12473,7 +12473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12492,7 +12492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12517,7 +12517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12542,7 +12542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12564,7 +12564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12586,7 +12586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12608,7 +12608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12630,7 +12630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12652,7 +12652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12674,7 +12674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12696,7 +12696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12718,7 +12718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12804,7 +12804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12883,7 +12883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12905,7 +12905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12927,7 +12927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12952,7 +12952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13244,7 +13244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13263,7 +13263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13304,7 +13304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13326,7 +13326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13345,7 +13345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13394,7 +13394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13419,7 +13419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13444,7 +13444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13469,7 +13469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13494,7 +13494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13516,7 +13516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13538,7 +13538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13557,7 +13557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13576,7 +13576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13598,7 +13598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13620,7 +13620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13660,7 +13660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13679,7 +13679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13701,7 +13701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13720,7 +13720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13739,7 +13739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13761,7 +13761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13783,7 +13783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13805,7 +13805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13824,7 +13824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13886,7 +13886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13908,7 +13908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14032,7 +14032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14054,7 +14054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14076,7 +14076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14120,7 +14120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14167,7 +14167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14192,7 +14192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14217,7 +14217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14242,7 +14242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14267,7 +14267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14292,7 +14292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14314,7 +14314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14336,7 +14336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14358,7 +14358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14380,7 +14380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14402,7 +14402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14424,7 +14424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14446,7 +14446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14515,7 +14515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14540,7 +14540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14565,7 +14565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14590,7 +14590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14612,7 +14612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14631,7 +14631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14653,7 +14653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14675,7 +14675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14697,7 +14697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14719,7 +14719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14785,7 +14785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14870,7 +14870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14895,7 +14895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14914,7 +14914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14936,7 +14936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -14980,7 +14980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14999,7 +14999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15024,7 +15024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15049,7 +15049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15071,7 +15071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15112,7 +15112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15131,7 +15131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15153,7 +15153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15175,7 +15175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15197,7 +15197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15219,7 +15219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15244,7 +15244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15269,7 +15269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15307,7 +15307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15357,7 +15357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15376,7 +15376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15395,7 +15395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15414,7 +15414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15436,7 +15436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15458,7 +15458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15480,7 +15480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15502,7 +15502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15524,7 +15524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15596,7 +15596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15615,7 +15615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15640,7 +15640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15665,7 +15665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15690,7 +15690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15715,7 +15715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15740,7 +15740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15765,7 +15765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15790,7 +15790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15812,7 +15812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15834,7 +15834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15856,7 +15856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15881,7 +15881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15903,7 +15903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15922,7 +15922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16004,7 +16004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16026,7 +16026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16051,7 +16051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16126,7 +16126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16175,7 +16175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16194,7 +16194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16213,7 +16213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16235,7 +16235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16257,7 +16257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16279,7 +16279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16304,7 +16304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16323,7 +16323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16342,7 +16342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16364,7 +16364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16402,7 +16402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16421,7 +16421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16440,7 +16440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16486,7 +16486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16508,7 +16508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16548,7 +16548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16624,7 +16624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16646,7 +16646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16668,7 +16668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16690,7 +16690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16712,7 +16712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16734,7 +16734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16759,7 +16759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16784,7 +16784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16806,7 +16806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16828,7 +16828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16850,7 +16850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16893,7 +16893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16915,7 +16915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16937,7 +16937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16959,7 +16959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16984,7 +16984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17034,7 +17034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17056,7 +17056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17099,7 +17099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17121,7 +17121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17167,7 +17167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17192,7 +17192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17236,7 +17236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17261,7 +17261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17283,7 +17283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17308,7 +17308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17333,7 +17333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17355,7 +17355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17377,7 +17377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17399,7 +17399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17446,7 +17446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17468,7 +17468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17490,7 +17490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17534,7 +17534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17556,7 +17556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17575,7 +17575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17600,7 +17600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17622,7 +17622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17647,7 +17647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17688,7 +17688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17725,7 +17725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17750,7 +17750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17772,7 +17772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17794,7 +17794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17834,7 +17834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17856,7 +17856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17881,7 +17881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17970,7 +17970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18052,7 +18052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18093,7 +18093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18118,7 +18118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18140,7 +18140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18159,7 +18159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18181,7 +18181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18200,7 +18200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18219,7 +18219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18238,7 +18238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18257,7 +18257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18276,7 +18276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18358,7 +18358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18396,7 +18396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18415,7 +18415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18455,7 +18455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18477,7 +18477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18496,7 +18496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18518,7 +18518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19626,7 +19626,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19672,7 +19672,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19703,7 +19703,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -19713,7 +19713,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -19724,7 +19724,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -19740,7 +19740,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/ingester/ingester.cdx.xml
+++ b/src/ingester/ingester.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3c7c125c-a7ba-435c-ba24-0aeb336f8c87" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c9383106-e00f-483b-a806-8803ac5ac0bd" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.263956000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.719393000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="application" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,12 +18,12 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/ingester#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0 bin-target-0">
           <name>ingester</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/ingester@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
-        <component type="application" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/ingester#0.1.0 bin-target-1">
+        <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0 bin-target-1">
           <name>wal-reader</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/ingester@0.1.0?download_url=file://.#bin/wal-reader.rs</purl>
@@ -35,6 +35,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -130,7 +162,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -139,7 +1562,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -148,7 +1571,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -157,7 +1580,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -517,19 +1940,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -579,25 +2002,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -667,19 +2112,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -689,19 +2134,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -711,19 +2156,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -733,19 +2178,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -755,19 +2200,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -777,19 +2222,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -799,19 +2244,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -821,19 +2266,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -843,19 +2288,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -865,19 +2310,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -887,19 +2332,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -909,19 +2354,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -931,19 +2376,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -953,19 +2398,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1119,6 +2564,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1144,6 +2608,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1163,19 +2646,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
       <name>async-nats</name>
-      <version>0.46.0</version>
+      <version>0.47.0</version>
       <description>A async Rust NATS client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0</hash>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/async-nats@0.46.0</purl>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/async-nats</url>
@@ -1185,6 +2668,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1207,6 +2734,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1484,19 +3030,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1731,19 +3277,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1785,6 +3331,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -2004,6 +3568,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -2026,6 +3609,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2067,6 +3675,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2207,6 +3840,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2609,6 +4264,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2675,6 +4395,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2880,25 +4622,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -3030,6 +4753,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3099,6 +4847,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3293,6 +5059,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3356,6 +5147,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3501,28 +5311,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_affinity@0.8.3">
-      <author>Philip Woods &lt;elzairthesorcerer@gmail.com&gt;</author>
-      <name>core_affinity</name>
-      <version>0.8.3</version>
-      <description>Manages CPU affinities</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342</hash>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/core_affinity@0.8.3</purl>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/core_affinity/</url>
+          <url>https://docs.rs/core_detect</url>
         </reference>
         <reference type="website">
-          <url>https://github.com/Elzair/core_affinity_rs</url>
+          <url>https://github.com/thomcc/core_detect</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/Elzair/core_affinity_rs</url>
+          <url>https://github.com/thomcc/core_detect</url>
         </reference>
       </externalReferences>
     </component>
@@ -3539,6 +5349,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3672,18 +5504,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3770,6 +5602,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3895,6 +5749,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -4065,729 +5940,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4930,6 +6100,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5199,6 +6391,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5424,6 +6635,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5585,6 +6846,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5623,6 +6950,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5946,6 +7295,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6392,28 +7760,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6525,6 +7871,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6921,6 +8285,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6945,27 +8334,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -7043,31 +8430,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -7090,31 +8452,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7357,18 +8694,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7613,6 +8950,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7676,6 +9035,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7745,6 +9129,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7805,6 +9211,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7827,19 +9255,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -8009,22 +9481,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8242,19 +9736,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8289,25 +9783,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8368,6 +9925,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8471,6 +10050,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8490,6 +10088,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8540,19 +10160,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8690,22 +10310,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8728,6 +10370,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8860,6 +10521,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -9145,25 +10850,41 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>num_cpus</name>
-      <version>1.17.0</version>
-      <description>Get the number of CPUs on a machine.</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b</hash>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
       </hashes>
       <licenses>
-        <expression>MIT OR Apache-2.0</expression>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/num_cpus@1.17.0</purl>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
       <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/num_cpus</url>
-        </reference>
         <reference type="vcs">
-          <url>https://github.com/seanmonstar/num_cpus</url>
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
         </reference>
       </externalReferences>
     </component>
@@ -9237,24 +10958,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9343,6 +11046,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9412,18 +11134,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9602,31 +11324,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9712,19 +11409,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9794,6 +11491,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -10251,6 +11967,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10464,44 +12221,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10677,7 +12396,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -11086,6 +12805,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -11111,18 +12851,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -11256,19 +12996,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11456,28 +13196,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11880,6 +13620,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11999,19 +13761,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -12190,27 +13952,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <name>rustls-native-certs</name>
-      <version>0.7.3</version>
-      <description>rustls-native-certs allows rustls to use the platform native certificate store</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-native-certs@0.7.3</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <name>rustls-native-certs</name>
       <version>0.8.3</version>
@@ -12229,27 +13970,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <name>rustls-pemfile</name>
-      <version>2.2.0</version>
-      <description>Basic .pem file parser for keys and certificates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-pemfile@2.2.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/pemfile</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/pemfile</url>
         </reference>
       </externalReferences>
     </component>
@@ -12277,78 +13997,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <name>rustls-webpki</name>
-      <version>0.102.8</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.102.8</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12508,28 +14189,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12555,19 +14214,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-cli</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad</hash>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-cli@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12580,19 +14239,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12605,19 +14264,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-migration</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4</hash>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-migration@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12630,19 +14289,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12809,31 +14468,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
-      <name>security-framework</name>
-      <version>2.11.1</version>
-      <description>Security.framework bindings for macOS and iOS</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/security-framework@2.11.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/security_framework</url>
-        </reference>
-        <reference type="website">
-          <url>https://lib.rs/crates/security_framework</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>security-framework</name>
@@ -12856,25 +14490,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -13233,6 +14848,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -13434,19 +15071,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -13494,6 +15131,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13654,19 +15310,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13679,44 +15335,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13742,19 +15373,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -14379,6 +16010,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -14401,77 +16070,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -14491,116 +16089,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14726,6 +16214,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14994,49 +16506,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -15126,19 +16614,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -15450,18 +16938,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
       <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
+      <version>0.33.0</version>
       <description>OpenTelemetry integration for tracing</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
@@ -15656,19 +17144,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15776,7 +17263,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -16304,19 +17791,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16975,6 +18462,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -17102,6 +18608,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -17118,7 +18634,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -17130,12 +18646,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -17153,23 +18669,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17177,7 +19716,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -17185,139 +19724,125 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/ingester#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_affinity@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
@@ -17379,16 +19904,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -17396,40 +19922,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17439,41 +19965,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -17483,58 +20010,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -17577,41 +20105,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
@@ -17620,10 +20166,32 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -17649,7 +20217,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -17668,7 +20236,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17676,7 +20244,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -17684,7 +20252,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17705,7 +20273,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17715,9 +20283,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17727,7 +20295,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17745,7 +20313,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17763,7 +20331,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17782,7 +20350,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17795,7 +20363,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17810,35 +20378,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17852,23 +20414,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17878,7 +20440,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17888,10 +20450,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17907,7 +20469,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17917,9 +20479,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17962,7 +20529,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17980,6 +20547,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17988,10 +20556,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -18013,10 +20596,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -18086,16 +20671,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -18129,10 +20731,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -18150,6 +20748,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -18167,6 +20770,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -18178,7 +20784,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -18204,6 +20810,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -18213,6 +20820,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -18226,18 +20834,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_affinity@0.8.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -18255,10 +20863,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -18269,7 +20877,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -18297,6 +20908,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -18341,511 +20958,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18880,6 +20993,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18888,10 +21006,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18901,8 +21019,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18923,16 +21041,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
@@ -18962,6 +21081,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18979,7 +21106,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18991,12 +21118,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19024,7 +21169,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -19040,6 +21185,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -19093,21 +21241,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -19118,19 +21266,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19138,9 +21273,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -19167,6 +21302,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -19189,7 +21329,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -19219,15 +21359,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19236,7 +21373,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19245,7 +21382,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -19257,31 +21394,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -19297,11 +21417,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -19357,9 +21474,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -19392,9 +21509,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -19402,12 +21522,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19424,10 +21550,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -19451,13 +21582,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -19471,8 +21618,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19501,10 +21648,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -19523,21 +21673,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -19547,27 +21706,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -19576,7 +21747,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19586,7 +21757,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -19599,13 +21770,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
@@ -19625,6 +21804,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
@@ -19674,51 +21862,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19728,8 +21892,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19740,7 +21907,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19776,9 +21943,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19787,17 +21951,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19805,18 +21969,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19827,6 +21991,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19853,12 +22023,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19900,11 +22070,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19936,16 +22111,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19960,7 +22125,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19982,14 +22147,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20088,14 +22253,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -20109,21 +22278,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -20134,13 +22303,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20165,9 +22334,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -20208,7 +22376,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20230,7 +22398,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -20239,7 +22407,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -20248,7 +22416,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -20274,7 +22442,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20283,6 +22451,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -20290,7 +22493,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -20303,19 +22506,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -20327,7 +22530,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -20369,47 +22572,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -20417,7 +22606,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -20425,7 +22614,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -20439,18 +22628,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
@@ -20458,12 +22643,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20471,17 +22656,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20489,10 +22674,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20503,7 +22689,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20513,7 +22699,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -20532,7 +22718,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20550,31 +22736,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20587,6 +22760,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20611,14 +22785,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20639,12 +22813,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -20656,7 +22835,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
@@ -20671,12 +22850,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20709,20 +22899,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20748,7 +22935,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -20761,11 +22948,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -20784,7 +22971,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20832,7 +23019,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20868,7 +23055,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20890,7 +23077,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20903,7 +23090,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20966,7 +23153,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20975,100 +23162,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -21082,6 +23189,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -21114,7 +23222,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -21133,32 +23241,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -21170,26 +23273,26 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -21234,9 +23337,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -21256,13 +23359,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21270,11 +23373,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21293,8 +23396,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -21329,7 +23432,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21345,7 +23448,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -21388,6 +23491,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -21402,7 +23506,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -21411,7 +23515,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -21457,7 +23561,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -21512,13 +23616,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -21618,6 +23722,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/ingester/ingester.cdx.xml
+++ b/src/ingester/ingester.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c9383106-e00f-483b-a806-8803ac5ac0bd" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f4678804-601c-4707-9e93-c0144f9f5fe5" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.719393000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.305200000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="application" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,12 +18,12 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0 bin-target-0">
           <name>ingester</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/ingester@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
-        <component type="application" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0 bin-target-1">
+        <component type="application" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0 bin-target-1">
           <name>wal-reader</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/ingester@0.1.0?download_url=file://.#bin/wal-reader.rs</purl>
@@ -36,7 +36,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -44,7 +44,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -52,7 +52,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -60,7 +60,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -68,7 +68,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -76,7 +76,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -87,7 +87,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -95,7 +95,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -106,7 +106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -114,7 +114,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -125,7 +125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -133,7 +133,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -144,7 +144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -152,7 +152,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -170,7 +170,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -178,7 +178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -186,7 +186,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -197,7 +197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -205,7 +205,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -216,7 +216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -224,7 +224,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -235,7 +235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -243,7 +243,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -254,7 +254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -262,7 +262,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -273,7 +273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -281,7 +281,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -292,7 +292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -300,7 +300,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -311,7 +311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -319,7 +319,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -330,7 +330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -338,7 +338,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -349,7 +349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -357,7 +357,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -368,7 +368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -376,7 +376,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -387,7 +387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -395,7 +395,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -406,7 +406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -414,7 +414,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -425,7 +425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -433,7 +433,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -444,7 +444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -452,7 +452,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -463,7 +463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -471,7 +471,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -482,7 +482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -490,7 +490,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -501,7 +501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -509,7 +509,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -520,7 +520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -528,7 +528,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -539,7 +539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -547,7 +547,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -558,7 +558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -566,7 +566,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -577,7 +577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -585,7 +585,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -596,7 +596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -604,7 +604,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -615,7 +615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -623,7 +623,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -634,7 +634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -642,7 +642,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -653,7 +653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -661,7 +661,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -672,7 +672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -680,7 +680,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -691,7 +691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -699,7 +699,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -710,7 +710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -718,7 +718,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -729,7 +729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -737,7 +737,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -748,7 +748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -756,7 +756,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -767,7 +767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -775,7 +775,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -786,7 +786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -794,7 +794,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -805,7 +805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -813,7 +813,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -827,7 +827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -835,7 +835,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -849,7 +849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -857,7 +857,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -878,7 +878,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -889,7 +889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -897,7 +897,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -911,7 +911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -919,7 +919,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -937,7 +937,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -955,7 +955,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -973,7 +973,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -984,7 +984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -992,7 +992,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1003,7 +1003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1011,7 +1011,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1022,7 +1022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1030,7 +1030,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1041,7 +1041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1049,7 +1049,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1060,7 +1060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1068,7 +1068,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1079,7 +1079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1087,7 +1087,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1098,7 +1098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1106,7 +1106,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1117,7 +1117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1125,7 +1125,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1136,7 +1136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1144,7 +1144,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1155,7 +1155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1163,7 +1163,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1174,7 +1174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1182,7 +1182,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1193,7 +1193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1201,7 +1201,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1212,7 +1212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1220,7 +1220,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1231,7 +1231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1239,7 +1239,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1250,7 +1250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1258,7 +1258,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1269,7 +1269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1277,7 +1277,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1288,7 +1288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1296,7 +1296,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1307,7 +1307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1315,7 +1315,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1326,7 +1326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1334,7 +1334,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1345,7 +1345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1353,7 +1353,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1364,7 +1364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1372,7 +1372,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1383,7 +1383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1391,7 +1391,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1402,7 +1402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1410,7 +1410,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1421,7 +1421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1429,7 +1429,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1440,7 +1440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1448,7 +1448,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1459,7 +1459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1467,7 +1467,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1478,7 +1478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1486,7 +1486,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1497,7 +1497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1505,7 +1505,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1516,7 +1516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1524,7 +1524,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1535,7 +1535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1543,7 +1543,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1553,7 +1553,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1562,7 +1562,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1571,7 +1571,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1580,7 +1580,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1590,7 +1590,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1678,7 +1678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1700,7 +1700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1722,7 +1722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1744,7 +1744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1769,10 +1769,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1794,7 +1794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1819,7 +1819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1844,7 +1844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1941,7 +1941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1981,7 +1981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2003,7 +2003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2025,10 +2025,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2069,7 +2069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2113,7 +2113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2135,7 +2135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2157,7 +2157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2179,7 +2179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2201,7 +2201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2223,7 +2223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2245,7 +2245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2267,7 +2267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2289,7 +2289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2311,7 +2311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2333,7 +2333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2355,7 +2355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2377,7 +2377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2399,7 +2399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2421,7 +2421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2527,7 +2527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2546,7 +2546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2565,7 +2565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2584,7 +2584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2609,7 +2609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2628,7 +2628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2647,7 +2647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2672,7 +2672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2697,7 +2697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2716,7 +2716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2738,7 +2738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2757,7 +2757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2776,7 +2776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2795,7 +2795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2814,7 +2814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2836,7 +2836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2883,7 +2883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2902,7 +2902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2924,7 +2924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2943,7 +2943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3012,7 +3012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3031,7 +3031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3050,7 +3050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3088,7 +3088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3107,7 +3107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3126,7 +3126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3145,7 +3145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3164,7 +3164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3183,7 +3183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3202,7 +3202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3221,7 +3221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3240,7 +3240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3259,7 +3259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3278,7 +3278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3297,7 +3297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3316,7 +3316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3416,7 +3416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3438,7 +3438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3457,7 +3457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3500,7 +3500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3547,7 +3547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3569,7 +3569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3613,7 +3613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3638,7 +3638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3663,7 +3663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3688,7 +3688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3738,7 +3738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3806,7 +3806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3894,7 +3894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3955,7 +3955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3977,7 +3977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3999,7 +3999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4021,7 +4021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4046,7 +4046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4071,7 +4071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4093,7 +4093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4115,7 +4115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4137,7 +4137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4156,7 +4156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4175,7 +4175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4200,7 +4200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4222,7 +4222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4265,7 +4265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4311,7 +4311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4352,7 +4352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4377,7 +4377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4399,7 +4399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4443,7 +4443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4462,7 +4462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4553,7 +4553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4623,7 +4623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4645,7 +4645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4667,7 +4667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4689,7 +4689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4754,7 +4754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4891,7 +4891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4916,7 +4916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4959,7 +4959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4984,7 +4984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5003,7 +5003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5022,7 +5022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5041,7 +5041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5107,7 +5107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5129,7 +5129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5170,7 +5170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5192,7 +5192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5211,7 +5211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5230,7 +5230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5312,7 +5312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5381,7 +5381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5400,7 +5400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5419,7 +5419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5441,7 +5441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5568,7 +5568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5656,7 +5656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5681,7 +5681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5728,7 +5728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5774,7 +5774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5796,7 +5796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5818,7 +5818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5837,7 +5837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5856,7 +5856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5875,7 +5875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5894,7 +5894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5919,7 +5919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6003,7 +6003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6022,7 +6022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6044,7 +6044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6066,7 +6066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6132,7 +6132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6189,7 +6189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6208,7 +6208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6233,7 +6233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6255,7 +6255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6277,7 +6277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6302,7 +6302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6327,7 +6327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6352,7 +6352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6392,7 +6392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6411,7 +6411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6436,7 +6436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6458,7 +6458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6545,7 +6545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6567,7 +6567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6589,7 +6589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6611,7 +6611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6636,7 +6636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6661,7 +6661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6740,7 +6740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6762,7 +6762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6784,7 +6784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6803,7 +6803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6822,7 +6822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6847,7 +6847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6869,7 +6869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6891,7 +6891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6913,7 +6913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6935,7 +6935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6954,7 +6954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6976,7 +6976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6995,7 +6995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7057,7 +7057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7079,7 +7079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7104,7 +7104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7126,7 +7126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7148,7 +7148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7170,7 +7170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7189,7 +7189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7227,7 +7227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7252,7 +7252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7274,7 +7274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7299,7 +7299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7318,7 +7318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7403,7 +7403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7446,7 +7446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7534,7 +7534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7601,7 +7601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7714,7 +7714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7761,7 +7761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7783,7 +7783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7802,7 +7802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7821,7 +7821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7840,7 +7840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7859,7 +7859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7896,7 +7896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7939,7 +7939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7964,7 +7964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8007,7 +8007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8073,7 +8073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8116,7 +8116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8135,7 +8135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8157,7 +8157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8179,7 +8179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8201,7 +8201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8223,7 +8223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8245,7 +8245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8267,7 +8267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8286,7 +8286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8381,7 +8381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8406,7 +8406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8431,7 +8431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8456,7 +8456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8629,7 +8629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8716,7 +8716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8760,7 +8760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8804,7 +8804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8826,7 +8826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8848,7 +8848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8870,7 +8870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8892,7 +8892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8911,7 +8911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9017,7 +9017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9039,7 +9039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9064,7 +9064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9086,7 +9086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9111,7 +9111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9174,7 +9174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9193,7 +9193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9212,7 +9212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9234,7 +9234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9256,7 +9256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9278,7 +9278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9300,7 +9300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9322,7 +9322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9347,7 +9347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9366,7 +9366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9385,7 +9385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9404,7 +9404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9423,7 +9423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9442,7 +9442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9501,7 +9501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9523,7 +9523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9548,7 +9548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9570,7 +9570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9611,7 +9611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9655,7 +9655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9677,7 +9677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9718,7 +9718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9737,7 +9737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9762,7 +9762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9784,7 +9784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9806,7 +9806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9825,7 +9825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9844,7 +9844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9869,7 +9869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9894,7 +9894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9957,7 +9957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9982,7 +9982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10004,7 +10004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10029,7 +10029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10051,7 +10051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10070,7 +10070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10092,7 +10092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10114,7 +10114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10136,7 +10136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10161,7 +10161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10204,7 +10204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10226,7 +10226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10248,7 +10248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10270,7 +10270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10292,7 +10292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10311,7 +10311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10330,7 +10330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10352,7 +10352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10437,7 +10437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10525,7 +10525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10547,7 +10547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10569,7 +10569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10588,7 +10588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10607,7 +10607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10657,7 +10657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10707,7 +10707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10851,7 +10851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10870,7 +10870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10889,7 +10889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10962,7 +10962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11006,7 +11006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11028,7 +11028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11047,7 +11047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11066,7 +11066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11088,7 +11088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11156,7 +11156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11181,7 +11181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11200,7 +11200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11219,7 +11219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11238,7 +11238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11263,7 +11263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11285,7 +11285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11325,7 +11325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11347,7 +11347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11372,7 +11372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11391,7 +11391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11410,7 +11410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11432,7 +11432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11473,7 +11473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11495,7 +11495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11514,7 +11514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11571,7 +11571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11596,7 +11596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11621,7 +11621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11646,7 +11646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11715,7 +11715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11734,7 +11734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11753,7 +11753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11772,7 +11772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11845,7 +11845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11867,7 +11867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11946,7 +11946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11968,7 +11968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11987,7 +11987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12071,7 +12071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12150,7 +12150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12200,7 +12200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12222,7 +12222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12247,7 +12247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12294,7 +12294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12313,7 +12313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12332,7 +12332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12351,7 +12351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12373,7 +12373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12392,7 +12392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12411,7 +12411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12433,7 +12433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12455,7 +12455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12477,7 +12477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12496,7 +12496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12515,7 +12515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12540,7 +12540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12565,7 +12565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12587,7 +12587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12609,7 +12609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12631,7 +12631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12653,7 +12653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12675,7 +12675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12697,7 +12697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12719,7 +12719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12741,7 +12741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12766,7 +12766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12827,7 +12827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12906,7 +12906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12928,7 +12928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12950,7 +12950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12975,7 +12975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13267,7 +13267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13286,7 +13286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13305,7 +13305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13327,7 +13327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13349,7 +13349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13368,7 +13368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13417,7 +13417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13442,7 +13442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13467,7 +13467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13492,7 +13492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13561,7 +13561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13580,7 +13580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13683,7 +13683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13702,7 +13702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13743,7 +13743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13762,7 +13762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13784,7 +13784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13806,7 +13806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13828,7 +13828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13847,7 +13847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13909,7 +13909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13931,7 +13931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14055,7 +14055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14077,7 +14077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14099,7 +14099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14143,7 +14143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14215,7 +14215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14240,7 +14240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14265,7 +14265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14290,7 +14290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14315,7 +14315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14337,7 +14337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14359,7 +14359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14381,7 +14381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14403,7 +14403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14425,7 +14425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14447,7 +14447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14469,7 +14469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14494,7 +14494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14516,7 +14516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14538,7 +14538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14563,7 +14563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14588,7 +14588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14613,7 +14613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14635,7 +14635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14654,7 +14654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14676,7 +14676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14698,7 +14698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14720,7 +14720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14742,7 +14742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14808,7 +14808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14893,7 +14893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14918,7 +14918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14937,7 +14937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14959,7 +14959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15003,7 +15003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15022,7 +15022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15047,7 +15047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15072,7 +15072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15094,7 +15094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15135,7 +15135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15154,7 +15154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15176,7 +15176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15198,7 +15198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15220,7 +15220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15242,7 +15242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15264,7 +15264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15286,7 +15286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15311,7 +15311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15336,7 +15336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15374,7 +15374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15424,7 +15424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15443,7 +15443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15462,7 +15462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15481,7 +15481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15503,7 +15503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15525,7 +15525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15547,7 +15547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15569,7 +15569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15591,7 +15591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15663,7 +15663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15682,7 +15682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15732,7 +15732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15757,7 +15757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15782,7 +15782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15807,7 +15807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15832,7 +15832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15857,7 +15857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15879,7 +15879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15901,7 +15901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15923,7 +15923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15948,7 +15948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15970,7 +15970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15989,7 +15989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16071,7 +16071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16093,7 +16093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16118,7 +16118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16193,7 +16193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16242,7 +16242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16261,7 +16261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16280,7 +16280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16302,7 +16302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16324,7 +16324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16346,7 +16346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16371,7 +16371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16390,7 +16390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16409,7 +16409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16431,7 +16431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16488,7 +16488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16507,7 +16507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16553,7 +16553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16575,7 +16575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16615,7 +16615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16691,7 +16691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16713,7 +16713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16735,7 +16735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16757,7 +16757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16779,7 +16779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16801,7 +16801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16826,7 +16826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16851,7 +16851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16873,7 +16873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16895,7 +16895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16917,7 +16917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16960,7 +16960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16982,7 +16982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17004,7 +17004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17026,7 +17026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17051,7 +17051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17101,7 +17101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17123,7 +17123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17166,7 +17166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17188,7 +17188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17234,7 +17234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17259,7 +17259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17303,7 +17303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17328,7 +17328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17350,7 +17350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17375,7 +17375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17400,7 +17400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17422,7 +17422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17444,7 +17444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17466,7 +17466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17513,7 +17513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17535,7 +17535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17557,7 +17557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17601,7 +17601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17623,7 +17623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17642,7 +17642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17667,7 +17667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17689,7 +17689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17714,7 +17714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17736,7 +17736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17755,7 +17755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17792,7 +17792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17817,7 +17817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17839,7 +17839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17861,7 +17861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17901,7 +17901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17923,7 +17923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17948,7 +17948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18037,7 +18037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18119,7 +18119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18160,7 +18160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18185,7 +18185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18207,7 +18207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18226,7 +18226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18248,7 +18248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18267,7 +18267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18286,7 +18286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18305,7 +18305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18324,7 +18324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18343,7 +18343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18425,7 +18425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18463,7 +18463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18482,7 +18482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18522,7 +18522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18544,7 +18544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18563,7 +18563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18585,7 +18585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19693,7 +19693,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19739,7 +19739,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19770,7 +19770,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -19780,7 +19780,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -19791,7 +19791,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -19807,27 +19807,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19838,9 +19838,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/ingestion_common/ingestion-common.cdx.xml
+++ b/src/ingestion_common/ingestion-common.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f2bd51ab-1d36-418f-b662-d13312edb2f4" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.763932000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0 bin-target-0">
+          <name>ingestion_common</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,15 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1600,15 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2265,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2664,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5171,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5263,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5786,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6118,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6535,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +7998,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +8972,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9226,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10034,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10558,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10731,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11695,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +13977,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14443,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14481,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14609,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14719,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14882,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14920,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +14972,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15206,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15291,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +15979,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16042,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16869,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17211,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17320,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17503,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19589,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20004,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20116,49 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20170,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20314,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20469,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21154,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21163,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21238,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21320,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21397,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21653,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +21847,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +21899,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22055,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22146,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22175,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22360,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +22901,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23010,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23030,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23095,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23119,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23149,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23220,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22525,6 +23490,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23501,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23652,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23785,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23819,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +23854,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/ingestion_common/ingestion-common.cdx.xml
+++ b/src/ingestion_common/ingestion-common.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f2bd51ab-1d36-418f-b662-d13312edb2f4" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:30a14d48-4e7f-48d1-8c13-d019fc01ded5" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.763932000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.348112000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0 bin-target-0">
           <name>ingestion_common</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1611,7 +1611,7 @@
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1743,7 +1743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1765,7 +1765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1790,10 +1790,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1815,7 +1815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1840,7 +1840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1865,7 +1865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1962,7 +1962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2002,7 +2002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2024,7 +2024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2046,10 +2046,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2420,7 +2420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2442,7 +2442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2548,7 +2548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2567,7 +2567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2630,7 +2630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2693,7 +2693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2718,7 +2718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2737,7 +2737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2759,7 +2759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2778,7 +2778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2797,7 +2797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2816,7 +2816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2835,7 +2835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2857,7 +2857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2904,7 +2904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2923,7 +2923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2945,7 +2945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2964,7 +2964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3033,7 +3033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3052,7 +3052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3071,7 +3071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3090,7 +3090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3109,7 +3109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3128,7 +3128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3147,7 +3147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3166,7 +3166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3185,7 +3185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3204,7 +3204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3223,7 +3223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3242,7 +3242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3261,7 +3261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3280,7 +3280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3299,7 +3299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3318,7 +3318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3337,7 +3337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3437,7 +3437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3459,7 +3459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3478,7 +3478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3568,7 +3568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3634,7 +3634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3659,7 +3659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3684,7 +3684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3709,7 +3709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3759,7 +3759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3827,7 +3827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3915,7 +3915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3976,7 +3976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4020,7 +4020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4042,7 +4042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4092,7 +4092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4114,7 +4114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4136,7 +4136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4158,7 +4158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4177,7 +4177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4196,7 +4196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4221,7 +4221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4243,7 +4243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4286,7 +4286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4332,7 +4332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4373,7 +4373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4398,7 +4398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4420,7 +4420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4464,7 +4464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4483,7 +4483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4574,7 +4574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4644,7 +4644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4666,7 +4666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4688,7 +4688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4710,7 +4710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4775,7 +4775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4912,7 +4912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4937,7 +4937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4980,7 +4980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5005,7 +5005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5024,7 +5024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5043,7 +5043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5062,7 +5062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5128,7 +5128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5150,7 +5150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5172,7 +5172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5210,7 +5210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5232,7 +5232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5251,7 +5251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5270,7 +5270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5289,7 +5289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5371,7 +5371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5440,7 +5440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5459,7 +5459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5478,7 +5478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5500,7 +5500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5627,7 +5627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5715,7 +5715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5740,7 +5740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5787,7 +5787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5833,7 +5833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5855,7 +5855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5877,7 +5877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5896,7 +5896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5915,7 +5915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5934,7 +5934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5953,7 +5953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5978,7 +5978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6062,7 +6062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6081,7 +6081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6103,7 +6103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6125,7 +6125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6147,7 +6147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6213,7 +6213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6270,7 +6270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6289,7 +6289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6314,7 +6314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6336,7 +6336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6358,7 +6358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6383,7 +6383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6408,7 +6408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6433,7 +6433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6473,7 +6473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6492,7 +6492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6517,7 +6517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6539,7 +6539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6626,7 +6626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6648,7 +6648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6670,7 +6670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6692,7 +6692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6717,7 +6717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6742,7 +6742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6821,7 +6821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6843,7 +6843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6865,7 +6865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6884,7 +6884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6903,7 +6903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6928,7 +6928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6950,7 +6950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6972,7 +6972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6994,7 +6994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7016,7 +7016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7035,7 +7035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7057,7 +7057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7076,7 +7076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7138,7 +7138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7160,7 +7160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7185,7 +7185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7207,7 +7207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7229,7 +7229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7251,7 +7251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7270,7 +7270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7308,7 +7308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7333,7 +7333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7355,7 +7355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7380,7 +7380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7399,7 +7399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7484,7 +7484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7527,7 +7527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7615,7 +7615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7795,7 +7795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7842,7 +7842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7864,7 +7864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7883,7 +7883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7902,7 +7902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7921,7 +7921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7940,7 +7940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7977,7 +7977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8020,7 +8020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8045,7 +8045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8088,7 +8088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8154,7 +8154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8197,7 +8197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8216,7 +8216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8238,7 +8238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8260,7 +8260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8282,7 +8282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8304,7 +8304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8326,7 +8326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8348,7 +8348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8367,7 +8367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8462,7 +8462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8487,7 +8487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8512,7 +8512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8537,7 +8537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8710,7 +8710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8797,7 +8797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8841,7 +8841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8885,7 +8885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8907,7 +8907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8929,7 +8929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8951,7 +8951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8973,7 +8973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -8992,7 +8992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9011,7 +9011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9117,7 +9117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9139,7 +9139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9164,7 +9164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9186,7 +9186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9211,7 +9211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9230,7 +9230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9296,7 +9296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9315,7 +9315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9334,7 +9334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9356,7 +9356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9378,7 +9378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9400,7 +9400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9422,7 +9422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9444,7 +9444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9469,7 +9469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9488,7 +9488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9507,7 +9507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9526,7 +9526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9545,7 +9545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9564,7 +9564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9623,7 +9623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9645,7 +9645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9670,7 +9670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9692,7 +9692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9733,7 +9733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9777,7 +9777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9799,7 +9799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9840,7 +9840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9859,7 +9859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9884,7 +9884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9906,7 +9906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9928,7 +9928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9947,7 +9947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9966,7 +9966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9991,7 +9991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10016,7 +10016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10035,7 +10035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10104,7 +10104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10176,7 +10176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10198,7 +10198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10217,7 +10217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10239,7 +10239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10261,7 +10261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10283,7 +10283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10308,7 +10308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10351,7 +10351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10373,7 +10373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10395,7 +10395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10417,7 +10417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10439,7 +10439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10458,7 +10458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10477,7 +10477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10499,7 +10499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10584,7 +10584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10672,7 +10672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10694,7 +10694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10716,7 +10716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10735,7 +10735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10754,7 +10754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10804,7 +10804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10854,7 +10854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10998,7 +10998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11017,7 +11017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11036,7 +11036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11109,7 +11109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11153,7 +11153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11175,7 +11175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11194,7 +11194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11213,7 +11213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11235,7 +11235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11303,7 +11303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11328,7 +11328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11347,7 +11347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11366,7 +11366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11385,7 +11385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11410,7 +11410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11432,7 +11432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11472,7 +11472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11494,7 +11494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11519,7 +11519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11538,7 +11538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11557,7 +11557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11579,7 +11579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11620,7 +11620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11642,7 +11642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11661,7 +11661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11699,7 +11699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11743,7 +11743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11768,7 +11768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11793,7 +11793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11818,7 +11818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11887,7 +11887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11906,7 +11906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11925,7 +11925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11944,7 +11944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12017,7 +12017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12039,7 +12039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12096,7 +12096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12118,7 +12118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12140,7 +12140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12159,7 +12159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12243,7 +12243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12281,7 +12281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12300,7 +12300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12322,7 +12322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12372,7 +12372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12394,7 +12394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12419,7 +12419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12466,7 +12466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12485,7 +12485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12504,7 +12504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12523,7 +12523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12545,7 +12545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12564,7 +12564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12583,7 +12583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12605,7 +12605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12627,7 +12627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12649,7 +12649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12668,7 +12668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12687,7 +12687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12712,7 +12712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12737,7 +12737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12759,7 +12759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12781,7 +12781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12803,7 +12803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12825,7 +12825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12847,7 +12847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12869,7 +12869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12891,7 +12891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12913,7 +12913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12938,7 +12938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12999,7 +12999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13078,7 +13078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13100,7 +13100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13122,7 +13122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13147,7 +13147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13439,7 +13439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13477,7 +13477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13499,7 +13499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13521,7 +13521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13540,7 +13540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13589,7 +13589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13614,7 +13614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13639,7 +13639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13664,7 +13664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13689,7 +13689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13711,7 +13711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13733,7 +13733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13752,7 +13752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13771,7 +13771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13793,7 +13793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13815,7 +13815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13855,7 +13855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13874,7 +13874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13896,7 +13896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13915,7 +13915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13934,7 +13934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13956,7 +13956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13978,7 +13978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -13997,7 +13997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14016,7 +14016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14035,7 +14035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14057,7 +14057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14076,7 +14076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14138,7 +14138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14160,7 +14160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14306,7 +14306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14328,7 +14328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14372,7 +14372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14419,7 +14419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14444,7 +14444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14469,7 +14469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14494,7 +14494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14519,7 +14519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14544,7 +14544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14566,7 +14566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14588,7 +14588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14610,7 +14610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14632,7 +14632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14654,7 +14654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14676,7 +14676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14698,7 +14698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14723,7 +14723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14742,7 +14742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14764,7 +14764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14786,7 +14786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14811,7 +14811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14836,7 +14836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14861,7 +14861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14883,7 +14883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14902,7 +14902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14924,7 +14924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14946,7 +14946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14968,7 +14968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14990,7 +14990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15056,7 +15056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15141,7 +15141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15166,7 +15166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15185,7 +15185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15207,7 +15207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15251,7 +15251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15270,7 +15270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15295,7 +15295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15314,7 +15314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15339,7 +15339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15361,7 +15361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15402,7 +15402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15421,7 +15421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15443,7 +15443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15465,7 +15465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15487,7 +15487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15509,7 +15509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15534,7 +15534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15559,7 +15559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15597,7 +15597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15647,7 +15647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15666,7 +15666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15685,7 +15685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15704,7 +15704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15726,7 +15726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15748,7 +15748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15770,7 +15770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15792,7 +15792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15814,7 +15814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15886,7 +15886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15905,7 +15905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15930,7 +15930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15955,7 +15955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15980,7 +15980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16005,7 +16005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16030,7 +16030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16055,7 +16055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16080,7 +16080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16105,7 +16105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16130,7 +16130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16152,7 +16152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16174,7 +16174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16196,7 +16196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16221,7 +16221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16243,7 +16243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16262,7 +16262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16344,7 +16344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16366,7 +16366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16391,7 +16391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16466,7 +16466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16515,7 +16515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16534,7 +16534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16553,7 +16553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16575,7 +16575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16597,7 +16597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16619,7 +16619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16644,7 +16644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16663,7 +16663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16682,7 +16682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16704,7 +16704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16742,7 +16742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16761,7 +16761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16780,7 +16780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16826,7 +16826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16848,7 +16848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16888,7 +16888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16964,7 +16964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16986,7 +16986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17008,7 +17008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17030,7 +17030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17052,7 +17052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17074,7 +17074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17099,7 +17099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17124,7 +17124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17146,7 +17146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17168,7 +17168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17190,7 +17190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17233,7 +17233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17255,7 +17255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17277,7 +17277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17299,7 +17299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17324,7 +17324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17374,7 +17374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17396,7 +17396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17439,7 +17439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17461,7 +17461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17532,7 +17532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17557,7 +17557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17601,7 +17601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17626,7 +17626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17648,7 +17648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17673,7 +17673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17698,7 +17698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17720,7 +17720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17742,7 +17742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17764,7 +17764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17811,7 +17811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17833,7 +17833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17855,7 +17855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17899,7 +17899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17921,7 +17921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17940,7 +17940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17965,7 +17965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17987,7 +17987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18012,7 +18012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18034,7 +18034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18053,7 +18053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18090,7 +18090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18115,7 +18115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18137,7 +18137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18159,7 +18159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18199,7 +18199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18221,7 +18221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18246,7 +18246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18335,7 +18335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18417,7 +18417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18458,7 +18458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18483,7 +18483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18505,7 +18505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18524,7 +18524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18546,7 +18546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18565,7 +18565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18584,7 +18584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18603,7 +18603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18622,7 +18622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18641,7 +18641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18723,7 +18723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18761,7 +18761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18780,7 +18780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18820,7 +18820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18842,7 +18842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18861,7 +18861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18883,7 +18883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20004,18 +20004,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20034,12 +20034,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20085,7 +20085,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20116,7 +20116,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20126,7 +20126,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20137,7 +20137,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20153,14 +20153,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20171,9 +20171,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />

--- a/src/jobs/openobserve-jobs.cdx.xml
+++ b/src/jobs/openobserve-jobs.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c20c5733-c591-4ccc-b624-6a64b4e59a24" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.269925000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+      <name>openobserve-jobs</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0 bin-target-0">
+          <name>openobserve_jobs</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,42 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <name>openobserve-builtins</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../builtins</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1660,105 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../enrichment_data</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <name>openobserve-org-storage</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../org_storage</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1767,87 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+      <name>report_server</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/report_server@0.1.0?download_url=file://../report_server</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2928,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3894,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3941,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3988,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4424,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4640,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4881,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5476,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5592,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5684,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6207,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6539,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6956,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7414,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7534,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8171,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8476,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9459,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9672,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9735,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10348,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10597,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11124,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11297,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11847,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11886,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12098,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12322,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13092,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13608,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14136,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14773,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14890,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15258,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15296,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15424,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15534,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15697,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15735,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15787,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +16021,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16106,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16279,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16336,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16414,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16857,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16920,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17268,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17543,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17791,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18136,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18245,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18431,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18478,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19101,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19170,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +20032,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20536,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20638,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20794,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21078,88 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21237,142 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21387,182 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21573,190 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +22060,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22481,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22496,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22579,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22608,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22641,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22756,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22771,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22780,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22855,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22937,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +23014,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +23089,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +23113,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23214,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23281,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23476,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23505,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23537,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23670,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23729,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23820,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23849,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23941,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23999,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +24059,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24194,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24323,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24433,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24640,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24679,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24750,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24770,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24835,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24859,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24889,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24960,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +25009,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +25024,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25245,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25256,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25322,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25358,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25416,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25550,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25584,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25620,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25686,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/jobs/openobserve-jobs.cdx.xml
+++ b/src/jobs/openobserve-jobs.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c20c5733-c591-4ccc-b624-6a64b4e59a24" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:e1a1f099-d039-42a3-b7de-85c4c519d960" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.269925000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.817275000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0">
       <name>openobserve-jobs</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0 bin-target-0">
           <name>openobserve_jobs</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-jobs@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <name>openobserve-builtins</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-builtins@0.1.0?download_url=file://../builtins</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://../org_storage</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <name>report_server</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/report_server@0.1.0?download_url=file://../report_server</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1822,7 +1822,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1831,7 +1831,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1840,7 +1840,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1850,7 +1850,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1938,7 +1938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1960,7 +1960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1982,7 +1982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -2004,7 +2004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2029,10 +2029,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2054,7 +2054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2079,7 +2079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2104,7 +2104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2201,7 +2201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2241,7 +2241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2263,7 +2263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2285,10 +2285,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2329,7 +2329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2373,7 +2373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2395,7 +2395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2417,7 +2417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2439,7 +2439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2461,7 +2461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2483,7 +2483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2505,7 +2505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2527,7 +2527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2549,7 +2549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2571,7 +2571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2593,7 +2593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2615,7 +2615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2637,7 +2637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2659,7 +2659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2681,7 +2681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2703,7 +2703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2809,7 +2809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2828,7 +2828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2847,7 +2847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2866,7 +2866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2891,7 +2891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2910,7 +2910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2954,7 +2954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2979,7 +2979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2998,7 +2998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -3020,7 +3020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3039,7 +3039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3058,7 +3058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3077,7 +3077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3096,7 +3096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3118,7 +3118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3165,7 +3165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3184,7 +3184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3206,7 +3206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3225,7 +3225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3294,7 +3294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3313,7 +3313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3332,7 +3332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3351,7 +3351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3370,7 +3370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3389,7 +3389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3408,7 +3408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3427,7 +3427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3446,7 +3446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3465,7 +3465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3484,7 +3484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3503,7 +3503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3522,7 +3522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3541,7 +3541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3560,7 +3560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3579,7 +3579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3598,7 +3598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3698,7 +3698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3720,7 +3720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3739,7 +3739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3782,7 +3782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3829,7 +3829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3851,7 +3851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3895,7 +3895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3917,7 +3917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3942,7 +3942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3967,7 +3967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3992,7 +3992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -4017,7 +4017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4042,7 +4042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4092,7 +4092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4160,7 +4160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4248,7 +4248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4309,7 +4309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4331,7 +4331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4353,7 +4353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4375,7 +4375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4400,7 +4400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4425,7 +4425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4450,7 +4450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4472,7 +4472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4494,7 +4494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4516,7 +4516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4535,7 +4535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4554,7 +4554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4579,7 +4579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4601,7 +4601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4644,7 +4644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4663,7 +4663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4709,7 +4709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4750,7 +4750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4775,7 +4775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4797,7 +4797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4841,7 +4841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4860,7 +4860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4885,7 +4885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4970,7 +4970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5040,7 +5040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5062,7 +5062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5084,7 +5084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5106,7 +5106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5171,7 +5171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5308,7 +5308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5333,7 +5333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5376,7 +5376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5401,7 +5401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5420,7 +5420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5439,7 +5439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5458,7 +5458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5477,7 +5477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5549,7 +5549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5571,7 +5571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5593,7 +5593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5631,7 +5631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5653,7 +5653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5672,7 +5672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5691,7 +5691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5710,7 +5710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5792,7 +5792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5861,7 +5861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5880,7 +5880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5899,7 +5899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5921,7 +5921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6048,7 +6048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6136,7 +6136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6161,7 +6161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6208,7 +6208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6276,7 +6276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6298,7 +6298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6317,7 +6317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6336,7 +6336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6355,7 +6355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6374,7 +6374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6399,7 +6399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6483,7 +6483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6502,7 +6502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6524,7 +6524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6546,7 +6546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6568,7 +6568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6634,7 +6634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6691,7 +6691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6710,7 +6710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6735,7 +6735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6757,7 +6757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6779,7 +6779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6804,7 +6804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6829,7 +6829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6854,7 +6854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6894,7 +6894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6913,7 +6913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6938,7 +6938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6960,7 +6960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7047,7 +7047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7091,7 +7091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7113,7 +7113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7138,7 +7138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7163,7 +7163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7242,7 +7242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7264,7 +7264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7286,7 +7286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7305,7 +7305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7324,7 +7324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7349,7 +7349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7371,7 +7371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7393,7 +7393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7415,7 +7415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7437,7 +7437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7459,7 +7459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7478,7 +7478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7500,7 +7500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7519,7 +7519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7538,7 +7538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7606,7 +7606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7628,7 +7628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7653,7 +7653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7675,7 +7675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7697,7 +7697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7719,7 +7719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7738,7 +7738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7776,7 +7776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7801,7 +7801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7823,7 +7823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7848,7 +7848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7867,7 +7867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7952,7 +7952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7995,7 +7995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8083,7 +8083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8150,7 +8150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8282,7 +8282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8329,7 +8329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8351,7 +8351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8370,7 +8370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8389,7 +8389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8408,7 +8408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8427,7 +8427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8464,7 +8464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8507,7 +8507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8532,7 +8532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8575,7 +8575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8641,7 +8641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8684,7 +8684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8703,7 +8703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8725,7 +8725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8747,7 +8747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8769,7 +8769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8791,7 +8791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8813,7 +8813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8835,7 +8835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8854,7 +8854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8949,7 +8949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8974,7 +8974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8999,7 +8999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -9024,7 +9024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9197,7 +9197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9284,7 +9284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9328,7 +9328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9372,7 +9372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9394,7 +9394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9416,7 +9416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9438,7 +9438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9460,7 +9460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9479,7 +9479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9498,7 +9498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9604,7 +9604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9626,7 +9626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9651,7 +9651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9673,7 +9673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9695,7 +9695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9720,7 +9720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9739,7 +9739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9805,7 +9805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9824,7 +9824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9843,7 +9843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9865,7 +9865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9887,7 +9887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9909,7 +9909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9931,7 +9931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9953,7 +9953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9978,7 +9978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9997,7 +9997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -10016,7 +10016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10035,7 +10035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10054,7 +10054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10073,7 +10073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10132,7 +10132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10154,7 +10154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10179,7 +10179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10201,7 +10201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10242,7 +10242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10286,7 +10286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10308,7 +10308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10349,7 +10349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10368,7 +10368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10387,7 +10387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10406,7 +10406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10425,7 +10425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10450,7 +10450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10494,7 +10494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10513,7 +10513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10532,7 +10532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10557,7 +10557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10582,7 +10582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10601,7 +10601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10670,7 +10670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10695,7 +10695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10717,7 +10717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10742,7 +10742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10764,7 +10764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10783,7 +10783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10805,7 +10805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10827,7 +10827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10849,7 +10849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10874,7 +10874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10917,7 +10917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10939,7 +10939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10961,7 +10961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10983,7 +10983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -11005,7 +11005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -11024,7 +11024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11043,7 +11043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11065,7 +11065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11150,7 +11150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11238,7 +11238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11260,7 +11260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11282,7 +11282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11301,7 +11301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11320,7 +11320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11370,7 +11370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11420,7 +11420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11564,7 +11564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11583,7 +11583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11602,7 +11602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11675,7 +11675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11719,7 +11719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11741,7 +11741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11760,7 +11760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11779,7 +11779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11801,7 +11801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11911,7 +11911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11936,7 +11936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11955,7 +11955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11974,7 +11974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11993,7 +11993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -12018,7 +12018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12040,7 +12040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12080,7 +12080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12102,7 +12102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12121,7 +12121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12146,7 +12146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12165,7 +12165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12184,7 +12184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12206,7 +12206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12247,7 +12247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12269,7 +12269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12288,7 +12288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12326,7 +12326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12370,7 +12370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12395,7 +12395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12420,7 +12420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12445,7 +12445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12514,7 +12514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12533,7 +12533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12552,7 +12552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12571,7 +12571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12644,7 +12644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12666,7 +12666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12723,7 +12723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12745,7 +12745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12767,7 +12767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12786,7 +12786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12870,7 +12870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12908,7 +12908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12927,7 +12927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12949,7 +12949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12999,7 +12999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -13021,7 +13021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13046,7 +13046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13118,7 +13118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13137,7 +13137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13156,7 +13156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13175,7 +13175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13197,7 +13197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13216,7 +13216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13235,7 +13235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13257,7 +13257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13279,7 +13279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13301,7 +13301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13320,7 +13320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13339,7 +13339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13364,7 +13364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13389,7 +13389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13411,7 +13411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13433,7 +13433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13455,7 +13455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13477,7 +13477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13499,7 +13499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13521,7 +13521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13543,7 +13543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13565,7 +13565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13590,7 +13590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13609,7 +13609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13631,7 +13631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13656,7 +13656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13678,7 +13678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13700,7 +13700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13770,7 +13770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13849,7 +13849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13871,7 +13871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13893,7 +13893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13918,7 +13918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14235,7 +14235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14254,7 +14254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14273,7 +14273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14295,7 +14295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14317,7 +14317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14336,7 +14336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14385,7 +14385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14410,7 +14410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14435,7 +14435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14460,7 +14460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14485,7 +14485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14507,7 +14507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14529,7 +14529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14548,7 +14548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14567,7 +14567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14589,7 +14589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14611,7 +14611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14651,7 +14651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14670,7 +14670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14692,7 +14692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14711,7 +14711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14774,7 +14774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14831,7 +14831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14853,7 +14853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14872,7 +14872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14953,7 +14953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14975,7 +14975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15099,7 +15099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15143,7 +15143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15187,7 +15187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15234,7 +15234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15259,7 +15259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15284,7 +15284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15309,7 +15309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15334,7 +15334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15359,7 +15359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15381,7 +15381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15403,7 +15403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15425,7 +15425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15447,7 +15447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15469,7 +15469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15491,7 +15491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15513,7 +15513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15538,7 +15538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15557,7 +15557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15579,7 +15579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15601,7 +15601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15626,7 +15626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15651,7 +15651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15676,7 +15676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15698,7 +15698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15717,7 +15717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15739,7 +15739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15761,7 +15761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15783,7 +15783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15805,7 +15805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15871,7 +15871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15956,7 +15956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15981,7 +15981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -16000,7 +16000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -16022,7 +16022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16066,7 +16066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16085,7 +16085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16110,7 +16110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16129,7 +16129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16154,7 +16154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16176,7 +16176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16217,7 +16217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16236,7 +16236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16258,7 +16258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16280,7 +16280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16302,7 +16302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16324,7 +16324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16346,7 +16346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16368,7 +16368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16393,7 +16393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16418,7 +16418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16437,7 +16437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16475,7 +16475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16525,7 +16525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16544,7 +16544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16563,7 +16563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16582,7 +16582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16604,7 +16604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16626,7 +16626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16648,7 +16648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16670,7 +16670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16692,7 +16692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16764,7 +16764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16783,7 +16783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16808,7 +16808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16833,7 +16833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16858,7 +16858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16883,7 +16883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16908,7 +16908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16933,7 +16933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16958,7 +16958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16983,7 +16983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -17008,7 +17008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -17030,7 +17030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17052,7 +17052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17074,7 +17074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17099,7 +17099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17121,7 +17121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17140,7 +17140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17222,7 +17222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17244,7 +17244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17269,7 +17269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17291,7 +17291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17366,7 +17366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17415,7 +17415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17434,7 +17434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17453,7 +17453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17475,7 +17475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17497,7 +17497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17519,7 +17519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17544,7 +17544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17569,7 +17569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17588,7 +17588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17607,7 +17607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17629,7 +17629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17667,7 +17667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17686,7 +17686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17705,7 +17705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17751,7 +17751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17773,7 +17773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17813,7 +17813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17889,7 +17889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17911,7 +17911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17933,7 +17933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17955,7 +17955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17977,7 +17977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17999,7 +17999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -18024,7 +18024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18049,7 +18049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18071,7 +18071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18093,7 +18093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18115,7 +18115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18158,7 +18158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18180,7 +18180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18202,7 +18202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18224,7 +18224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18249,7 +18249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18299,7 +18299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18321,7 +18321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18364,7 +18364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18386,7 +18386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18457,7 +18457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18500,7 +18500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18522,7 +18522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18566,7 +18566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18591,7 +18591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18613,7 +18613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18638,7 +18638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18663,7 +18663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18685,7 +18685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18707,7 +18707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18729,7 +18729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18776,7 +18776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18798,7 +18798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18820,7 +18820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18864,7 +18864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18886,7 +18886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18905,7 +18905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18930,7 +18930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18952,7 +18952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18977,7 +18977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18999,7 +18999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -19018,7 +19018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19055,7 +19055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19080,7 +19080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19102,7 +19102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19127,7 +19127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19152,7 +19152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19174,7 +19174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19193,7 +19193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19233,7 +19233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19255,7 +19255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19280,7 +19280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19369,7 +19369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19451,7 +19451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19492,7 +19492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19517,7 +19517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19539,7 +19539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19558,7 +19558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19580,7 +19580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19599,7 +19599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19618,7 +19618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19637,7 +19637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19656,7 +19656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19675,7 +19675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19757,7 +19757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19795,7 +19795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19814,7 +19814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19854,7 +19854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19876,7 +19876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19895,7 +19895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19917,7 +19917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21078,21 +21078,21 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21101,18 +21101,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21131,36 +21131,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21206,7 +21206,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21237,25 +21237,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21263,36 +21263,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21301,31 +21301,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21336,10 +21336,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -21347,38 +21347,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21387,7 +21387,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21397,7 +21397,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21408,7 +21408,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21424,110 +21424,110 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/jobs#openobserve-jobs@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/jobs#openobserve-jobs@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/builtins#openobserve-builtins@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/builtins#openobserve-builtins@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21537,33 +21537,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21574,12 +21574,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
@@ -21587,24 +21587,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21613,17 +21613,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21633,7 +21633,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21642,48 +21642,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21691,25 +21691,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21717,10 +21717,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21732,9 +21732,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21742,16 +21742,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/mcp/openobserve-mcp.cdx.xml
+++ b/src/mcp/openobserve-mcp.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:33facde5-d2fc-4951-8f2a-ebd8a59be62d" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:216e21f7-1695-422b-97da-7bef1a4f2bbe" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.196661000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.744496000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <name>openobserve-mcp</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0 bin-target-0">
           <name>openobserve_mcp</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -807,7 +807,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%3Fbranch=v0.23.2-feat%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
+      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
       <externalReferences>
         <reference type="website">
           <url>https://gitlab.com/lx-industries/rmcp-openapi</url>
@@ -818,7 +818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -826,7 +826,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -840,7 +840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -848,7 +848,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -862,7 +862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -870,7 +870,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -891,7 +891,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -902,7 +902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -910,7 +910,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -924,7 +924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -986,7 +986,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -997,7 +997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1005,7 +1005,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1016,7 +1016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1024,7 +1024,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1035,7 +1035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1043,7 +1043,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1054,7 +1054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1062,7 +1062,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1073,7 +1073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1081,7 +1081,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1092,7 +1092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1100,7 +1100,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1111,7 +1111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1119,7 +1119,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1130,7 +1130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1138,7 +1138,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1149,7 +1149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1157,7 +1157,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1168,7 +1168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1176,7 +1176,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1187,7 +1187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1195,7 +1195,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1206,7 +1206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1214,7 +1214,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1225,7 +1225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1233,7 +1233,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1244,7 +1244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1252,7 +1252,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1263,7 +1263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1271,7 +1271,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1282,7 +1282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1290,7 +1290,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1301,7 +1301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1309,7 +1309,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1320,7 +1320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1328,7 +1328,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1339,7 +1339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1347,7 +1347,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1358,7 +1358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1366,7 +1366,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1377,7 +1377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1385,7 +1385,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1396,7 +1396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1404,7 +1404,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1415,7 +1415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1423,7 +1423,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1434,7 +1434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1442,7 +1442,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1453,7 +1453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1461,7 +1461,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1472,7 +1472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1480,7 +1480,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1491,7 +1491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1499,7 +1499,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1510,7 +1510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1518,7 +1518,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1529,7 +1529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1537,7 +1537,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1556,7 +1556,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1566,7 +1566,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1575,7 +1575,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1585,7 +1585,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-codec</name>
       <version>0.5.2</version>
       <description>Codec utilities for working with framed protocols</description>
@@ -1604,7 +1604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-http</name>
       <version>3.13.1</version>
       <description>HTTP types and services for the Actix ecosystem</description>
@@ -1626,7 +1626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-router</name>
       <version>0.5.4</version>
       <description>Resource path matching and router</description>
@@ -1645,7 +1645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-rt</name>
       <version>2.11.0</version>
       <description>Tokio-based single-threaded async runtime for the Actix ecosystem</description>
@@ -1667,7 +1667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com>, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com></author>
       <name>actix-server</name>
       <version>2.6.0</version>
       <description>General purpose TCP server built for the Actix ecosystem</description>
@@ -1689,7 +1689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-service</name>
       <version>2.0.3</version>
       <description>Service trait and combinators for representing asynchronous request/response operations.</description>
@@ -1708,7 +1708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-utils</name>
       <version>3.0.1</version>
       <description>Various utilities used in the Actix ecosystem</description>
@@ -1727,7 +1727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>actix-web</name>
       <version>4.14.0</version>
       <description>Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust</description>
@@ -1749,7 +1749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1837,7 +1837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1859,7 +1859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1881,7 +1881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1903,7 +1903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1928,10 +1928,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1953,7 +1953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1978,7 +1978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2003,7 +2003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2100,7 +2100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2140,7 +2140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2162,7 +2162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2184,10 +2184,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2228,7 +2228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2272,7 +2272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2294,7 +2294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2316,7 +2316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2338,7 +2338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2360,7 +2360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2382,7 +2382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2404,7 +2404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2426,7 +2426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2448,7 +2448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2470,7 +2470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2492,7 +2492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2514,7 +2514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2536,7 +2536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2558,7 +2558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2580,7 +2580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2686,7 +2686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2705,7 +2705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2724,7 +2724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2743,7 +2743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2768,7 +2768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2787,7 +2787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2806,7 +2806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2831,7 +2831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2850,7 +2850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2872,7 +2872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2891,7 +2891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2910,7 +2910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2948,7 +2948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2970,7 +2970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3017,7 +3017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3036,7 +3036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3058,7 +3058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3077,7 +3077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3146,7 +3146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3165,7 +3165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3184,7 +3184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3203,7 +3203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3222,7 +3222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3241,7 +3241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3260,7 +3260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3279,7 +3279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3298,7 +3298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3317,7 +3317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3336,7 +3336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3355,7 +3355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3374,7 +3374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3393,7 +3393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3412,7 +3412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3431,7 +3431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3450,7 +3450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3550,7 +3550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3572,7 +3572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3591,7 +3591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3634,7 +3634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3681,7 +3681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3703,7 +3703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3747,7 +3747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3772,7 +3772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3797,7 +3797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3822,7 +3822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3872,7 +3872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3940,7 +3940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4028,7 +4028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4111,7 +4111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4133,7 +4133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4155,7 +4155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4180,7 +4180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4205,7 +4205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4227,7 +4227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4249,7 +4249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4271,7 +4271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4290,7 +4290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4309,7 +4309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4334,7 +4334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4356,7 +4356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4375,7 +4375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>bytestring</name>
       <version>1.5.1</version>
       <description>A UTF-8 encoded read-only string using `Bytes` as storage</description>
@@ -4421,7 +4421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4467,7 +4467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4508,7 +4508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4533,7 +4533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4555,7 +4555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4599,7 +4599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4618,7 +4618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4709,7 +4709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4779,7 +4779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4801,7 +4801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4823,7 +4823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4845,7 +4845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4910,7 +4910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5047,7 +5047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5072,7 +5072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5115,7 +5115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5140,7 +5140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5159,7 +5159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5178,7 +5178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5197,7 +5197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5263,7 +5263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5285,7 +5285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5326,7 +5326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5348,7 +5348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5367,7 +5367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5386,7 +5386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5468,7 +5468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5537,7 +5537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5556,7 +5556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5575,7 +5575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5597,7 +5597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5724,7 +5724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5812,7 +5812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5837,7 +5837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5905,7 +5905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5927,7 +5927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5949,7 +5949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5968,7 +5968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5987,7 +5987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6006,7 +6006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6025,7 +6025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6050,7 +6050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6134,7 +6134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6153,7 +6153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6175,7 +6175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6197,7 +6197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6263,7 +6263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6320,7 +6320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6339,7 +6339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6364,7 +6364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6386,7 +6386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6408,7 +6408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6433,7 +6433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6458,7 +6458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6483,7 +6483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6523,7 +6523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6542,7 +6542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6567,7 +6567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6629,7 +6629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6651,7 +6651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6673,7 +6673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6695,7 +6695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6720,7 +6720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6745,7 +6745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6824,7 +6824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6846,7 +6846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6868,7 +6868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6887,7 +6887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6906,7 +6906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6931,7 +6931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6953,7 +6953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6975,7 +6975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6997,7 +6997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7019,7 +7019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7038,7 +7038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7060,7 +7060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7079,7 +7079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7141,7 +7141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7163,7 +7163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7188,7 +7188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7210,7 +7210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7232,7 +7232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7254,7 +7254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7273,7 +7273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7311,7 +7311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7336,7 +7336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7358,7 +7358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7383,7 +7383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7402,7 +7402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7487,7 +7487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7530,7 +7530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7618,7 +7618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7685,7 +7685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7845,7 +7845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7867,7 +7867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7886,7 +7886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7905,7 +7905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7924,7 +7924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7943,7 +7943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7980,7 +7980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8002,7 +8002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8027,7 +8027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8070,7 +8070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8136,7 +8136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8179,7 +8179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8198,7 +8198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8220,7 +8220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8242,7 +8242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8264,7 +8264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8286,7 +8286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8308,7 +8308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8330,7 +8330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8349,7 +8349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8444,7 +8444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8469,7 +8469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8494,7 +8494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8519,7 +8519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8692,7 +8692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8758,7 +8758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1">
-      <author>Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Rob Ede &lt;robjtede@icloud.com></author>
       <name>impl-more</name>
       <version>0.3.1</version>
       <description>Concise, declarative trait implementation macros</description>
@@ -8798,7 +8798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8842,7 +8842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8886,7 +8886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8908,7 +8908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8930,7 +8930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8952,7 +8952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8974,7 +8974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8993,7 +8993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9099,7 +9099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9121,7 +9121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9146,7 +9146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9168,7 +9168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9193,7 +9193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9256,7 +9256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9275,7 +9275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9294,7 +9294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2">
-      <author>Pyfisch &lt;pyfisch@gmail.com&gt;, Tpt &lt;thomas@pellissier-tanon.fr&gt;</author>
+      <author>Pyfisch &lt;pyfisch@gmail.com>, Tpt &lt;thomas@pellissier-tanon.fr></author>
       <name>language-tags</name>
       <version>0.3.2</version>
       <description>Language tags for Rust</description>
@@ -9313,7 +9313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9335,7 +9335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9357,7 +9357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9379,7 +9379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9401,7 +9401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9423,7 +9423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9448,7 +9448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9467,7 +9467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9486,7 +9486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9505,7 +9505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9524,7 +9524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9543,7 +9543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9602,7 +9602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9624,7 +9624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9649,7 +9649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9671,7 +9671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9712,7 +9712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9756,7 +9756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9778,7 +9778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4">
-      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>local-waker</name>
       <version>0.1.4</version>
       <description>A synchronization primitive for thread-local task wakeup</description>
@@ -9797,7 +9797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9838,7 +9838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9857,7 +9857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9882,7 +9882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9904,7 +9904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9926,7 +9926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9945,7 +9945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9964,7 +9964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9989,7 +9989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10014,7 +10014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10077,7 +10077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10102,7 +10102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10124,7 +10124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10149,7 +10149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10171,7 +10171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10190,7 +10190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10256,7 +10256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10281,7 +10281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10324,7 +10324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10346,7 +10346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10368,7 +10368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10390,7 +10390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10412,7 +10412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10431,7 +10431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10450,7 +10450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10532,7 +10532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10620,7 +10620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10642,7 +10642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10664,7 +10664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10683,7 +10683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10733,7 +10733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10783,7 +10783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10927,7 +10927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10946,7 +10946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10965,7 +10965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10984,7 +10984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Rob Ede &lt;robjtede@icloud.com></author>
       <name>oas3</name>
       <version>0.20.1</version>
       <description>Structures and tools to parse, navigate, and validate OpenAPI v3.1.xß specifications</description>
@@ -11057,7 +11057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11101,7 +11101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11123,7 +11123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11142,7 +11142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11161,7 +11161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11183,7 +11183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11251,7 +11251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11276,7 +11276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11295,7 +11295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11314,7 +11314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11333,7 +11333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11358,7 +11358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11380,7 +11380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11420,7 +11420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11442,7 +11442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11467,7 +11467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11486,7 +11486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11505,7 +11505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11527,7 +11527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11568,7 +11568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11590,7 +11590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3">
-      <author>Aditya Kumar &lt;git@adityais.dev&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Aditya Kumar &lt;git@adityais.dev>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>pastey</name>
       <version>0.2.3</version>
       <description>Macros for all your token pasting needs. Successor of paste.</description>
@@ -11609,7 +11609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11628,7 +11628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11685,7 +11685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11710,7 +11710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11735,7 +11735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11760,7 +11760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11829,7 +11829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11848,7 +11848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11867,7 +11867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11886,7 +11886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11959,7 +11959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11981,7 +11981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12038,7 +12038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12060,7 +12060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12082,7 +12082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12101,7 +12101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12185,7 +12185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12223,7 +12223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12242,7 +12242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12264,7 +12264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12314,7 +12314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12336,7 +12336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12361,7 +12361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12408,7 +12408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12427,7 +12427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12465,7 +12465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12487,7 +12487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12506,7 +12506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12525,7 +12525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12547,7 +12547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12569,7 +12569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12591,7 +12591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12610,7 +12610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12629,7 +12629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12654,7 +12654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12679,7 +12679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12701,7 +12701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12723,7 +12723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12745,7 +12745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12767,7 +12767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12789,7 +12789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12811,7 +12811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12833,7 +12833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12855,7 +12855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12880,7 +12880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12941,7 +12941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13020,7 +13020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13042,7 +13042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13064,7 +13064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13089,7 +13089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13381,7 +13381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13400,7 +13400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13419,7 +13419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13441,7 +13441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13463,7 +13463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13482,7 +13482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13531,7 +13531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13556,7 +13556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13581,7 +13581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13606,7 +13606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13631,7 +13631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13653,7 +13653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13675,7 +13675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13694,7 +13694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13713,7 +13713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13735,7 +13735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13757,7 +13757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13797,7 +13797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13816,7 +13816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13838,7 +13838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13857,7 +13857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13993,7 +13993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14015,7 +14015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14037,7 +14037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14059,7 +14059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14078,7 +14078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14140,7 +14140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14162,7 +14162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14286,7 +14286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14308,7 +14308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14330,7 +14330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14374,7 +14374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14399,7 +14399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars</name>
       <version>1.2.1</version>
       <description>Generate JSON Schemas from Rust code</description>
@@ -14421,7 +14421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1">
-      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <author>Graham Esau &lt;gesau@hotmail.co.uk></author>
       <name>schemars_derive</name>
       <version>1.2.1</version>
       <description>Macros for #[derive(JsonSchema)], for use with schemars</description>
@@ -14465,7 +14465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14490,7 +14490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14515,7 +14515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14540,7 +14540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14562,7 +14562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14584,7 +14584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14606,7 +14606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14628,7 +14628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14650,7 +14650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14675,7 +14675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14697,7 +14697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14719,7 +14719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14744,7 +14744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14769,7 +14769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14794,7 +14794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive_internals</name>
       <version>0.29.1</version>
       <description>AST representation used by Serde derive macros. Unstable.</description>
@@ -14819,7 +14819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14841,7 +14841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14863,7 +14863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14885,7 +14885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14907,7 +14907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14973,7 +14973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15058,7 +15058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15083,7 +15083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15102,7 +15102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15146,7 +15146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15165,7 +15165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15190,7 +15190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15215,7 +15215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15237,7 +15237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15278,7 +15278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15297,7 +15297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15319,7 +15319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15341,7 +15341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15363,7 +15363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15385,7 +15385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15410,7 +15410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.5.10</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15435,7 +15435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15460,7 +15460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15498,7 +15498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15548,7 +15548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15567,7 +15567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15586,7 +15586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15627,7 +15627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15649,7 +15649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15671,7 +15671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15693,7 +15693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4">
-      <author>4t145 &lt;u4t145@163.com&gt;</author>
+      <author>4t145 &lt;u4t145@163.com></author>
       <name>sse-stream</name>
       <version>0.2.4</version>
       <description>Conversion between http body and sse stream</description>
@@ -15715,7 +15715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15737,7 +15737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15809,7 +15809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15828,7 +15828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15853,7 +15853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15878,7 +15878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15903,7 +15903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15928,7 +15928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15953,7 +15953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15978,7 +15978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16003,7 +16003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16025,7 +16025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16047,7 +16047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16069,7 +16069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16094,7 +16094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16116,7 +16116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16135,7 +16135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16217,7 +16217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16239,7 +16239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16264,7 +16264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16339,7 +16339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16388,7 +16388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16407,7 +16407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16426,7 +16426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16448,7 +16448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16470,7 +16470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16492,7 +16492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16536,7 +16536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16555,7 +16555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16577,7 +16577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16615,7 +16615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16634,7 +16634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16653,7 +16653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16699,7 +16699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16721,7 +16721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16743,7 +16743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16819,7 +16819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16841,7 +16841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16863,7 +16863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16885,7 +16885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16907,7 +16907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16929,7 +16929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16954,7 +16954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16979,7 +16979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17001,7 +17001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17023,7 +17023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17045,7 +17045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17067,7 +17067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17089,7 +17089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17111,7 +17111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17133,7 +17133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17183,7 +17183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17205,7 +17205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17248,7 +17248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17270,7 +17270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17316,7 +17316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17341,7 +17341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17385,7 +17385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17410,7 +17410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17432,7 +17432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17457,7 +17457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17482,7 +17482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17504,7 +17504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17526,7 +17526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17548,7 +17548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17595,7 +17595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17617,7 +17617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17639,7 +17639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17683,7 +17683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17705,7 +17705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17724,7 +17724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17749,7 +17749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17771,7 +17771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17796,7 +17796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17818,7 +17818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17837,7 +17837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17874,7 +17874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17899,7 +17899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17921,7 +17921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17943,7 +17943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17983,7 +17983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18005,7 +18005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18030,7 +18030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18119,7 +18119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18201,7 +18201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18242,7 +18242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18267,7 +18267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18289,7 +18289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18308,7 +18308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18330,7 +18330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18349,7 +18349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18368,7 +18368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18387,7 +18387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18406,7 +18406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18425,7 +18425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18507,7 +18507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18545,7 +18545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18564,7 +18564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18604,7 +18604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18626,7 +18626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18645,7 +18645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18667,7 +18667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19796,7 +19796,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19842,7 +19842,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19873,11 +19873,11 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/mcp#openobserve-mcp@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19889,7 +19889,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/mcp/openobserve-mcp.cdx.xml
+++ b/src/mcp/openobserve-mcp.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:33facde5-d2fc-4951-8f2a-ebd8a59be62d" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.196661000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+      <name>openobserve-mcp</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0 bin-target-0">
+          <name>openobserve_mcp</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-mcp@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -799,6 +799,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/rmcp-openapi?branch=v0.23.2-feat#0.23.2">
+      <name>rmcp-openapi</name>
+      <version>0.23.2</version>
+      <description>Library for converting OpenAPI specifications to MCP tools</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp-openapi@0.23.2?vcs_url=git%2Bhttps://github.com/openobserve/rmcp-openapi%3Fbranch=v0.23.2-feat%406587f6dcef81eaed9a9c037edc6bb98dec8e652a</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://gitlab.com/lx-industries/rmcp-openapi</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/lx-industries/rmcp-openapi</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -1566,6 +1584,170 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-codec</name>
+      <version>0.5.2</version>
+      <description>Codec utilities for working with framed protocols</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-codec@0.5.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-http</name>
+      <version>3.13.1</version>
+      <description>HTTP types and services for the Actix ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-http@3.13.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://actix.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-router</name>
+      <version>0.5.4</version>
+      <description>Resource path matching and router</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-router@0.5.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-rt</name>
+      <version>2.11.0</version>
+      <description>Tokio-based single-threaded async runtime for the Actix ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-rt@2.11.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://actix.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;, Ali MJ Al-Nasrawy &lt;alimjalnasrawy@gmail.com&gt;</author>
+      <name>actix-server</name>
+      <version>2.6.0</version>
+      <description>General purpose TCP server built for the Actix ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-server@2.6.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://actix.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net/tree/master/actix-server</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-service</name>
+      <version>2.0.3</version>
+      <description>Service trait and combinators for representing asynchronous request/response operations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-service@2.0.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-utils</name>
+      <version>3.0.1</version>
+      <description>Various utilities used in the Actix ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-utils@3.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>actix-web</name>
+      <version>4.14.0</version>
+      <description>Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/actix-web@4.14.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://actix.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-web</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
       <name>adler2</name>
@@ -2212,28 +2394,6 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/arrow-data@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -4211,6 +4371,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/bytes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>bytestring</name>
+      <version>1.5.1</version>
+      <description>A UTF-8 encoded read-only string using `Bytes` as storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bytestring@1.5.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://actix.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
         </reference>
       </externalReferences>
     </component>
@@ -8575,6 +8757,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1">
+      <author>Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>impl-more</name>
+      <version>0.3.1</version>
+      <description>Concise, declarative trait implementation macros</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/impl-more@0.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/robjtede/impl-more</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
       <version>2.14.0</version>
@@ -9092,6 +9293,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2">
+      <author>Pyfisch &lt;pyfisch@gmail.com&gt;, Tpt &lt;thomas@pellissier-tanon.fr&gt;</author>
+      <name>language-tags</name>
+      <version>0.3.2</version>
+      <description>Language tags for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/language-tags@0.3.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pyfisch/rust-language-tags</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
       <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
       <name>lasso</name>
@@ -9554,6 +9774,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/LeoBorai/local-ip-address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4">
+      <author>Nikolay Kim &lt;fafhrd91@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>local-waker</name>
+      <version>0.1.4</version>
+      <description>A synchronization primitive for thread-local task wakeup</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/local-waker@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/actix/actix-net</url>
         </reference>
       </externalReferences>
     </component>
@@ -10744,6 +10983,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1">
+      <author>softprops &lt;d.tangren@gmail.com&gt;, Rob Ede &lt;robjtede@icloud.com&gt;</author>
+      <name>oas3</name>
+      <version>0.20.1</version>
+      <description>Structures and tools to parse, navigate, and validate OpenAPI v3.1.xß specifications</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">16f67c885c7b19aaf652e84102035258ecb4e0425a4f71037e187798e367bd87</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/oas3@0.20.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/x52dev/oas3-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <name>objc2-core-foundation</name>
       <version>0.3.1</version>
@@ -11328,6 +11586,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3">
+      <author>Aditya Kumar &lt;git@adityais.dev&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>pastey</name>
+      <version>0.2.3</version>
+      <description>Macros for all your token pasting needs. Successor of paste.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pastey@0.2.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/as1100k/pastey</url>
         </reference>
       </externalReferences>
     </component>
@@ -13598,6 +13875,123 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-actix-web@0.9.5">
+      <name>rmcp-actix-web</name>
+      <version>0.9.5</version>
+      <description>actix-web transport implementations for RMCP (Rust Model Context Protocol)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">79d583880b37748b74ef1895a25ea5ddfa3abfe8881f0539a626d3feb65e9b9a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp-actix-web@0.9.5</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://gitlab.com/lx-industries/rmcp-actix-web</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/lx-industries/rmcp-actix-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.12.0">
+      <name>rmcp-macros</name>
+      <version>0.12.0</version>
+      <description>Rust SDK for Model Context Protocol macros library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp-macros@0.12.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rmcp-macros</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/modelcontextprotocol/rust-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/modelcontextprotocol/rust-sdk/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.13.0">
+      <name>rmcp-macros</name>
+      <version>0.13.0</version>
+      <description>Rust SDK for Model Context Protocol macros library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp-macros@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rmcp-macros</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/modelcontextprotocol/rust-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/modelcontextprotocol/rust-sdk/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.12.0">
+      <name>rmcp</name>
+      <version>0.12.0</version>
+      <description>Rust SDK for Model Context Protocol</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp@0.12.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rmcp</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/modelcontextprotocol/rust-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/modelcontextprotocol/rust-sdk/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.13.0">
+      <name>rmcp</name>
+      <version>0.13.0</version>
+      <description>Rust SDK for Model Context Protocol</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rmcp@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rmcp</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/modelcontextprotocol/rust-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/modelcontextprotocol/rust-sdk/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
@@ -14004,6 +14398,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1">
+      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <name>schemars</name>
+      <version>1.2.1</version>
+      <description>Generate JSON Schemas from Rust code</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/schemars@1.2.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://graham.cool/schemars/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/GREsau/schemars</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1">
+      <author>Graham Esau &lt;gesau@hotmail.co.uk&gt;</author>
+      <name>schemars_derive</name>
+      <version>1.2.1</version>
+      <description>Macros for #[derive(JsonSchema)], for use with schemars</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/schemars_derive@1.2.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://graham.cool/schemars/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/GREsau/schemars</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0">
       <author>bluss</author>
       <name>scopeguard</name>
@@ -14241,7 +14679,7 @@
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2</hash>
       </hashes>
@@ -14346,6 +14784,31 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://serde.rs/derive.html</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_derive_internals</name>
+      <version>0.29.1</version>
+      <description>AST representation used by Serde derive macros. Unstable.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_derive_internals@0.29.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_derive_internals</url>
         </reference>
         <reference type="website">
           <url>https://serde.rs</url>
@@ -14946,6 +15409,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <name>socket2</name>
+      <version>0.5.10</version>
+      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/socket2</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
@@ -15201,6 +15689,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/launchbadge/sqlx</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4">
+      <author>4t145 &lt;u4t145@163.com&gt;</author>
+      <name>sse-stream</name>
+      <version>0.2.4</version>
+      <description>Conversion between http body and sse stream</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sse-stream@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sse-stream/sse-stream</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/4t145/sse-stream/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18769,6 +19279,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/rmcp-openapi?branch=v0.23.2-feat#0.23.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.12.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-actix-web@0.9.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -19342,19 +19873,21 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/mcp#openobserve-mcp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="git+https://github.com/openobserve/rmcp-openapi?branch=v0.23.2-feat#0.23.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +19899,106 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-http@3.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20133,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -20171,6 +20790,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
@@ -20959,6 +21581,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#impl-more@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
@@ -21067,6 +21690,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
@@ -21160,6 +21784,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
@@ -21348,6 +21973,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oas3@0.20.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
@@ -21465,6 +22101,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
@@ -22004,6 +22641,83 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-actix-web@0.9.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#actix-web@4.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.12.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.12.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.12.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pastey@0.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rmcp-macros@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -22101,6 +22815,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#schemars_derive@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -22193,6 +22921,11 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
@@ -22314,6 +23047,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -22500,6 +23236,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sse-stream@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">

--- a/src/node/openobserve-node.cdx.xml
+++ b/src/node/openobserve-node.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:6eff0da3-49a6-459b-8e41-1febedf672ae" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f2f6650b-c383-48fa-8ae7-86a2e1af5846" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.828165000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.409273000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0 bin-target-0">
           <name>openobserve_node</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1610,7 +1610,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1619,7 +1619,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1628,7 +1628,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1638,7 +1638,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1726,7 +1726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1748,7 +1748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1770,7 +1770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1792,7 +1792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1817,10 +1817,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1842,7 +1842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1867,7 +1867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1892,7 +1892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2029,7 +2029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2051,7 +2051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2073,10 +2073,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2117,7 +2117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2161,7 +2161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2183,7 +2183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2205,7 +2205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2227,7 +2227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2249,7 +2249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2271,7 +2271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2293,7 +2293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2315,7 +2315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2337,7 +2337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2359,7 +2359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2381,7 +2381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2403,7 +2403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2425,7 +2425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2447,7 +2447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2469,7 +2469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2575,7 +2575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2594,7 +2594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2613,7 +2613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2632,7 +2632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2657,7 +2657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2676,7 +2676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2695,7 +2695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2720,7 +2720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2745,7 +2745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2764,7 +2764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2786,7 +2786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2805,7 +2805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2824,7 +2824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2843,7 +2843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2862,7 +2862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2884,7 +2884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2931,7 +2931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2950,7 +2950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2972,7 +2972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2991,7 +2991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3060,7 +3060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3079,7 +3079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3117,7 +3117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3136,7 +3136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3155,7 +3155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3174,7 +3174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3193,7 +3193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3212,7 +3212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3231,7 +3231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3250,7 +3250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3269,7 +3269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3288,7 +3288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3307,7 +3307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3326,7 +3326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3345,7 +3345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3364,7 +3364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3464,7 +3464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3505,7 +3505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3548,7 +3548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3595,7 +3595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3617,7 +3617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3661,7 +3661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3686,7 +3686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3711,7 +3711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3736,7 +3736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3786,7 +3786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3854,7 +3854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3942,7 +3942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4003,7 +4003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4025,7 +4025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4047,7 +4047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4069,7 +4069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4094,7 +4094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4119,7 +4119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4141,7 +4141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4163,7 +4163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4185,7 +4185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4204,7 +4204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4223,7 +4223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4248,7 +4248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4270,7 +4270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4313,7 +4313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4359,7 +4359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4400,7 +4400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4425,7 +4425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4447,7 +4447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4491,7 +4491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4510,7 +4510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4601,7 +4601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4671,7 +4671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4693,7 +4693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4715,7 +4715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4737,7 +4737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4802,7 +4802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4939,7 +4939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4964,7 +4964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5007,7 +5007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5032,7 +5032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5051,7 +5051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5089,7 +5089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5155,7 +5155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5177,7 +5177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5199,7 +5199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5237,7 +5237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5259,7 +5259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5278,7 +5278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5297,7 +5297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5316,7 +5316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5398,7 +5398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5467,7 +5467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5486,7 +5486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5505,7 +5505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5527,7 +5527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5654,7 +5654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5742,7 +5742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5767,7 +5767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5814,7 +5814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5860,7 +5860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5882,7 +5882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5904,7 +5904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5923,7 +5923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5942,7 +5942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5961,7 +5961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5980,7 +5980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6005,7 +6005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6089,7 +6089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6108,7 +6108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6130,7 +6130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6152,7 +6152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6174,7 +6174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6240,7 +6240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6297,7 +6297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6316,7 +6316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6341,7 +6341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6385,7 +6385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6410,7 +6410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6435,7 +6435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6460,7 +6460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6500,7 +6500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6519,7 +6519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6544,7 +6544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6566,7 +6566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6653,7 +6653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6675,7 +6675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6697,7 +6697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6719,7 +6719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6744,7 +6744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6769,7 +6769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6848,7 +6848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6870,7 +6870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6892,7 +6892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6911,7 +6911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6930,7 +6930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6955,7 +6955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6977,7 +6977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6999,7 +6999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7021,7 +7021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7043,7 +7043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7062,7 +7062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7084,7 +7084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7103,7 +7103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7165,7 +7165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7187,7 +7187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7212,7 +7212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7234,7 +7234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7256,7 +7256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7278,7 +7278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7297,7 +7297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7335,7 +7335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7360,7 +7360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7382,7 +7382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7407,7 +7407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7426,7 +7426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7511,7 +7511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7554,7 +7554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7642,7 +7642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7709,7 +7709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7822,7 +7822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7869,7 +7869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7891,7 +7891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7910,7 +7910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7929,7 +7929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7948,7 +7948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7967,7 +7967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8004,7 +8004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8047,7 +8047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8072,7 +8072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8115,7 +8115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8181,7 +8181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8224,7 +8224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8243,7 +8243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8265,7 +8265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8287,7 +8287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8309,7 +8309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8331,7 +8331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8353,7 +8353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8375,7 +8375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8394,7 +8394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8489,7 +8489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8514,7 +8514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8539,7 +8539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8564,7 +8564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8737,7 +8737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8824,7 +8824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8868,7 +8868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8912,7 +8912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8934,7 +8934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8956,7 +8956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8978,7 +8978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9000,7 +9000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9019,7 +9019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9038,7 +9038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9144,7 +9144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9166,7 +9166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9191,7 +9191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9213,7 +9213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9238,7 +9238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9257,7 +9257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9323,7 +9323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9342,7 +9342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9361,7 +9361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9383,7 +9383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9405,7 +9405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9427,7 +9427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9449,7 +9449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9471,7 +9471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9496,7 +9496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9515,7 +9515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9534,7 +9534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9553,7 +9553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9572,7 +9572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9591,7 +9591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9650,7 +9650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9672,7 +9672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9697,7 +9697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9719,7 +9719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9760,7 +9760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9804,7 +9804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9826,7 +9826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9867,7 +9867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9886,7 +9886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9911,7 +9911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9933,7 +9933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9955,7 +9955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9974,7 +9974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9993,7 +9993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10018,7 +10018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10043,7 +10043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10062,7 +10062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10131,7 +10131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10156,7 +10156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10178,7 +10178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10203,7 +10203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10225,7 +10225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10244,7 +10244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10266,7 +10266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10288,7 +10288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10310,7 +10310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10335,7 +10335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10378,7 +10378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10400,7 +10400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10422,7 +10422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10444,7 +10444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10466,7 +10466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10485,7 +10485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10504,7 +10504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10526,7 +10526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10611,7 +10611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10699,7 +10699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10721,7 +10721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10743,7 +10743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10762,7 +10762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10781,7 +10781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10831,7 +10831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11025,7 +11025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11044,7 +11044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11063,7 +11063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11136,7 +11136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11180,7 +11180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11202,7 +11202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11221,7 +11221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11240,7 +11240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11262,7 +11262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11330,7 +11330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11355,7 +11355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11374,7 +11374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11393,7 +11393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11412,7 +11412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11437,7 +11437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11459,7 +11459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11499,7 +11499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11521,7 +11521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11546,7 +11546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11565,7 +11565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11584,7 +11584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11606,7 +11606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11647,7 +11647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11669,7 +11669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11688,7 +11688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11726,7 +11726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11770,7 +11770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11795,7 +11795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11820,7 +11820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11845,7 +11845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11914,7 +11914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11933,7 +11933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11952,7 +11952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11971,7 +11971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12044,7 +12044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12066,7 +12066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12123,7 +12123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12145,7 +12145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12167,7 +12167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12186,7 +12186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12308,7 +12308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12327,7 +12327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12349,7 +12349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12399,7 +12399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12421,7 +12421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12493,7 +12493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12531,7 +12531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12550,7 +12550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12572,7 +12572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12591,7 +12591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12610,7 +12610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12632,7 +12632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12654,7 +12654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12676,7 +12676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12695,7 +12695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12714,7 +12714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12739,7 +12739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12764,7 +12764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12786,7 +12786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12808,7 +12808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12830,7 +12830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12852,7 +12852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12874,7 +12874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12896,7 +12896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12918,7 +12918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12940,7 +12940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12965,7 +12965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13026,7 +13026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13105,7 +13105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13127,7 +13127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13149,7 +13149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13174,7 +13174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13466,7 +13466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13485,7 +13485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13504,7 +13504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13526,7 +13526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13548,7 +13548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13567,7 +13567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13616,7 +13616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13641,7 +13641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13666,7 +13666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13691,7 +13691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13716,7 +13716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13738,7 +13738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13760,7 +13760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13779,7 +13779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13798,7 +13798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13820,7 +13820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13842,7 +13842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13882,7 +13882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13901,7 +13901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13923,7 +13923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13942,7 +13942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13961,7 +13961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13983,7 +13983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14005,7 +14005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14024,7 +14024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14043,7 +14043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14062,7 +14062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14084,7 +14084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14103,7 +14103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14165,7 +14165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14187,7 +14187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14311,7 +14311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14333,7 +14333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14355,7 +14355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14399,7 +14399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14446,7 +14446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14496,7 +14496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14521,7 +14521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14546,7 +14546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14571,7 +14571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14593,7 +14593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14615,7 +14615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14637,7 +14637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14659,7 +14659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14681,7 +14681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14703,7 +14703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14725,7 +14725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14750,7 +14750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14769,7 +14769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14791,7 +14791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14813,7 +14813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14838,7 +14838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14863,7 +14863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14888,7 +14888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14910,7 +14910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14929,7 +14929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14951,7 +14951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14973,7 +14973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14995,7 +14995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15017,7 +15017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15083,7 +15083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15168,7 +15168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15193,7 +15193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15212,7 +15212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15234,7 +15234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15278,7 +15278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15297,7 +15297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15322,7 +15322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15341,7 +15341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15366,7 +15366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15388,7 +15388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15429,7 +15429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15448,7 +15448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15470,7 +15470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15492,7 +15492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15514,7 +15514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15536,7 +15536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15558,7 +15558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15580,7 +15580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15630,7 +15630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15668,7 +15668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15718,7 +15718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15737,7 +15737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15756,7 +15756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15775,7 +15775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15797,7 +15797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15819,7 +15819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15841,7 +15841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15863,7 +15863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15885,7 +15885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15957,7 +15957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15976,7 +15976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16001,7 +16001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16026,7 +16026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16051,7 +16051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16076,7 +16076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16101,7 +16101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16126,7 +16126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16151,7 +16151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16176,7 +16176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16201,7 +16201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16223,7 +16223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16245,7 +16245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16267,7 +16267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16292,7 +16292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16314,7 +16314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16333,7 +16333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16415,7 +16415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16437,7 +16437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16462,7 +16462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16537,7 +16537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16586,7 +16586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16605,7 +16605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16624,7 +16624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16646,7 +16646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16668,7 +16668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16690,7 +16690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16715,7 +16715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16734,7 +16734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16753,7 +16753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16775,7 +16775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16813,7 +16813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16832,7 +16832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16851,7 +16851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16897,7 +16897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16919,7 +16919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16959,7 +16959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17035,7 +17035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17057,7 +17057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17079,7 +17079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17101,7 +17101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17123,7 +17123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17145,7 +17145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17170,7 +17170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17195,7 +17195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17261,7 +17261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17304,7 +17304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17326,7 +17326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17348,7 +17348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17370,7 +17370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17395,7 +17395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17445,7 +17445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17467,7 +17467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17510,7 +17510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17532,7 +17532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17603,7 +17603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17628,7 +17628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17672,7 +17672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17719,7 +17719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17744,7 +17744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17769,7 +17769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17791,7 +17791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17813,7 +17813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17835,7 +17835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17882,7 +17882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17904,7 +17904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17926,7 +17926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17970,7 +17970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17992,7 +17992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18011,7 +18011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18036,7 +18036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18058,7 +18058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18083,7 +18083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18105,7 +18105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18124,7 +18124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18161,7 +18161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18186,7 +18186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18208,7 +18208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18230,7 +18230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18270,7 +18270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18292,7 +18292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18317,7 +18317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18406,7 +18406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18488,7 +18488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18529,7 +18529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18554,7 +18554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18576,7 +18576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18595,7 +18595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18617,7 +18617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18636,7 +18636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18655,7 +18655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18674,7 +18674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18693,7 +18693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18712,7 +18712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18794,7 +18794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18832,7 +18832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18851,7 +18851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18891,7 +18891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18913,7 +18913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18932,7 +18932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18954,7 +18954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20075,18 +20075,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20105,12 +20105,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20156,7 +20156,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20187,24 +20187,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20215,10 +20215,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20228,7 +20228,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20239,7 +20239,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20255,39 +20255,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20298,9 +20298,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20308,9 +20308,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/node/openobserve-node.cdx.xml
+++ b/src/node/openobserve-node.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:6eff0da3-49a6-459b-8e41-1febedf672ae" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.828165000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0 bin-target-0">
+          <name>openobserve_node</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,33 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1618,24 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2292,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2691,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5198,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5290,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5813,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6145,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6562,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8025,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +8999,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9253,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10061,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10585,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10758,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11722,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14004,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14470,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14508,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14636,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14746,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14909,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14947,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +14999,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15233,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15318,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15491,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15548,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16050,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16113,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16940,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17282,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17391,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17574,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19660,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20075,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,18 +20187,104 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
@@ -19366,6 +20297,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20450,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20605,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21290,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21299,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21374,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21456,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21533,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21789,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +21983,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +22035,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22191,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22282,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22311,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22496,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +23037,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23146,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23166,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23231,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23255,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23285,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23356,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23405,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23419,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +23635,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23646,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23797,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23930,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23964,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +23999,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/org_storage/openobserve-org-storage.cdx.xml
+++ b/src/org_storage/openobserve-org-storage.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3c9eac23-df50-4e60-be5b-6ece37e3a180" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:21797f12-9223-4333-b9db-2673a616b4a8" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.119414000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.672492000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0 bin-target-0">
           <name>openobserve_org_storage</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1566,7 +1566,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1576,7 +1576,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1664,7 +1664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1686,7 +1686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1708,7 +1708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1730,7 +1730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1755,10 +1755,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1780,7 +1780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1805,7 +1805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1830,7 +1830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1927,7 +1927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1967,7 +1967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2011,10 +2011,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2055,7 +2055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2099,7 +2099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2121,7 +2121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2143,7 +2143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2165,7 +2165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2187,7 +2187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2209,7 +2209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2231,7 +2231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2253,7 +2253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2275,7 +2275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2297,7 +2297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2319,7 +2319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2341,7 +2341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2363,7 +2363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2385,7 +2385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2407,7 +2407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2513,7 +2513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2532,7 +2532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2551,7 +2551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2595,7 +2595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2614,7 +2614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2633,7 +2633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2658,7 +2658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2683,7 +2683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2702,7 +2702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2724,7 +2724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2743,7 +2743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2762,7 +2762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2781,7 +2781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2800,7 +2800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2822,7 +2822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2869,7 +2869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2888,7 +2888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2910,7 +2910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2998,7 +2998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3017,7 +3017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3036,7 +3036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3055,7 +3055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3074,7 +3074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3093,7 +3093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3112,7 +3112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3131,7 +3131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3150,7 +3150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3169,7 +3169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3188,7 +3188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3207,7 +3207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3226,7 +3226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3245,7 +3245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3264,7 +3264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3283,7 +3283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3302,7 +3302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3402,7 +3402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3424,7 +3424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3443,7 +3443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3533,7 +3533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3555,7 +3555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3599,7 +3599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3624,7 +3624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3649,7 +3649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3674,7 +3674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3724,7 +3724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3792,7 +3792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3880,7 +3880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3941,7 +3941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3963,7 +3963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3985,7 +3985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4007,7 +4007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4032,7 +4032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4057,7 +4057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4079,7 +4079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4101,7 +4101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4123,7 +4123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4142,7 +4142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4186,7 +4186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4208,7 +4208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4251,7 +4251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4297,7 +4297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4338,7 +4338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4363,7 +4363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4385,7 +4385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4429,7 +4429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4448,7 +4448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4539,7 +4539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4609,7 +4609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4631,7 +4631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4653,7 +4653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4675,7 +4675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4740,7 +4740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4877,7 +4877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4902,7 +4902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4945,7 +4945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4970,7 +4970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4989,7 +4989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5008,7 +5008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5027,7 +5027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5093,7 +5093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5115,7 +5115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5156,7 +5156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5178,7 +5178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5197,7 +5197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5216,7 +5216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5298,7 +5298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5367,7 +5367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5386,7 +5386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5405,7 +5405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5427,7 +5427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5554,7 +5554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5642,7 +5642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5667,7 +5667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5714,7 +5714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5760,7 +5760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5782,7 +5782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5804,7 +5804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5823,7 +5823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5842,7 +5842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5861,7 +5861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5880,7 +5880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5905,7 +5905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5989,7 +5989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6008,7 +6008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6030,7 +6030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6052,7 +6052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6118,7 +6118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6175,7 +6175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6194,7 +6194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6219,7 +6219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6241,7 +6241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6263,7 +6263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6288,7 +6288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6313,7 +6313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6378,7 +6378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6397,7 +6397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6422,7 +6422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6444,7 +6444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6531,7 +6531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6553,7 +6553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6575,7 +6575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6597,7 +6597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6622,7 +6622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6647,7 +6647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6726,7 +6726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6748,7 +6748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6770,7 +6770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6789,7 +6789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6808,7 +6808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6833,7 +6833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6855,7 +6855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6877,7 +6877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6899,7 +6899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6921,7 +6921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6940,7 +6940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6962,7 +6962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6981,7 +6981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7043,7 +7043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7065,7 +7065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7090,7 +7090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7112,7 +7112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7134,7 +7134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7156,7 +7156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7175,7 +7175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7213,7 +7213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7238,7 +7238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7260,7 +7260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7285,7 +7285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7304,7 +7304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7389,7 +7389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7432,7 +7432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7520,7 +7520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7587,7 +7587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7700,7 +7700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7747,7 +7747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7769,7 +7769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7788,7 +7788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7807,7 +7807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7826,7 +7826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7845,7 +7845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7882,7 +7882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7925,7 +7925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7950,7 +7950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7993,7 +7993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8059,7 +8059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8102,7 +8102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8121,7 +8121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8143,7 +8143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8165,7 +8165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8187,7 +8187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8209,7 +8209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8231,7 +8231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8253,7 +8253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8272,7 +8272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8367,7 +8367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8392,7 +8392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8417,7 +8417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8442,7 +8442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8615,7 +8615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8702,7 +8702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8746,7 +8746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8790,7 +8790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8812,7 +8812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8834,7 +8834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8856,7 +8856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8878,7 +8878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8897,7 +8897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9003,7 +9003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9025,7 +9025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9050,7 +9050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9072,7 +9072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9097,7 +9097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9160,7 +9160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9179,7 +9179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9198,7 +9198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9220,7 +9220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9242,7 +9242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9264,7 +9264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9286,7 +9286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9308,7 +9308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9333,7 +9333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9352,7 +9352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9371,7 +9371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9390,7 +9390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9409,7 +9409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9428,7 +9428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9487,7 +9487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9509,7 +9509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9534,7 +9534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9556,7 +9556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9597,7 +9597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9663,7 +9663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9704,7 +9704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9723,7 +9723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9748,7 +9748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9770,7 +9770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9792,7 +9792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9811,7 +9811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9830,7 +9830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9855,7 +9855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9880,7 +9880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9943,7 +9943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9968,7 +9968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10015,7 +10015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10037,7 +10037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10056,7 +10056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10078,7 +10078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10100,7 +10100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10122,7 +10122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10147,7 +10147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10190,7 +10190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10256,7 +10256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10278,7 +10278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10316,7 +10316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10338,7 +10338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10423,7 +10423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10511,7 +10511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10533,7 +10533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10555,7 +10555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10574,7 +10574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10593,7 +10593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10643,7 +10643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10693,7 +10693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10837,7 +10837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10856,7 +10856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10875,7 +10875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10948,7 +10948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10992,7 +10992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11014,7 +11014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11033,7 +11033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11052,7 +11052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11074,7 +11074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11142,7 +11142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11167,7 +11167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11186,7 +11186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11205,7 +11205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11224,7 +11224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11249,7 +11249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11271,7 +11271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11311,7 +11311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11333,7 +11333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11358,7 +11358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11377,7 +11377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11396,7 +11396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11418,7 +11418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11459,7 +11459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11481,7 +11481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11500,7 +11500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11557,7 +11557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11582,7 +11582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11607,7 +11607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11632,7 +11632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11701,7 +11701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11720,7 +11720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11758,7 +11758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11831,7 +11831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11853,7 +11853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11910,7 +11910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11932,7 +11932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11954,7 +11954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11973,7 +11973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12057,7 +12057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12095,7 +12095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12114,7 +12114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12136,7 +12136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12186,7 +12186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12208,7 +12208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12233,7 +12233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12280,7 +12280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12318,7 +12318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12337,7 +12337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12359,7 +12359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12378,7 +12378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12397,7 +12397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12419,7 +12419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12441,7 +12441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12463,7 +12463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12482,7 +12482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12501,7 +12501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12526,7 +12526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12551,7 +12551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12573,7 +12573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12595,7 +12595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12617,7 +12617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12639,7 +12639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12661,7 +12661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12683,7 +12683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12727,7 +12727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12752,7 +12752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12813,7 +12813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12892,7 +12892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12914,7 +12914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12936,7 +12936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12961,7 +12961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13253,7 +13253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13272,7 +13272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13291,7 +13291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13313,7 +13313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13335,7 +13335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13403,7 +13403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13428,7 +13428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13453,7 +13453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13478,7 +13478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13503,7 +13503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13525,7 +13525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13547,7 +13547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13566,7 +13566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13585,7 +13585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13607,7 +13607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13629,7 +13629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13669,7 +13669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13688,7 +13688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13710,7 +13710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13729,7 +13729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13748,7 +13748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13770,7 +13770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13792,7 +13792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13814,7 +13814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13833,7 +13833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13895,7 +13895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13917,7 +13917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14041,7 +14041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14063,7 +14063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14085,7 +14085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14129,7 +14129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14176,7 +14176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14201,7 +14201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14226,7 +14226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14251,7 +14251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14276,7 +14276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14301,7 +14301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14323,7 +14323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14345,7 +14345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14367,7 +14367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14389,7 +14389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14411,7 +14411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14433,7 +14433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14455,7 +14455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14480,7 +14480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14502,7 +14502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14524,7 +14524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14549,7 +14549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14574,7 +14574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14599,7 +14599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14621,7 +14621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14640,7 +14640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14662,7 +14662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14706,7 +14706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14728,7 +14728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14794,7 +14794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14879,7 +14879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14904,7 +14904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14923,7 +14923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14945,7 +14945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -14989,7 +14989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15008,7 +15008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15033,7 +15033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15058,7 +15058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15080,7 +15080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15140,7 +15140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15162,7 +15162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15184,7 +15184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15206,7 +15206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15228,7 +15228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15253,7 +15253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15278,7 +15278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15316,7 +15316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15366,7 +15366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15385,7 +15385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15404,7 +15404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15423,7 +15423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15445,7 +15445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15467,7 +15467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15489,7 +15489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15511,7 +15511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15533,7 +15533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15624,7 +15624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15649,7 +15649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15674,7 +15674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15699,7 +15699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15724,7 +15724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15749,7 +15749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15799,7 +15799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15821,7 +15821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15843,7 +15843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15865,7 +15865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15890,7 +15890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15912,7 +15912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15931,7 +15931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16013,7 +16013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16035,7 +16035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16060,7 +16060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16135,7 +16135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16184,7 +16184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16203,7 +16203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16266,7 +16266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16288,7 +16288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16313,7 +16313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16351,7 +16351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16373,7 +16373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16411,7 +16411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16430,7 +16430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16449,7 +16449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16495,7 +16495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16633,7 +16633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16655,7 +16655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16677,7 +16677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16699,7 +16699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16721,7 +16721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16743,7 +16743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16768,7 +16768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16793,7 +16793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16815,7 +16815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16837,7 +16837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16859,7 +16859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16902,7 +16902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16924,7 +16924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16946,7 +16946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16968,7 +16968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16993,7 +16993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17065,7 +17065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17108,7 +17108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17130,7 +17130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17176,7 +17176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17201,7 +17201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17245,7 +17245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17270,7 +17270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17292,7 +17292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17317,7 +17317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17364,7 +17364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17386,7 +17386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17408,7 +17408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17455,7 +17455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17477,7 +17477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17565,7 +17565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17584,7 +17584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17609,7 +17609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17656,7 +17656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17678,7 +17678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17734,7 +17734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17759,7 +17759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17781,7 +17781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17803,7 +17803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17843,7 +17843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17865,7 +17865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17890,7 +17890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18061,7 +18061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18102,7 +18102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18127,7 +18127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18149,7 +18149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18168,7 +18168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18190,7 +18190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18209,7 +18209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18228,7 +18228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18247,7 +18247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18266,7 +18266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18285,7 +18285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18367,7 +18367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18405,7 +18405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18424,7 +18424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18505,7 +18505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18527,7 +18527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19635,7 +19635,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19681,7 +19681,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19712,7 +19712,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -19722,7 +19722,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -19733,7 +19733,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -19749,20 +19749,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/org_storage#openobserve-org-storage@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/org_storage/openobserve-org-storage.cdx.xml
+++ b/src/org_storage/openobserve-org-storage.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3c9eac23-df50-4e60-be5b-6ece37e3a180" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.119414000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <name>openobserve-org-storage</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0 bin-target-0">
+          <name>openobserve_org_storage</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-org-storage@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -1557,6 +1557,15 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -2221,28 +2230,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2629,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5701,6 +5713,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6403,6 +6440,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7810,6 +7894,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -10292,6 +10397,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10570,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +14200,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14238,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14164,6 +14363,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SeaQL/sea-query</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14620,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14658,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14657,6 +14941,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/signal-hook</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +16538,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +16880,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +16989,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -19342,19 +19712,55 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/org_storage#openobserve-org-storage@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19500,20 +19906,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20061,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20407,6 +20829,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
@@ -20552,6 +20980,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20797,6 +21235,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21271,6 +21712,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +21741,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -22109,6 +22561,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +22581,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +22646,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22204,9 +22692,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22266,6 +22762,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22678,6 +23180,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23313,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23347,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />

--- a/src/promql/promql.cdx.xml
+++ b/src/promql/promql.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:a96f122d-c473-498e-a4d8-b9c71a2f7bb1" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.846715000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0 bin-target-0">
+          <name>promql</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/promql@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -799,6 +799,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -1557,6 +1573,15 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -2221,28 +2246,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2645,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -3586,6 +3614,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -4238,6 +4288,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
       <name>camino</name>
@@ -4457,6 +4526,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5701,6 +5789,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6406,6 +6519,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <author>bluss</author>
       <name>either</name>
@@ -6912,6 +7072,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +7709,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8014,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -9598,6 +9823,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -10292,6 +10574,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10747,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +11506,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +14396,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14434,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14164,6 +14559,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SeaQL/sea-query</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14816,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14854,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14657,6 +15137,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/signal-hook</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
         </reference>
       </externalReferences>
     </component>
@@ -14968,6 +15470,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +16753,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17095,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17204,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16827,6 +17412,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +18017,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +18061,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18769,6 +19420,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -19342,19 +20002,61 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19500,20 +20202,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20357,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +20778,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20175,6 +20896,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +20929,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20407,6 +21137,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
@@ -20552,6 +21288,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20636,6 +21382,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +21483,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +21550,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21164,6 +21920,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21271,6 +22063,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22092,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21418,6 +22221,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22109,6 +22916,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +22936,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23001,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22204,9 +23047,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,6 +23118,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22316,6 +23173,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22678,6 +23541,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23674,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23708,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22855,6 +23745,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +23801,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/promql/promql.cdx.xml
+++ b/src/promql/promql.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:a96f122d-c473-498e-a4d8-b9c71a2f7bb1" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:35572553-117e-4d60-ba04-de4fd77401ab" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.846715000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.426333000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0 bin-target-0">
           <name>promql</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/promql@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -816,7 +816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -824,7 +824,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -838,7 +838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -846,7 +846,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -860,7 +860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -868,7 +868,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -889,7 +889,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -900,7 +900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -908,7 +908,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -922,7 +922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -930,7 +930,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -948,7 +948,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -966,7 +966,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -984,7 +984,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -995,7 +995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1003,7 +1003,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1014,7 +1014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1022,7 +1022,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1033,7 +1033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1041,7 +1041,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1052,7 +1052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1060,7 +1060,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1071,7 +1071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1079,7 +1079,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1090,7 +1090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1098,7 +1098,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1109,7 +1109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1117,7 +1117,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1128,7 +1128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1136,7 +1136,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1147,7 +1147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1155,7 +1155,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1166,7 +1166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1174,7 +1174,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1185,7 +1185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1193,7 +1193,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1204,7 +1204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1212,7 +1212,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1223,7 +1223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1231,7 +1231,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1242,7 +1242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1250,7 +1250,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1261,7 +1261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1269,7 +1269,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1280,7 +1280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1288,7 +1288,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1299,7 +1299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1307,7 +1307,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1318,7 +1318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1326,7 +1326,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1337,7 +1337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1345,7 +1345,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1356,7 +1356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1364,7 +1364,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1375,7 +1375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1383,7 +1383,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1394,7 +1394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1402,7 +1402,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1413,7 +1413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1421,7 +1421,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1432,7 +1432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1440,7 +1440,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1451,7 +1451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1459,7 +1459,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1470,7 +1470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1478,7 +1478,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1489,7 +1489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1497,7 +1497,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1508,7 +1508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1516,7 +1516,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1527,7 +1527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1535,7 +1535,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1546,7 +1546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1554,7 +1554,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1564,7 +1564,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1573,7 +1573,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1582,7 +1582,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1680,7 +1680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1702,7 +1702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1724,7 +1724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1746,7 +1746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1771,10 +1771,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1846,7 +1846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1943,7 +1943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1983,7 +1983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2005,7 +2005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2027,10 +2027,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2071,7 +2071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2115,7 +2115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2137,7 +2137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2159,7 +2159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2181,7 +2181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2203,7 +2203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2225,7 +2225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2247,7 +2247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2269,7 +2269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2291,7 +2291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2313,7 +2313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2335,7 +2335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2357,7 +2357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2379,7 +2379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2401,7 +2401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2423,7 +2423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2529,7 +2529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2548,7 +2548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2567,7 +2567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2611,7 +2611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2630,7 +2630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2674,7 +2674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2699,7 +2699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2718,7 +2718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2740,7 +2740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2759,7 +2759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2778,7 +2778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2797,7 +2797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2816,7 +2816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2838,7 +2838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2885,7 +2885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2904,7 +2904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2926,7 +2926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2945,7 +2945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3014,7 +3014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3033,7 +3033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3052,7 +3052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3071,7 +3071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3090,7 +3090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3109,7 +3109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3128,7 +3128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3147,7 +3147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3166,7 +3166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3185,7 +3185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3204,7 +3204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3223,7 +3223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3242,7 +3242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3261,7 +3261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3280,7 +3280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3299,7 +3299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3318,7 +3318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3418,7 +3418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3440,7 +3440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3459,7 +3459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3502,7 +3502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3549,7 +3549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3571,7 +3571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3637,7 +3637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3662,7 +3662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3687,7 +3687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3712,7 +3712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3762,7 +3762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3830,7 +3830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3918,7 +3918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3979,7 +3979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4001,7 +4001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4070,7 +4070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4095,7 +4095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4117,7 +4117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4139,7 +4139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4180,7 +4180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4199,7 +4199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4224,7 +4224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4246,7 +4246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4289,7 +4289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4308,7 +4308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4354,7 +4354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4420,7 +4420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4442,7 +4442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4486,7 +4486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4505,7 +4505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4530,7 +4530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4615,7 +4615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4685,7 +4685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4707,7 +4707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4729,7 +4729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4751,7 +4751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4816,7 +4816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4953,7 +4953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4978,7 +4978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5021,7 +5021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5046,7 +5046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5065,7 +5065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5084,7 +5084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5103,7 +5103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5169,7 +5169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5191,7 +5191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5232,7 +5232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5254,7 +5254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5273,7 +5273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5292,7 +5292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5374,7 +5374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5443,7 +5443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5462,7 +5462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5481,7 +5481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5503,7 +5503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5630,7 +5630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5718,7 +5718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5743,7 +5743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5790,7 +5790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5836,7 +5836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5858,7 +5858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5880,7 +5880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5899,7 +5899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5918,7 +5918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5937,7 +5937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5956,7 +5956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5981,7 +5981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6065,7 +6065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6084,7 +6084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6106,7 +6106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6128,7 +6128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6194,7 +6194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6251,7 +6251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6270,7 +6270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6295,7 +6295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6317,7 +6317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6339,7 +6339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6364,7 +6364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6389,7 +6389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6414,7 +6414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6454,7 +6454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6473,7 +6473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6498,7 +6498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6520,7 +6520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6607,7 +6607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6629,7 +6629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6651,7 +6651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6673,7 +6673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6698,7 +6698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6723,7 +6723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6802,7 +6802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6824,7 +6824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6846,7 +6846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6865,7 +6865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6884,7 +6884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6909,7 +6909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6931,7 +6931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6953,7 +6953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6975,7 +6975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6997,7 +6997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7016,7 +7016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7038,7 +7038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7057,7 +7057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7076,7 +7076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7144,7 +7144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7166,7 +7166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7191,7 +7191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7213,7 +7213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7235,7 +7235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7257,7 +7257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7276,7 +7276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7314,7 +7314,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7339,7 +7339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7361,7 +7361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7386,7 +7386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7405,7 +7405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7490,7 +7490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7533,7 +7533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7621,7 +7621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7688,7 +7688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7820,7 +7820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7867,7 +7867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7889,7 +7889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7908,7 +7908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7927,7 +7927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7946,7 +7946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7965,7 +7965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8002,7 +8002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8045,7 +8045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8070,7 +8070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8113,7 +8113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8179,7 +8179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8222,7 +8222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8241,7 +8241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8263,7 +8263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8285,7 +8285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8307,7 +8307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8329,7 +8329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8351,7 +8351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8373,7 +8373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8392,7 +8392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8487,7 +8487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8512,7 +8512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8537,7 +8537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8562,7 +8562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8735,7 +8735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8822,7 +8822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8866,7 +8866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8910,7 +8910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8932,7 +8932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8954,7 +8954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8976,7 +8976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8998,7 +8998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9017,7 +9017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9123,7 +9123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9145,7 +9145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9170,7 +9170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9192,7 +9192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9217,7 +9217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9280,7 +9280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9299,7 +9299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9318,7 +9318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9340,7 +9340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9362,7 +9362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9384,7 +9384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9406,7 +9406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9428,7 +9428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9453,7 +9453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9472,7 +9472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9491,7 +9491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9510,7 +9510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9529,7 +9529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9548,7 +9548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9607,7 +9607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9629,7 +9629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9654,7 +9654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9676,7 +9676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9717,7 +9717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9761,7 +9761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9783,7 +9783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9824,7 +9824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -9843,7 +9843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -9862,7 +9862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -9881,7 +9881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9900,7 +9900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9925,7 +9925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9947,7 +9947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9969,7 +9969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9988,7 +9988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10007,7 +10007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10032,7 +10032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10057,7 +10057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10120,7 +10120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10145,7 +10145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10167,7 +10167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10192,7 +10192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10214,7 +10214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10233,7 +10233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10255,7 +10255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10277,7 +10277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10299,7 +10299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10324,7 +10324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10367,7 +10367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10389,7 +10389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10411,7 +10411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10433,7 +10433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10455,7 +10455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10474,7 +10474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10493,7 +10493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10515,7 +10515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10600,7 +10600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10688,7 +10688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10710,7 +10710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10732,7 +10732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10751,7 +10751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10770,7 +10770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10820,7 +10820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10870,7 +10870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11014,7 +11014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11033,7 +11033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11052,7 +11052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11125,7 +11125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11169,7 +11169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11191,7 +11191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11210,7 +11210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11229,7 +11229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11251,7 +11251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11319,7 +11319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11344,7 +11344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11363,7 +11363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11382,7 +11382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11401,7 +11401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11426,7 +11426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11448,7 +11448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11488,7 +11488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11510,7 +11510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -11529,7 +11529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11554,7 +11554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11573,7 +11573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11592,7 +11592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11614,7 +11614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11655,7 +11655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11677,7 +11677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11696,7 +11696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11753,7 +11753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11778,7 +11778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11803,7 +11803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11828,7 +11828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11897,7 +11897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11916,7 +11916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11935,7 +11935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11954,7 +11954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12027,7 +12027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12049,7 +12049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12106,7 +12106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12150,7 +12150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12169,7 +12169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12253,7 +12253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12291,7 +12291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12310,7 +12310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12332,7 +12332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12382,7 +12382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12404,7 +12404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12429,7 +12429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12476,7 +12476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12495,7 +12495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12514,7 +12514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12533,7 +12533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12555,7 +12555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12574,7 +12574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12593,7 +12593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12615,7 +12615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12637,7 +12637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12659,7 +12659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12678,7 +12678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12697,7 +12697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12722,7 +12722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12747,7 +12747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12769,7 +12769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12791,7 +12791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12813,7 +12813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12835,7 +12835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12857,7 +12857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12879,7 +12879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12901,7 +12901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12923,7 +12923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12948,7 +12948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13009,7 +13009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13088,7 +13088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13110,7 +13110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13132,7 +13132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13157,7 +13157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13449,7 +13449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13468,7 +13468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13487,7 +13487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13509,7 +13509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13531,7 +13531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13550,7 +13550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13624,7 +13624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13649,7 +13649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13674,7 +13674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13699,7 +13699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13721,7 +13721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13743,7 +13743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13762,7 +13762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13781,7 +13781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13803,7 +13803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13825,7 +13825,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13865,7 +13865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13884,7 +13884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13906,7 +13906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13925,7 +13925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13944,7 +13944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13966,7 +13966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13988,7 +13988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14010,7 +14010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14029,7 +14029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14091,7 +14091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14113,7 +14113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14281,7 +14281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14325,7 +14325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14372,7 +14372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14397,7 +14397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14447,7 +14447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14472,7 +14472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14497,7 +14497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14519,7 +14519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14541,7 +14541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14563,7 +14563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14585,7 +14585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14607,7 +14607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14629,7 +14629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14651,7 +14651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14676,7 +14676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14698,7 +14698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14720,7 +14720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14745,7 +14745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14770,7 +14770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14795,7 +14795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14817,7 +14817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14836,7 +14836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14858,7 +14858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14880,7 +14880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14902,7 +14902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14924,7 +14924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14990,7 +14990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15075,7 +15075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15100,7 +15100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15119,7 +15119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15141,7 +15141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15185,7 +15185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15204,7 +15204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15229,7 +15229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15254,7 +15254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15276,7 +15276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15317,7 +15317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15336,7 +15336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15358,7 +15358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15380,7 +15380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15402,7 +15402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15424,7 +15424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15449,7 +15449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15474,7 +15474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15531,7 +15531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15581,7 +15581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15600,7 +15600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15619,7 +15619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15638,7 +15638,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15660,7 +15660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15682,7 +15682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15704,7 +15704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15726,7 +15726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15748,7 +15748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15820,7 +15820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15839,7 +15839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15864,7 +15864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15889,7 +15889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15914,7 +15914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15939,7 +15939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15964,7 +15964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15989,7 +15989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16014,7 +16014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16036,7 +16036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16058,7 +16058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16080,7 +16080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16105,7 +16105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16127,7 +16127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16146,7 +16146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16228,7 +16228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16250,7 +16250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16275,7 +16275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16350,7 +16350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16399,7 +16399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16418,7 +16418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16437,7 +16437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16459,7 +16459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16481,7 +16481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16503,7 +16503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16528,7 +16528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16547,7 +16547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16566,7 +16566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16588,7 +16588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16626,7 +16626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16645,7 +16645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16664,7 +16664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16710,7 +16710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16732,7 +16732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16772,7 +16772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16848,7 +16848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16870,7 +16870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16892,7 +16892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16914,7 +16914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16936,7 +16936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16958,7 +16958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16983,7 +16983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17008,7 +17008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17030,7 +17030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17052,7 +17052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17074,7 +17074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17117,7 +17117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17139,7 +17139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17161,7 +17161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17183,7 +17183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17208,7 +17208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17258,7 +17258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17280,7 +17280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17323,7 +17323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17345,7 +17345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17391,7 +17391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17416,7 +17416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -17438,7 +17438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17482,7 +17482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17507,7 +17507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17529,7 +17529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17554,7 +17554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17579,7 +17579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17601,7 +17601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17623,7 +17623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17645,7 +17645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17692,7 +17692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17714,7 +17714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17736,7 +17736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17780,7 +17780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17802,7 +17802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17821,7 +17821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17846,7 +17846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17868,7 +17868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17893,7 +17893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17915,7 +17915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17934,7 +17934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17971,7 +17971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17996,7 +17996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18018,7 +18018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -18043,7 +18043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18065,7 +18065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -18084,7 +18084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18124,7 +18124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18146,7 +18146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18171,7 +18171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18260,7 +18260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18342,7 +18342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18383,7 +18383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18408,7 +18408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18430,7 +18430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18449,7 +18449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18471,7 +18471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18490,7 +18490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18509,7 +18509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18528,7 +18528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18547,7 +18547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18566,7 +18566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18648,7 +18648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18686,7 +18686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18705,7 +18705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18745,7 +18745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18767,7 +18767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18786,7 +18786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18808,7 +18808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19925,7 +19925,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19971,7 +19971,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20002,7 +20002,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20012,7 +20012,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20023,7 +20023,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20039,16 +20039,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -20058,7 +20058,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/promql_service/promql-service.cdx.xml
+++ b/src/promql_service/promql-service.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:7a51f1f9-d0db-455e-a1a6-f9ac3a8ef2c2" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:dbf5f72d-63b3-42b7-ae79-e9926a97fdec" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.865291000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.443998000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0 bin-target-0">
           <name>promql_service</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/promql-service@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1742,7 +1742,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1830,7 +1830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1852,7 +1852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1874,7 +1874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1896,7 +1896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1921,10 +1921,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1946,7 +1946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1971,7 +1971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1996,7 +1996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2093,7 +2093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2133,7 +2133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2155,7 +2155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2177,10 +2177,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2221,7 +2221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2265,7 +2265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2287,7 +2287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2309,7 +2309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2331,7 +2331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2353,7 +2353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2375,7 +2375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2397,7 +2397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2419,7 +2419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2441,7 +2441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2463,7 +2463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2485,7 +2485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2507,7 +2507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2529,7 +2529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2551,7 +2551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2573,7 +2573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2595,7 +2595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2701,7 +2701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2720,7 +2720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2739,7 +2739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2758,7 +2758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2783,7 +2783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2802,7 +2802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2821,7 +2821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2846,7 +2846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2871,7 +2871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2890,7 +2890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2912,7 +2912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2931,7 +2931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2950,7 +2950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2969,7 +2969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2988,7 +2988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3010,7 +3010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3057,7 +3057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3076,7 +3076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3117,7 +3117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3186,7 +3186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3205,7 +3205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3224,7 +3224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3243,7 +3243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3262,7 +3262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3281,7 +3281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3300,7 +3300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3319,7 +3319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3338,7 +3338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3357,7 +3357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3376,7 +3376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3395,7 +3395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3414,7 +3414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3433,7 +3433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3452,7 +3452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3471,7 +3471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3490,7 +3490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3612,7 +3612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3631,7 +3631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3674,7 +3674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3721,7 +3721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3743,7 +3743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3787,7 +3787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3809,7 +3809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3834,7 +3834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3859,7 +3859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3884,7 +3884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3934,7 +3934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4002,7 +4002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4090,7 +4090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4151,7 +4151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4173,7 +4173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4195,7 +4195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4217,7 +4217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4242,7 +4242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4267,7 +4267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4289,7 +4289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4311,7 +4311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4333,7 +4333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4352,7 +4352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4371,7 +4371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4396,7 +4396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4418,7 +4418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4461,7 +4461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4480,7 +4480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4526,7 +4526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4567,7 +4567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4592,7 +4592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4614,7 +4614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4658,7 +4658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4677,7 +4677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4702,7 +4702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4787,7 +4787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4857,7 +4857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4879,7 +4879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4901,7 +4901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4923,7 +4923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4988,7 +4988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5125,7 +5125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5150,7 +5150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5193,7 +5193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5218,7 +5218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5237,7 +5237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5256,7 +5256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5275,7 +5275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5341,7 +5341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5363,7 +5363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5385,7 +5385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5423,7 +5423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5445,7 +5445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5464,7 +5464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5483,7 +5483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5502,7 +5502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5584,7 +5584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5653,7 +5653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5672,7 +5672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5691,7 +5691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5713,7 +5713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5840,7 +5840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5928,7 +5928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5953,7 +5953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6000,7 +6000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6046,7 +6046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6068,7 +6068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6090,7 +6090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6109,7 +6109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6128,7 +6128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6147,7 +6147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6166,7 +6166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6191,7 +6191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6275,7 +6275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6294,7 +6294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6316,7 +6316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6360,7 +6360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6426,7 +6426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6483,7 +6483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6502,7 +6502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6527,7 +6527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6549,7 +6549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6571,7 +6571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6596,7 +6596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6621,7 +6621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6646,7 +6646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6686,7 +6686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6705,7 +6705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6730,7 +6730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6752,7 +6752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6839,7 +6839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6861,7 +6861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6883,7 +6883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6905,7 +6905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6930,7 +6930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6955,7 +6955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7034,7 +7034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7056,7 +7056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7078,7 +7078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7097,7 +7097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7116,7 +7116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7141,7 +7141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7163,7 +7163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7185,7 +7185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7207,7 +7207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7229,7 +7229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7248,7 +7248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7270,7 +7270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7289,7 +7289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7308,7 +7308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7376,7 +7376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7398,7 +7398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7445,7 +7445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7467,7 +7467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7489,7 +7489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7508,7 +7508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7546,7 +7546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7571,7 +7571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7593,7 +7593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7618,7 +7618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7637,7 +7637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7722,7 +7722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7765,7 +7765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7853,7 +7853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7920,7 +7920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8052,7 +8052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8099,7 +8099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8121,7 +8121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8140,7 +8140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8159,7 +8159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8178,7 +8178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8197,7 +8197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8234,7 +8234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8277,7 +8277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8302,7 +8302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8345,7 +8345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8411,7 +8411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8454,7 +8454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8473,7 +8473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8495,7 +8495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8517,7 +8517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8539,7 +8539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8561,7 +8561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8583,7 +8583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8605,7 +8605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8624,7 +8624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8719,7 +8719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8744,7 +8744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8769,7 +8769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8794,7 +8794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8967,7 +8967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9054,7 +9054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9098,7 +9098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9142,7 +9142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9164,7 +9164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9186,7 +9186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9208,7 +9208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9230,7 +9230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9249,7 +9249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9268,7 +9268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9374,7 +9374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9396,7 +9396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9421,7 +9421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9443,7 +9443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9465,7 +9465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9490,7 +9490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9509,7 +9509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9575,7 +9575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9594,7 +9594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9613,7 +9613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9635,7 +9635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9657,7 +9657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9679,7 +9679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9701,7 +9701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9723,7 +9723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9748,7 +9748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9767,7 +9767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9786,7 +9786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9805,7 +9805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9824,7 +9824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9843,7 +9843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9902,7 +9902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9924,7 +9924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9949,7 +9949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9971,7 +9971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10012,7 +10012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10056,7 +10056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10078,7 +10078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10119,7 +10119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10138,7 +10138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10157,7 +10157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10176,7 +10176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10195,7 +10195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10220,7 +10220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10242,7 +10242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10264,7 +10264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10283,7 +10283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10302,7 +10302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10327,7 +10327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10352,7 +10352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10371,7 +10371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10440,7 +10440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10465,7 +10465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10487,7 +10487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10512,7 +10512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10534,7 +10534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10553,7 +10553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10575,7 +10575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10597,7 +10597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10619,7 +10619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10644,7 +10644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10687,7 +10687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10709,7 +10709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10731,7 +10731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10753,7 +10753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10775,7 +10775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10794,7 +10794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10813,7 +10813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10835,7 +10835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10920,7 +10920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11008,7 +11008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11030,7 +11030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11052,7 +11052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11071,7 +11071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11090,7 +11090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11140,7 +11140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11190,7 +11190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11334,7 +11334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11353,7 +11353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11372,7 +11372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11445,7 +11445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11489,7 +11489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11511,7 +11511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11571,7 +11571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11639,7 +11639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11664,7 +11664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11683,7 +11683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11702,7 +11702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11721,7 +11721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11746,7 +11746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11768,7 +11768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11808,7 +11808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11830,7 +11830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -11849,7 +11849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11874,7 +11874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11893,7 +11893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11912,7 +11912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11934,7 +11934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11975,7 +11975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11997,7 +11997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12016,7 +12016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12054,7 +12054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12098,7 +12098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12123,7 +12123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12148,7 +12148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12173,7 +12173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12242,7 +12242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12261,7 +12261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12280,7 +12280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12372,7 +12372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12394,7 +12394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12451,7 +12451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12473,7 +12473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12495,7 +12495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12514,7 +12514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12598,7 +12598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12636,7 +12636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12655,7 +12655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12677,7 +12677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12727,7 +12727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12749,7 +12749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12774,7 +12774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12821,7 +12821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12840,7 +12840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12859,7 +12859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12878,7 +12878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12900,7 +12900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12919,7 +12919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12938,7 +12938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12960,7 +12960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12982,7 +12982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13004,7 +13004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13023,7 +13023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13042,7 +13042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13067,7 +13067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13092,7 +13092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13114,7 +13114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13136,7 +13136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13158,7 +13158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13180,7 +13180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13202,7 +13202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13224,7 +13224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13246,7 +13246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13268,7 +13268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13293,7 +13293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13312,7 +13312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13334,7 +13334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13359,7 +13359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13381,7 +13381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13403,7 +13403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13473,7 +13473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13552,7 +13552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13574,7 +13574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13596,7 +13596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13913,7 +13913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13932,7 +13932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13951,7 +13951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13973,7 +13973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13995,7 +13995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14014,7 +14014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14063,7 +14063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14088,7 +14088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14113,7 +14113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14138,7 +14138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14163,7 +14163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14185,7 +14185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14207,7 +14207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14226,7 +14226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14245,7 +14245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14267,7 +14267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14289,7 +14289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14329,7 +14329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14348,7 +14348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14370,7 +14370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14389,7 +14389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14408,7 +14408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14430,7 +14430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14452,7 +14452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14490,7 +14490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14509,7 +14509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14531,7 +14531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14550,7 +14550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14612,7 +14612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14634,7 +14634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14758,7 +14758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14780,7 +14780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14802,7 +14802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14846,7 +14846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14893,7 +14893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14918,7 +14918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14943,7 +14943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14968,7 +14968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14993,7 +14993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15018,7 +15018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15040,7 +15040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15062,7 +15062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15084,7 +15084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15106,7 +15106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15128,7 +15128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15150,7 +15150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15172,7 +15172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15197,7 +15197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15216,7 +15216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15238,7 +15238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15260,7 +15260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15285,7 +15285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15310,7 +15310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15335,7 +15335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15357,7 +15357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15376,7 +15376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15398,7 +15398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15420,7 +15420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15442,7 +15442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15464,7 +15464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15530,7 +15530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15615,7 +15615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15640,7 +15640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15659,7 +15659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15681,7 +15681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15725,7 +15725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15744,7 +15744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15769,7 +15769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15788,7 +15788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15813,7 +15813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15835,7 +15835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15876,7 +15876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15895,7 +15895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15917,7 +15917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15939,7 +15939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15961,7 +15961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15983,7 +15983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16005,7 +16005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16027,7 +16027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16052,7 +16052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16077,7 +16077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16096,7 +16096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16134,7 +16134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16184,7 +16184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16203,7 +16203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16241,7 +16241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16263,7 +16263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16285,7 +16285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16307,7 +16307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16329,7 +16329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16351,7 +16351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16423,7 +16423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16442,7 +16442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16467,7 +16467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16492,7 +16492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16542,7 +16542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16567,7 +16567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16592,7 +16592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16617,7 +16617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16642,7 +16642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16667,7 +16667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16689,7 +16689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16711,7 +16711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16733,7 +16733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16758,7 +16758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16780,7 +16780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16799,7 +16799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16881,7 +16881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16903,7 +16903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16928,7 +16928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17025,7 +17025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17074,7 +17074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17093,7 +17093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17112,7 +17112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17134,7 +17134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17156,7 +17156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17178,7 +17178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17203,7 +17203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17222,7 +17222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17241,7 +17241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17263,7 +17263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17301,7 +17301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17320,7 +17320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17339,7 +17339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17385,7 +17385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17407,7 +17407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17447,7 +17447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17523,7 +17523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17545,7 +17545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17567,7 +17567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17589,7 +17589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17611,7 +17611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17633,7 +17633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17658,7 +17658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17683,7 +17683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17705,7 +17705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17727,7 +17727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17749,7 +17749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17792,7 +17792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17814,7 +17814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17836,7 +17836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17858,7 +17858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17883,7 +17883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17933,7 +17933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17955,7 +17955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17998,7 +17998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18020,7 +18020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18091,7 +18091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18116,7 +18116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18138,7 +18138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18182,7 +18182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18207,7 +18207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18229,7 +18229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18254,7 +18254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18279,7 +18279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18301,7 +18301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18323,7 +18323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18345,7 +18345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18392,7 +18392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18414,7 +18414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18436,7 +18436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18480,7 +18480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18502,7 +18502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18521,7 +18521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18546,7 +18546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18568,7 +18568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18593,7 +18593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18615,7 +18615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18634,7 +18634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18671,7 +18671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18696,7 +18696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18718,7 +18718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -18743,7 +18743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18765,7 +18765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -18784,7 +18784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18824,7 +18824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18846,7 +18846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18871,7 +18871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18960,7 +18960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19042,7 +19042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19083,7 +19083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19108,7 +19108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19130,7 +19130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19149,7 +19149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19171,7 +19171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19190,7 +19190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19209,7 +19209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19228,7 +19228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19247,7 +19247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19266,7 +19266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19348,7 +19348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19386,7 +19386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19405,7 +19405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19445,7 +19445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19467,7 +19467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19486,7 +19486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19508,7 +19508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20669,18 +20669,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20699,12 +20699,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20750,7 +20750,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20781,24 +20781,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20809,15 +20809,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -20826,7 +20826,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20836,7 +20836,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20847,7 +20847,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20863,36 +20863,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -20902,33 +20902,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20939,7 +20939,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -20948,17 +20948,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -20968,7 +20968,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20977,48 +20977,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21026,11 +21026,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21038,10 +21038,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21053,9 +21053,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21063,16 +21063,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/promql_service/promql-service.cdx.xml
+++ b/src/promql_service/promql-service.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:7a51f1f9-d0db-455e-a1a6-f9ac3a8ef2c2" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.865291000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0 bin-target-0">
+          <name>promql_service</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/promql-service@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1633,51 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1686,60 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2820,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3786,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -4238,6 +4460,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
       <name>camino</name>
@@ -4457,6 +4698,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5384,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5476,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5999,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6331,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6748,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6912,6 +7304,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +7941,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8246,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9229,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9442,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9505,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10118,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10367,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +10894,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11067,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11183,6 +11829,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
       <name>parking</name>
@@ -11385,6 +12050,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +13311,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13642,6 +14451,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14917,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14955,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15083,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15193,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15356,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15394,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15446,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15680,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15765,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15938,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15995,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16073,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16516,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16579,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15750,6 +16924,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/myrrlyn/tap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +17428,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17770,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17879,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18065,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18112,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +18717,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +18761,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19623,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20127,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20229,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20385,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +20669,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +20781,37 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +20826,108 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +20938,146 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21381,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +21802,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20175,6 +21920,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +21953,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20324,6 +22078,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22087,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22162,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22244,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22321,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20636,6 +22415,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +22516,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +22583,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +22778,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +22807,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +22839,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +22972,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23031,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23122,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23151,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21418,6 +23280,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23340,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21724,6 +23594,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -22011,6 +23909,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +24018,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24038,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24103,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24127,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24157,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24228,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24277,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24292,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +24513,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +24524,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +24590,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22677,6 +24675,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +24809,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24843,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +24879,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +24944,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/proto/proto.cdx.xml
+++ b/src/proto/proto.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d8298fd2-9d43-4b52-93ab-032e80dc9324" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:92af863e-3ddc-4500-8aec-ecacc04e1b1a" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.602211000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.192189000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0 bin-target-0">
           <name>proto</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/proto@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -38,7 +38,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -46,7 +46,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -54,7 +54,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -65,7 +65,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -73,7 +73,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -84,7 +84,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -92,7 +92,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -103,7 +103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -111,7 +111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -122,7 +122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -130,7 +130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -141,7 +141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -149,7 +149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -160,7 +160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -168,7 +168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -179,7 +179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -187,7 +187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -198,7 +198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -206,7 +206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -217,7 +217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -225,7 +225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -236,7 +236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -244,7 +244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -255,7 +255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -263,7 +263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -274,7 +274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -282,7 +282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -293,7 +293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -301,7 +301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -312,7 +312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -320,7 +320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -331,7 +331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -339,7 +339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -350,7 +350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -358,7 +358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -369,7 +369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -377,7 +377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -388,7 +388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -396,7 +396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -407,7 +407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -415,7 +415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -426,7 +426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -434,7 +434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -445,7 +445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -453,7 +453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -464,7 +464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -472,7 +472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -483,7 +483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -491,7 +491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -502,7 +502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -510,7 +510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -521,7 +521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -529,7 +529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -540,7 +540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -562,7 +562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -584,7 +584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -606,10 +606,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -631,7 +631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -656,7 +656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -681,7 +681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -721,7 +721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -765,7 +765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -787,7 +787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -809,7 +809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -897,7 +897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -919,7 +919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -941,7 +941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -963,7 +963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -985,7 +985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -1007,7 +1007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -1029,7 +1029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -1051,7 +1051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -1073,7 +1073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -1092,7 +1092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -1136,7 +1136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -1155,7 +1155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -1290,7 +1290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -1425,7 +1425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -1450,7 +1450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -1475,7 +1475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -1500,7 +1500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -1543,7 +1543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -1589,7 +1589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -1608,7 +1608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -1633,7 +1633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -1652,7 +1652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -1744,7 +1744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -1769,7 +1769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -1794,7 +1794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -1813,7 +1813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -1879,7 +1879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -1901,7 +1901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -1923,7 +1923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -2030,7 +2030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -2070,7 +2070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -2136,7 +2136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -2161,7 +2161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -2186,7 +2186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -2255,7 +2255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -2280,7 +2280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -2327,7 +2327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -2370,7 +2370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -2392,7 +2392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -2414,7 +2414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -2476,7 +2476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -2498,7 +2498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -2545,7 +2545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -2564,7 +2564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -2602,7 +2602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -2816,7 +2816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -2951,7 +2951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -2970,7 +2970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -2989,7 +2989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -3026,7 +3026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -3051,7 +3051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -3076,7 +3076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -3120,7 +3120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -3142,7 +3142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -3164,7 +3164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -3186,7 +3186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -3275,7 +3275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -3300,7 +3300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -3325,7 +3325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -3350,7 +3350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -3588,7 +3588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -3610,7 +3610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -3632,7 +3632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -3654,7 +3654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -3695,7 +3695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -3717,7 +3717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -3742,7 +3742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -3761,7 +3761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -3780,7 +3780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -3799,7 +3799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -3818,7 +3818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -3837,7 +3837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -3896,7 +3896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -3921,7 +3921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -3943,7 +3943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -3962,7 +3962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -4006,7 +4006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -4047,7 +4047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -4066,7 +4066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -4088,7 +4088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -4151,7 +4151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -4176,7 +4176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -4198,7 +4198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -4223,7 +4223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -4245,7 +4245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -4267,7 +4267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -4407,7 +4407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -4429,7 +4429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -4448,7 +4448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -4467,7 +4467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -4486,7 +4486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -4508,7 +4508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -4571,7 +4571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -4590,7 +4590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -4663,7 +4663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -4685,7 +4685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -4748,7 +4748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -4773,7 +4773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -4795,7 +4795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -4814,7 +4814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -4833,7 +4833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -4852,7 +4852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -4874,7 +4874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -4896,7 +4896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -4918,7 +4918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -4937,7 +4937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -4959,7 +4959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -4984,7 +4984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -5078,7 +5078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -5250,7 +5250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -5269,7 +5269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -5288,7 +5288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -5313,7 +5313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -5338,7 +5338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -5363,7 +5363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -5446,7 +5446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -5552,7 +5552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -5574,7 +5574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -5621,7 +5621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -5643,7 +5643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -5668,7 +5668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -5690,7 +5690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -5712,7 +5712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -5737,7 +5737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -5762,7 +5762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -5787,7 +5787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -5809,7 +5809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -5831,7 +5831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -5875,7 +5875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -5894,7 +5894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -5916,7 +5916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -5935,7 +5935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -5960,7 +5960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -5985,7 +5985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -6026,7 +6026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -6051,7 +6051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -6076,7 +6076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -6095,7 +6095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -6145,7 +6145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -6167,7 +6167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -6192,7 +6192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -6217,7 +6217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -6239,7 +6239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -6264,7 +6264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -6324,7 +6324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -6349,7 +6349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -6368,7 +6368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -6390,7 +6390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -6415,7 +6415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -6453,7 +6453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -6472,7 +6472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -6537,7 +6537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -6559,7 +6559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -6581,7 +6581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -6603,7 +6603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -6625,7 +6625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -6647,7 +6647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -6669,7 +6669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -6691,7 +6691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -6713,7 +6713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -6738,7 +6738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -6763,7 +6763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -6785,7 +6785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -6807,7 +6807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -6829,7 +6829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -6851,7 +6851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -6876,7 +6876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -6898,7 +6898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -6941,7 +6941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -6963,7 +6963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -6985,7 +6985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -7007,7 +7007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -7029,7 +7029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -7051,7 +7051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -7073,7 +7073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -7095,7 +7095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -7139,7 +7139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -7164,7 +7164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -7189,7 +7189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -7211,7 +7211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -7233,7 +7233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -7258,7 +7258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -7320,7 +7320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -7339,7 +7339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -7358,7 +7358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -7377,7 +7377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -7396,7 +7396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -7415,7 +7415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -7497,7 +7497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -7556,7 +7556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -7578,7 +7578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -7597,7 +7597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -7619,7 +7619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -8038,7 +8038,7 @@
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />

--- a/src/proto/proto.cdx.xml
+++ b/src/proto/proto.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c901133a-9f94-49e7-8eb9-86028acce3ef" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d8298fd2-9d43-4b52-93ab-032e80dc9324" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.237676000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.602211000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0 bin-target-0">
           <name>proto</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/proto@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,515 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
       <name>adler2</name>
@@ -171,19 +680,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -255,19 +764,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -277,19 +786,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -299,19 +808,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -321,19 +830,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -343,19 +852,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -365,19 +874,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -387,19 +896,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -409,19 +918,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -431,19 +940,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -453,19 +962,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -475,19 +984,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -497,19 +1006,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -519,19 +1028,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -541,19 +1050,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -802,31 +1311,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
-      <author>Andrew Kubera</author>
-      <name>bigdecimal</name>
-      <version>0.4.10</version>
-      <description>Arbitrary precision decimal numbers</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/bigdecimal@0.4.10</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/bigdecimal</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/akubera/bigdecimal-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/akubera/bigdecimal-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <author>The Rust Project Developers</author>
       <name>bitflags</name>
@@ -909,6 +1393,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -1036,6 +1542,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>cc</name>
@@ -1102,6 +1673,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
+      <author>RustCrypto Developers</author>
+      <name>chacha20</name>
+      <version>0.10.0</version>
+      <description>The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2). Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/chacha20@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/chacha20</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/stream-ciphers</url>
         </reference>
       </externalReferences>
     </component>
@@ -1238,6 +1831,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -1367,19 +1985,41 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <author>RustCrypto Developers</author>
-      <name>cpufeatures</name>
-      <version>0.2.17</version>
-      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets,  with no_std support and support for mobile targets including Android and iOS </description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation</name>
+      <version>0.9.4</version>
+      <description>Bindings to Core Foundation for macOS</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280</hash>
+        <hash alg="SHA-256">91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <purl>pkg:cargo/core-foundation@0.9.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -1405,48 +2045,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/srijs/rust-crc32fast</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <name>crossbeam-deque</name>
-      <version>0.8.6</version>
-      <description>Concurrent work-stealing deque</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/crossbeam-deque@0.8.6</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/crossbeam-rs/crossbeam</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
-      <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
-      <description>Epoch-based garbage collection</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/crossbeam-rs/crossbeam</url>
         </reference>
       </externalReferences>
     </component>
@@ -1506,6 +2104,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -1590,732 +2210,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7">
       <author>RustCrypto Developers</author>
       <name>digest</name>
@@ -2329,6 +2223,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -3091,19 +3007,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
       <name>hashbrown</name>
-      <version>0.16.1</version>
+      <version>0.17.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100</hash>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -3310,6 +3225,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/chronotope/humantime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hybrid-array</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -3629,18 +3566,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -3939,19 +3876,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
@@ -4128,19 +4065,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
@@ -4182,6 +4119,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -4263,19 +4222,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -4447,24 +4406,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
       <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
       <name>once_cell</name>
@@ -4544,19 +4485,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -5061,18 +5002,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
       <name>quick-xml</name>
-      <version>0.38.4</version>
+      <version>0.39.2</version>
       <description>High performance xml reader and writer</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c</hash>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/quick-xml@0.38.4</purl>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/quick-xml</url>
@@ -5082,18 +5023,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -5155,6 +5096,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/quote</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand</name>
+      <version>0.10.1</version>
+      <description>Random number generators and other randomness functionality. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand@0.10.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rand</url>
         </reference>
       </externalReferences>
     </component>
@@ -5280,30 +5246,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
-      <name>rayon-core</name>
-      <version>1.13.0</version>
-      <description>Core APIs for Rayon</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/rayon-core@1.13.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/rayon-core/</url>
-        </reference>
-        <reference type="other">
-          <url>rayon-core</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rayon-rs/rayon</url>
         </reference>
       </externalReferences>
     </component>
@@ -5570,18 +5512,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.103.9</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
@@ -5910,19 +5852,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
       <author>RustCrypto Developers</author>
       <name>sha2</name>
-      <version>0.10.9</version>
+      <version>0.11.0</version>
       <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283</hash>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sha2@0.10.9</purl>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sha2</url>
@@ -6108,19 +6050,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.6.2</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -6133,38 +6075,38 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -6343,6 +6285,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -6510,19 +6490,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -6600,19 +6580,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -6939,19 +6919,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -7184,19 +7163,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -7663,16 +7642,409 @@
     </component>
   </components>
   <dependencies>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
@@ -7695,46 +8067,46 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -7744,41 +8116,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -7788,64 +8161,65 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -7909,21 +8283,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -7936,10 +8302,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
@@ -7957,14 +8325,32 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1" />
@@ -7992,6 +8378,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -8005,27 +8392,27 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -8045,516 +8432,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -8574,7 +8461,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
@@ -8635,21 +8522,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -8660,9 +8547,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -8680,11 +8567,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -8710,6 +8596,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
@@ -8717,7 +8606,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -8726,7 +8615,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -8738,11 +8627,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -8760,7 +8650,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
@@ -8816,9 +8706,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
@@ -8833,7 +8723,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
@@ -8858,10 +8748,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -8879,7 +8769,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
@@ -8887,14 +8777,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -8904,7 +8799,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -8925,37 +8820,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
@@ -8965,17 +8832,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -8983,18 +8850,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -9003,7 +8870,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
@@ -9052,7 +8919,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -9105,11 +8972,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -9123,25 +8991,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
@@ -9158,10 +9031,6 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -9207,7 +9076,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -9220,7 +9089,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
@@ -9230,7 +9099,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
@@ -9239,7 +9108,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
@@ -9251,7 +9120,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -9260,16 +9129,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -9282,6 +9153,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -9297,15 +9169,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
@@ -9315,13 +9187,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -9336,7 +9208,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
@@ -9352,6 +9224,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -9383,38 +9264,37 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37" />
@@ -9453,9 +9333,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -9475,13 +9355,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -9489,11 +9369,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -9516,7 +9396,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -9540,9 +9420,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>

--- a/src/report_server/report_server.cdx.xml
+++ b/src/report_server/report_server.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:702caa21-9b84-4b45-8d50-3cc05484fba3" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d9bdca78-58b7-4a78-a2ab-aa217dc557b3" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.288080000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.834174000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <name>report_server</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/report_server@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0 bin-target-0">
           <name>report_server</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/report_server@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2542,7 +2542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2709,7 +2709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2747,7 +2747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2766,7 +2766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2835,7 +2835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2854,7 +2854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2876,7 +2876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2895,7 +2895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2964,7 +2964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -2983,7 +2983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3002,7 +3002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3021,7 +3021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3040,7 +3040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3059,7 +3059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3097,7 +3097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3116,7 +3116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3135,7 +3135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3154,7 +3154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3173,7 +3173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3192,7 +3192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3211,7 +3211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3230,7 +3230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3368,7 +3368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3390,7 +3390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3409,7 +3409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3452,7 +3452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3499,7 +3499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3565,7 +3565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3690,7 +3690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3758,7 +3758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3846,7 +3846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3907,7 +3907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3929,7 +3929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4108,7 +4108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4127,7 +4127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4152,7 +4152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4217,7 +4217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4263,7 +4263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4505,7 +4505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4575,7 +4575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4597,7 +4597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4706,7 +4706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4843,7 +4843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4868,7 +4868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4911,7 +4911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4936,7 +4936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4974,7 +4974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -4993,7 +4993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5059,7 +5059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5081,7 +5081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5122,7 +5122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5163,7 +5163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5182,7 +5182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5264,7 +5264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5333,7 +5333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5352,7 +5352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5371,7 +5371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5520,7 +5520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5608,7 +5608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5701,7 +5701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5723,7 +5723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5745,7 +5745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5764,7 +5764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5783,7 +5783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5802,7 +5802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5821,7 +5821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5846,7 +5846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5930,7 +5930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5949,7 +5949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -5993,7 +5993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6135,7 +6135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6160,7 +6160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6182,7 +6182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6229,7 +6229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6279,7 +6279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6425,7 +6425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6620,7 +6620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6642,7 +6642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6702,7 +6702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6727,7 +6727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6749,7 +6749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6875,7 +6875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6937,7 +6937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6959,7 +6959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -6984,7 +6984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7006,7 +7006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7028,7 +7028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7050,7 +7050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7107,7 +7107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7132,7 +7132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7179,7 +7179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7198,7 +7198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7283,7 +7283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7481,7 +7481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7594,7 +7594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7641,7 +7641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7663,7 +7663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7701,7 +7701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7720,7 +7720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7739,7 +7739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7776,7 +7776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7823,7 +7823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7866,7 +7866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7932,7 +7932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7975,7 +7975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -7994,7 +7994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8016,7 +8016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8060,7 +8060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8145,7 +8145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8240,7 +8240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8265,7 +8265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8488,7 +8488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8575,7 +8575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8619,7 +8619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8663,7 +8663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8685,7 +8685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8729,7 +8729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8770,7 +8770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8876,7 +8876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8923,7 +8923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8970,7 +8970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9033,7 +9033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9052,7 +9052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9071,7 +9071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9093,7 +9093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9115,7 +9115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9137,7 +9137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9206,7 +9206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9225,7 +9225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9244,7 +9244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9263,7 +9263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9282,7 +9282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9360,7 +9360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9382,7 +9382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9514,7 +9514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9596,7 +9596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9621,7 +9621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9728,7 +9728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9753,7 +9753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9841,7 +9841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9863,7 +9863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9888,7 +9888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -9995,7 +9995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10020,7 +10020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10063,7 +10063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10085,7 +10085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10170,7 +10170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10189,7 +10189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10211,7 +10211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10271,7 +10271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10381,7 +10381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10403,7 +10403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10422,7 +10422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10522,7 +10522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10666,7 +10666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10685,7 +10685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10704,7 +10704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10777,7 +10777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10821,7 +10821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10843,7 +10843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10862,7 +10862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10971,7 +10971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -10996,7 +10996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11015,7 +11015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11053,7 +11053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11078,7 +11078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11140,7 +11140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11162,7 +11162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11187,7 +11187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11206,7 +11206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11225,7 +11225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11288,7 +11288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11310,7 +11310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11329,7 +11329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11386,7 +11386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11436,7 +11436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11461,7 +11461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11568,7 +11568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11587,7 +11587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11682,7 +11682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11802,7 +11802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11886,7 +11886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11943,7 +11943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12015,7 +12015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12037,7 +12037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12062,7 +12062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12166,7 +12166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12188,7 +12188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12207,7 +12207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12226,7 +12226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12248,7 +12248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12292,7 +12292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12311,7 +12311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12330,7 +12330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12355,7 +12355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12380,7 +12380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12424,7 +12424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12581,7 +12581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12642,7 +12642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12721,7 +12721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12790,7 +12790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13142,7 +13142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13164,7 +13164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13183,7 +13183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13232,7 +13232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13257,7 +13257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13307,7 +13307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13332,7 +13332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13376,7 +13376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13395,7 +13395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13414,7 +13414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13436,7 +13436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13498,7 +13498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13558,7 +13558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13577,7 +13577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13662,7 +13662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13746,7 +13746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13870,7 +13870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13958,7 +13958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14005,7 +14005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14030,7 +14030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14055,7 +14055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14124,7 +14124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14146,7 +14146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14168,7 +14168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14215,7 +14215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14334,7 +14334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14378,7 +14378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14400,7 +14400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14573,7 +14573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14598,7 +14598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14617,7 +14617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14661,7 +14661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14680,7 +14680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14705,7 +14705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14834,7 +14834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14878,7 +14878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14900,7 +14900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14925,7 +14925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14950,7 +14950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -14988,7 +14988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15038,7 +15038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15057,7 +15057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15076,7 +15076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15095,7 +15095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15117,7 +15117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15139,7 +15139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15161,7 +15161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15183,7 +15183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15277,7 +15277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15296,7 +15296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15321,7 +15321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15346,7 +15346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15371,7 +15371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15396,7 +15396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15421,7 +15421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15446,7 +15446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15471,7 +15471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15515,7 +15515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15537,7 +15537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15562,7 +15562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15584,7 +15584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15603,7 +15603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15685,7 +15685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15732,7 +15732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15807,7 +15807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15856,7 +15856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15875,7 +15875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15894,7 +15894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15916,7 +15916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15938,7 +15938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -15960,7 +15960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -15985,7 +15985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16004,7 +16004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16023,7 +16023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16045,7 +16045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16083,7 +16083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16102,7 +16102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16121,7 +16121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16167,7 +16167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16189,7 +16189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16211,7 +16211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16287,7 +16287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16309,7 +16309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16353,7 +16353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16375,7 +16375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16397,7 +16397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16422,7 +16422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16447,7 +16447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16491,7 +16491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16513,7 +16513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16651,7 +16651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16673,7 +16673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16716,7 +16716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16738,7 +16738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16784,7 +16784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16809,7 +16809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16853,7 +16853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16878,7 +16878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16900,7 +16900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16925,7 +16925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17063,7 +17063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17107,7 +17107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17151,7 +17151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17173,7 +17173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17192,7 +17192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17264,7 +17264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17286,7 +17286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17305,7 +17305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17367,7 +17367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17389,7 +17389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17411,7 +17411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17451,7 +17451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17473,7 +17473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17498,7 +17498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17587,7 +17587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17710,7 +17710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17735,7 +17735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17757,7 +17757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17776,7 +17776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17798,7 +17798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17817,7 +17817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17836,7 +17836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17855,7 +17855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17874,7 +17874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17893,7 +17893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -17975,7 +17975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18013,7 +18013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18032,7 +18032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18072,7 +18072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18094,7 +18094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18113,7 +18113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18135,7 +18135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19243,7 +19243,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19289,7 +19289,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19320,7 +19320,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19331,12 +19331,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/report_server#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />

--- a/src/report_server/report_server.cdx.xml
+++ b/src/report_server/report_server.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:77dd3a1b-09ac-43dd-90e1-061c654cf05e" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:702caa21-9b84-4b45-8d50-3cc05484fba3" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.291703000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.288080000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/report_server#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
       <name>report_server</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/report_server@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/report_server#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0 bin-target-0">
           <name>report_server</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/report_server@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -125,7 +157,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -134,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -494,19 +1917,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -556,25 +1979,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -644,19 +2089,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -666,19 +2111,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -688,19 +2133,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -710,19 +2155,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -732,19 +2177,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -754,19 +2199,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -776,19 +2221,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -798,19 +2243,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -820,19 +2265,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -842,19 +2287,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -864,19 +2309,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -886,19 +2331,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -908,19 +2353,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -930,19 +2375,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1096,6 +2541,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1121,6 +2585,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1137,6 +2620,50 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1159,6 +2686,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1436,19 +2982,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1683,19 +3229,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1737,6 +3283,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -1956,6 +3520,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -1978,6 +3561,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2019,6 +3627,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2159,6 +3792,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2561,6 +4216,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2627,6 +4347,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2832,25 +4574,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -2982,6 +4705,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3051,6 +4799,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3245,6 +5011,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3308,6 +5099,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3431,6 +5241,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation</name>
+      <version>0.9.4</version>
+      <description>Bindings to Core Foundation for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core-foundation@0.9.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/core_detect</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
       <author>RustCrypto Developers</author>
       <name>cpufeatures</name>
@@ -3444,6 +5301,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3577,18 +5456,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3675,6 +5554,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3775,6 +5676,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/block-modes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -3945,729 +5867,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4810,6 +6027,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5079,6 +6318,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5257,6 +6515,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5418,6 +6726,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5456,6 +6830,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5779,6 +7175,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6225,28 +7640,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6358,6 +7751,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6733,6 +8144,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6757,27 +8193,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -6855,31 +8289,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -6902,31 +8311,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7169,18 +8553,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7425,6 +8809,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7488,6 +8894,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7557,6 +8988,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7617,6 +9070,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7639,19 +9114,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -7821,22 +9340,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8054,19 +9595,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8101,25 +9642,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8180,6 +9784,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8283,6 +9909,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8302,6 +9947,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8352,19 +10019,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8502,22 +10169,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8540,6 +10229,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8647,6 +10355,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8913,6 +10665,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
       <name>num_threads</name>
@@ -8983,24 +10773,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9089,6 +10861,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9158,18 +10949,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9348,31 +11139,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9458,19 +11224,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9540,6 +11306,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -9997,6 +11782,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10210,44 +12036,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10423,7 +12211,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -10832,6 +12620,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -10857,18 +12666,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -11002,19 +12811,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11202,28 +13011,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11626,6 +13435,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11745,19 +13576,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -11981,60 +13812,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12194,28 +14004,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12241,19 +14029,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12266,19 +14054,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12423,25 +14211,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -12759,6 +14528,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -12938,19 +14729,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -12998,6 +14789,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13114,19 +14924,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13139,44 +14949,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13202,19 +14987,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -13839,6 +15624,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -13861,77 +15684,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -13951,116 +15703,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14186,6 +15828,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14454,49 +16120,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -14568,19 +16210,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -14892,27 +16534,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
-      <description>OpenTelemetry integration for tracing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -15073,19 +16694,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15193,7 +16813,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -15721,19 +17341,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16392,6 +18012,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -16519,6 +18158,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -16535,7 +18184,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -16547,12 +18196,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -16570,23 +18219,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16594,7 +19266,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -16602,85 +19274,75 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/report_server#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/report_server#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -16739,16 +19401,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -16756,40 +19419,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16799,41 +19462,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -16843,58 +19507,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -16937,22 +19602,63 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -16978,7 +19684,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -16997,7 +19703,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17005,7 +19711,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -17013,7 +19719,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17034,7 +19740,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17044,9 +19750,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17056,7 +19762,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17074,7 +19780,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17092,7 +19798,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17111,7 +19817,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17124,7 +19830,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17139,35 +19845,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17181,23 +19881,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17207,7 +19907,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17217,10 +19917,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17236,7 +19936,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17246,9 +19946,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17291,7 +19996,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17309,6 +20014,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17317,10 +20023,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -17342,10 +20063,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -17415,16 +20138,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -17458,10 +20198,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -17479,6 +20215,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -17496,6 +20237,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -17507,7 +20251,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -17533,6 +20277,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -17542,6 +20287,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -17555,10 +20301,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -17576,10 +20330,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -17590,7 +20344,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -17612,6 +20369,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -17656,511 +20419,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18195,6 +20454,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18203,10 +20467,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18216,8 +20480,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18238,16 +20502,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
@@ -18267,6 +20532,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18284,7 +20557,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18296,12 +20569,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18329,7 +20620,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -18345,6 +20636,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -18398,21 +20692,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -18423,19 +20717,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18443,9 +20724,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -18472,6 +20753,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -18491,7 +20777,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -18521,15 +20807,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -18538,7 +20821,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18547,7 +20830,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -18559,31 +20842,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -18599,11 +20865,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -18659,9 +20922,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -18694,9 +20957,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -18704,12 +20970,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -18726,10 +20998,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -18753,13 +21030,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -18773,8 +21066,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18803,10 +21096,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -18825,21 +21121,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -18849,27 +21154,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18878,7 +21195,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18888,7 +21205,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -18901,13 +21218,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
@@ -18919,6 +21244,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
@@ -18965,48 +21299,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19016,8 +21329,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19028,7 +21344,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19064,9 +21380,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19075,17 +21388,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19093,18 +21406,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19115,6 +21428,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19141,12 +21460,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19188,11 +21507,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19224,16 +21548,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19248,7 +21562,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19270,14 +21584,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19376,14 +21690,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -19397,21 +21715,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -19422,13 +21740,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19453,9 +21771,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -19496,7 +21813,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -19518,7 +21835,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -19527,7 +21844,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19536,7 +21853,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -19562,7 +21879,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -19571,6 +21888,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -19578,7 +21930,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -19591,19 +21943,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -19615,7 +21967,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -19657,12 +22009,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
@@ -19671,21 +22023,19 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -19693,7 +22043,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -19701,7 +22051,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -19715,18 +22065,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19734,7 +22080,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19742,10 +22088,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19756,7 +22103,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19766,7 +22113,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -19785,29 +22132,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19820,6 +22161,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19836,14 +22178,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19864,12 +22206,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19881,7 +22228,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19890,12 +22237,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -19919,20 +22277,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19958,7 +22313,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19971,11 +22326,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -19994,7 +22349,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20042,7 +22397,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20078,7 +22433,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20100,7 +22455,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20113,7 +22468,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20176,7 +22531,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20185,100 +22540,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -20292,6 +22567,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20324,7 +22600,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -20343,48 +22619,43 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -20429,9 +22700,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20451,13 +22722,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20465,11 +22736,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20487,14 +22758,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20536,7 +22799,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20579,6 +22842,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -20593,7 +22857,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -20602,7 +22866,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20648,7 +22912,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -20703,13 +22967,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -20809,6 +23073,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/schema/schema.cdx.xml
+++ b/src/schema/schema.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d0e50e00-3b33-477d-a9a1-750d6f3f1a6b" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:7fc21e58-37ee-45d2-9c52-c7775702a9cb" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.974791000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.548212000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0 bin-target-0">
           <name>schema</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/schema@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1610,7 +1610,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1619,7 +1619,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1628,7 +1628,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1637,7 +1637,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1647,7 +1647,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1735,7 +1735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1757,7 +1757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1779,7 +1779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1801,7 +1801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1826,10 +1826,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1851,7 +1851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1876,7 +1876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1901,7 +1901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1998,7 +1998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2038,7 +2038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2060,7 +2060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2082,10 +2082,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2126,7 +2126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2170,7 +2170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2192,7 +2192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2214,7 +2214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2236,7 +2236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2258,7 +2258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2280,7 +2280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2302,7 +2302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2324,7 +2324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2346,7 +2346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2368,7 +2368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2390,7 +2390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2412,7 +2412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2434,7 +2434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2456,7 +2456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2478,7 +2478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2584,7 +2584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2603,7 +2603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2622,7 +2622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2641,7 +2641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2666,7 +2666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2685,7 +2685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2704,7 +2704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2729,7 +2729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2754,7 +2754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2773,7 +2773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2795,7 +2795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2814,7 +2814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2833,7 +2833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2852,7 +2852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2871,7 +2871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2893,7 +2893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2940,7 +2940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2959,7 +2959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2981,7 +2981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3000,7 +3000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3088,7 +3088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3107,7 +3107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3126,7 +3126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3145,7 +3145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3164,7 +3164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3183,7 +3183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3202,7 +3202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3221,7 +3221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3240,7 +3240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3259,7 +3259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3278,7 +3278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3297,7 +3297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3316,7 +3316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3335,7 +3335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3354,7 +3354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3373,7 +3373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3473,7 +3473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3495,7 +3495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3514,7 +3514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3557,7 +3557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3604,7 +3604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3626,7 +3626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3670,7 +3670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3695,7 +3695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3720,7 +3720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3745,7 +3745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3795,7 +3795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3863,7 +3863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4012,7 +4012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4034,7 +4034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4056,7 +4056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4078,7 +4078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4103,7 +4103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4128,7 +4128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4150,7 +4150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4172,7 +4172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4194,7 +4194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4213,7 +4213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4232,7 +4232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4257,7 +4257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4279,7 +4279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4322,7 +4322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4368,7 +4368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4409,7 +4409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4434,7 +4434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4456,7 +4456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4500,7 +4500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4519,7 +4519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4610,7 +4610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4680,7 +4680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4702,7 +4702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4724,7 +4724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4746,7 +4746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4811,7 +4811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4948,7 +4948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4973,7 +4973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5016,7 +5016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5041,7 +5041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5060,7 +5060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5079,7 +5079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5098,7 +5098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5164,7 +5164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5186,7 +5186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5208,7 +5208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5246,7 +5246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5268,7 +5268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5287,7 +5287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5306,7 +5306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5325,7 +5325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5407,7 +5407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5476,7 +5476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5495,7 +5495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5514,7 +5514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5536,7 +5536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5663,7 +5663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5751,7 +5751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5776,7 +5776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5823,7 +5823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5869,7 +5869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5891,7 +5891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5913,7 +5913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5932,7 +5932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5951,7 +5951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5970,7 +5970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5989,7 +5989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6014,7 +6014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6098,7 +6098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6117,7 +6117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6139,7 +6139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6161,7 +6161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6183,7 +6183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6249,7 +6249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6306,7 +6306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6325,7 +6325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6350,7 +6350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6372,7 +6372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6394,7 +6394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6419,7 +6419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6444,7 +6444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6509,7 +6509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6528,7 +6528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6553,7 +6553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6575,7 +6575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6662,7 +6662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6684,7 +6684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6706,7 +6706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6728,7 +6728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6753,7 +6753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6778,7 +6778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6857,7 +6857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6879,7 +6879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6901,7 +6901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6920,7 +6920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6939,7 +6939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6964,7 +6964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6986,7 +6986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7008,7 +7008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7030,7 +7030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7052,7 +7052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7071,7 +7071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7093,7 +7093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7112,7 +7112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7174,7 +7174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7196,7 +7196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7221,7 +7221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7243,7 +7243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7265,7 +7265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7287,7 +7287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7306,7 +7306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7344,7 +7344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7369,7 +7369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7391,7 +7391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7416,7 +7416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7435,7 +7435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7520,7 +7520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7563,7 +7563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7651,7 +7651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7718,7 +7718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7831,7 +7831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7878,7 +7878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7900,7 +7900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7919,7 +7919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7938,7 +7938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7957,7 +7957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7976,7 +7976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8013,7 +8013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8056,7 +8056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8081,7 +8081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8124,7 +8124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8190,7 +8190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8233,7 +8233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8252,7 +8252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8274,7 +8274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8296,7 +8296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8318,7 +8318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8340,7 +8340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8362,7 +8362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8384,7 +8384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8403,7 +8403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8498,7 +8498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8523,7 +8523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8548,7 +8548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8573,7 +8573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8746,7 +8746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8833,7 +8833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8877,7 +8877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8921,7 +8921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8943,7 +8943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8965,7 +8965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8987,7 +8987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9009,7 +9009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9028,7 +9028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9047,7 +9047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9153,7 +9153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9175,7 +9175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9200,7 +9200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9222,7 +9222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9247,7 +9247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9266,7 +9266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9332,7 +9332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9351,7 +9351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9370,7 +9370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9392,7 +9392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9414,7 +9414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9436,7 +9436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9458,7 +9458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9480,7 +9480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9505,7 +9505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9524,7 +9524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9543,7 +9543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9562,7 +9562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9581,7 +9581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9600,7 +9600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9659,7 +9659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9681,7 +9681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9706,7 +9706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9728,7 +9728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9769,7 +9769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9813,7 +9813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9835,7 +9835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9876,7 +9876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9895,7 +9895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9920,7 +9920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9942,7 +9942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9964,7 +9964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9983,7 +9983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10002,7 +10002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10027,7 +10027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10052,7 +10052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10071,7 +10071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10140,7 +10140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10165,7 +10165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10187,7 +10187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10253,7 +10253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10275,7 +10275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10319,7 +10319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10344,7 +10344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10387,7 +10387,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10409,7 +10409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10431,7 +10431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10453,7 +10453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10475,7 +10475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10494,7 +10494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10513,7 +10513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10535,7 +10535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10620,7 +10620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10708,7 +10708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10730,7 +10730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10752,7 +10752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10771,7 +10771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10790,7 +10790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10840,7 +10840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10890,7 +10890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11053,7 +11053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11072,7 +11072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11145,7 +11145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11189,7 +11189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11211,7 +11211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11230,7 +11230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11249,7 +11249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11271,7 +11271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11339,7 +11339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11364,7 +11364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11383,7 +11383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11402,7 +11402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11421,7 +11421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11446,7 +11446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11468,7 +11468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11508,7 +11508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11555,7 +11555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11574,7 +11574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11593,7 +11593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11615,7 +11615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11656,7 +11656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11678,7 +11678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11697,7 +11697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11735,7 +11735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11779,7 +11779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11804,7 +11804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11829,7 +11829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11854,7 +11854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11923,7 +11923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11942,7 +11942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11961,7 +11961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11980,7 +11980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12053,7 +12053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12075,7 +12075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12132,7 +12132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12154,7 +12154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12176,7 +12176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12195,7 +12195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12279,7 +12279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12317,7 +12317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12336,7 +12336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12358,7 +12358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12408,7 +12408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12430,7 +12430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12455,7 +12455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12502,7 +12502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12521,7 +12521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12540,7 +12540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12559,7 +12559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12581,7 +12581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12600,7 +12600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12619,7 +12619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12641,7 +12641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12663,7 +12663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12685,7 +12685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12704,7 +12704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12723,7 +12723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12748,7 +12748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12773,7 +12773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12795,7 +12795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12817,7 +12817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12839,7 +12839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12861,7 +12861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12883,7 +12883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12905,7 +12905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12927,7 +12927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12949,7 +12949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12974,7 +12974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13035,7 +13035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13114,7 +13114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13136,7 +13136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13158,7 +13158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13183,7 +13183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13475,7 +13475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13494,7 +13494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13513,7 +13513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13535,7 +13535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13557,7 +13557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13576,7 +13576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13625,7 +13625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13650,7 +13650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13675,7 +13675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13700,7 +13700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13725,7 +13725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13747,7 +13747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13769,7 +13769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13788,7 +13788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13807,7 +13807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13829,7 +13829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13851,7 +13851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13891,7 +13891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13910,7 +13910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13932,7 +13932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13951,7 +13951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13970,7 +13970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13992,7 +13992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14014,7 +14014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14033,7 +14033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14052,7 +14052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14071,7 +14071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14093,7 +14093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14112,7 +14112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14174,7 +14174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14196,7 +14196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14320,7 +14320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14342,7 +14342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14364,7 +14364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14408,7 +14408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14455,7 +14455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14480,7 +14480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14505,7 +14505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14530,7 +14530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14555,7 +14555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14580,7 +14580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14602,7 +14602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14624,7 +14624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14646,7 +14646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14668,7 +14668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14690,7 +14690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14712,7 +14712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14734,7 +14734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14759,7 +14759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14778,7 +14778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14800,7 +14800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14822,7 +14822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14847,7 +14847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14872,7 +14872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14897,7 +14897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14919,7 +14919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14938,7 +14938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14960,7 +14960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14982,7 +14982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15004,7 +15004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15026,7 +15026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15092,7 +15092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15177,7 +15177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15202,7 +15202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15221,7 +15221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15243,7 +15243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15287,7 +15287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15306,7 +15306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15331,7 +15331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15350,7 +15350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15375,7 +15375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15397,7 +15397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15438,7 +15438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15457,7 +15457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15479,7 +15479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15501,7 +15501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15523,7 +15523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15545,7 +15545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15567,7 +15567,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15589,7 +15589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15614,7 +15614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15639,7 +15639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15677,7 +15677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15727,7 +15727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15746,7 +15746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15765,7 +15765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15784,7 +15784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15806,7 +15806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15828,7 +15828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15850,7 +15850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15872,7 +15872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15894,7 +15894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15966,7 +15966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15985,7 +15985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16010,7 +16010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16035,7 +16035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16060,7 +16060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16085,7 +16085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16110,7 +16110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16135,7 +16135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16160,7 +16160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16185,7 +16185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16210,7 +16210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16232,7 +16232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16254,7 +16254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16276,7 +16276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16301,7 +16301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16323,7 +16323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16342,7 +16342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16424,7 +16424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16446,7 +16446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16471,7 +16471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16546,7 +16546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16595,7 +16595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16614,7 +16614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16633,7 +16633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16655,7 +16655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16677,7 +16677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16699,7 +16699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16724,7 +16724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16743,7 +16743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16762,7 +16762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16784,7 +16784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16822,7 +16822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16841,7 +16841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16860,7 +16860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16906,7 +16906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16928,7 +16928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16968,7 +16968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17044,7 +17044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17066,7 +17066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17088,7 +17088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17110,7 +17110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17132,7 +17132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17154,7 +17154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17179,7 +17179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17204,7 +17204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17226,7 +17226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17248,7 +17248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17270,7 +17270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17313,7 +17313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17335,7 +17335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17357,7 +17357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17379,7 +17379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17404,7 +17404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17454,7 +17454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17476,7 +17476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17519,7 +17519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17541,7 +17541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17612,7 +17612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17637,7 +17637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17681,7 +17681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17706,7 +17706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17728,7 +17728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17753,7 +17753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17778,7 +17778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17800,7 +17800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17822,7 +17822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17844,7 +17844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17891,7 +17891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17913,7 +17913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17935,7 +17935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18001,7 +18001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18020,7 +18020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18045,7 +18045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18067,7 +18067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18092,7 +18092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18114,7 +18114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18133,7 +18133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18170,7 +18170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18195,7 +18195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18217,7 +18217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18239,7 +18239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18279,7 +18279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18301,7 +18301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18326,7 +18326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18415,7 +18415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18497,7 +18497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18538,7 +18538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18563,7 +18563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18585,7 +18585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18604,7 +18604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18626,7 +18626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18645,7 +18645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18664,7 +18664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18683,7 +18683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18702,7 +18702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18721,7 +18721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18803,7 +18803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18841,7 +18841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18860,7 +18860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18900,7 +18900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18922,7 +18922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18941,7 +18941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18963,7 +18963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20084,18 +20084,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20114,12 +20114,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20165,7 +20165,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20196,24 +20196,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20224,10 +20224,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20237,7 +20237,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20248,7 +20248,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20264,34 +20264,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20302,26 +20302,26 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20329,9 +20329,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/schema/schema.cdx.xml
+++ b/src/schema/schema.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d0e50e00-3b33-477d-a9a1-750d6f3f1a6b" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.974791000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0 bin-target-0">
+          <name>schema</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/schema@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,42 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1627,24 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2301,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2700,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5207,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5299,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5822,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6154,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6571,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8034,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +9008,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9262,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10070,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10594,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10767,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11731,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14013,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14479,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14517,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14645,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14755,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14918,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14956,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15008,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15242,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15327,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15500,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15557,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16059,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16122,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16949,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17291,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17400,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17583,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19669,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20084,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20196,100 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20301,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20471,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20626,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21311,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21320,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21395,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21477,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21554,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21810,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +22004,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +22056,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22212,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22303,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22332,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22517,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +23058,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23167,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23187,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23252,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23276,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23306,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23377,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23426,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23440,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +23656,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23667,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23818,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23951,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23985,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +24020,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/search/search.cdx.xml
+++ b/src/search/search.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:5668811d-75c7-40d8-bc22-92d7b781801a" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.883291000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0 bin-target-0">
+          <name>search</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/search@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -978,6 +993,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1153,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1557,6 +1608,24 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1634,24 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2642,6 +2729,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5236,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5698,6 +5829,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/block-modes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
         </reference>
       </externalReferences>
     </component>
@@ -6403,6 +6559,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8022,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8963,6 +9187,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/jiff</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +10538,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10711,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +12911,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13642,6 +14051,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14517,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14555,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14164,6 +14680,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SeaQL/sea-query</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14937,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14975,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14657,6 +15258,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/signal-hook</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16015,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16078,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15750,6 +16423,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/myrrlyn/tap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +16927,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17269,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17378,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19031,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18863,6 +19629,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19005,6 +19784,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19356,6 +20159,43 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +20206,91 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +20594,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21279,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20406,6 +21362,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20552,6 +21514,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21770,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -21016,6 +21991,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -21271,6 +22255,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22284,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21725,6 +22720,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -22011,6 +23034,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23143,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23163,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23228,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22204,9 +23274,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22266,6 +23344,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22525,6 +23609,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23620,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +23686,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22677,6 +23771,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +23905,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +23939,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />

--- a/src/search/search.cdx.xml
+++ b/src/search/search.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:5668811d-75c7-40d8-bc22-92d7b781801a" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d56f205c-b483-4e95-bc54-9455b8f728cd" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.883291000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.461698000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0 bin-target-0">
           <name>search</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/search@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -815,7 +815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -837,7 +837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -845,7 +845,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -859,7 +859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -867,7 +867,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -888,7 +888,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -899,7 +899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -907,7 +907,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -921,7 +921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -929,7 +929,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -947,7 +947,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -965,7 +965,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -983,7 +983,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -994,24 +994,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1019,7 +1019,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1030,7 +1030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1038,7 +1038,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1049,7 +1049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1057,7 +1057,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1068,7 +1068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1076,7 +1076,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1087,7 +1087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1095,7 +1095,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1106,7 +1106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1114,7 +1114,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1125,7 +1125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1133,7 +1133,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1144,7 +1144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1152,7 +1152,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1163,7 +1163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1171,7 +1171,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1182,7 +1182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1190,7 +1190,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1201,7 +1201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1209,7 +1209,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1220,7 +1220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1228,7 +1228,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1239,7 +1239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1247,7 +1247,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1258,7 +1258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1266,7 +1266,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1277,7 +1277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1285,7 +1285,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1296,7 +1296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1304,7 +1304,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1315,7 +1315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1323,7 +1323,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1334,7 +1334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1342,7 +1342,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1353,7 +1353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1361,7 +1361,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1372,7 +1372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1380,7 +1380,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1391,7 +1391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1399,7 +1399,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1410,7 +1410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1418,7 +1418,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1429,7 +1429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1437,7 +1437,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1448,7 +1448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1456,7 +1456,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1467,7 +1467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1475,7 +1475,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1486,7 +1486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1494,7 +1494,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1505,7 +1505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1513,7 +1513,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1524,7 +1524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1532,7 +1532,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1543,7 +1543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1551,7 +1551,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1562,7 +1562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1570,7 +1570,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1581,7 +1581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1589,7 +1589,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1599,7 +1599,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1608,7 +1608,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1617,7 +1617,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1626,7 +1626,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1635,7 +1635,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1644,7 +1644,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1654,7 +1654,7 @@
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1742,7 +1742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1764,7 +1764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1786,7 +1786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1808,7 +1808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1833,10 +1833,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1858,7 +1858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1883,7 +1883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1908,7 +1908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2005,7 +2005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2045,7 +2045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2067,7 +2067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2089,10 +2089,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2133,7 +2133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2177,7 +2177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2199,7 +2199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2221,7 +2221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2243,7 +2243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2265,7 +2265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2287,7 +2287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2309,7 +2309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2331,7 +2331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2353,7 +2353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2375,7 +2375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2397,7 +2397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2419,7 +2419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2441,7 +2441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2463,7 +2463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2485,7 +2485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2507,7 +2507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2613,7 +2613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2632,7 +2632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2651,7 +2651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2670,7 +2670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2695,7 +2695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2714,7 +2714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2733,7 +2733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2758,7 +2758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2783,7 +2783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2802,7 +2802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2824,7 +2824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2843,7 +2843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2862,7 +2862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2881,7 +2881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2900,7 +2900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2922,7 +2922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2969,7 +2969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2988,7 +2988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3010,7 +3010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3029,7 +3029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3117,7 +3117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3136,7 +3136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3155,7 +3155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3174,7 +3174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3193,7 +3193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3212,7 +3212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3231,7 +3231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3250,7 +3250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3269,7 +3269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3288,7 +3288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3307,7 +3307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3326,7 +3326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3345,7 +3345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3364,7 +3364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3383,7 +3383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3402,7 +3402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3502,7 +3502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3524,7 +3524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3543,7 +3543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3586,7 +3586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3633,7 +3633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3655,7 +3655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3699,7 +3699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3724,7 +3724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3749,7 +3749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3774,7 +3774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3824,7 +3824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3892,7 +3892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3980,7 +3980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4041,7 +4041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4063,7 +4063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4085,7 +4085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4107,7 +4107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4132,7 +4132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4157,7 +4157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4179,7 +4179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4201,7 +4201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4223,7 +4223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4242,7 +4242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4261,7 +4261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4286,7 +4286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4308,7 +4308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4397,7 +4397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4438,7 +4438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4463,7 +4463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4485,7 +4485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4529,7 +4529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4548,7 +4548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4639,7 +4639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4709,7 +4709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4731,7 +4731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4753,7 +4753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4775,7 +4775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4840,7 +4840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4977,7 +4977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5002,7 +5002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5045,7 +5045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5089,7 +5089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5108,7 +5108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5127,7 +5127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5193,7 +5193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5215,7 +5215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5237,7 +5237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5275,7 +5275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5297,7 +5297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5316,7 +5316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5335,7 +5335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5417,7 +5417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5486,7 +5486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5505,7 +5505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5524,7 +5524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5546,7 +5546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5673,7 +5673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5761,7 +5761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5786,7 +5786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5833,7 +5833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5879,7 +5879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5901,7 +5901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5923,7 +5923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5942,7 +5942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5961,7 +5961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5980,7 +5980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5999,7 +5999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6024,7 +6024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6108,7 +6108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6127,7 +6127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6149,7 +6149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6171,7 +6171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6237,7 +6237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6294,7 +6294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6313,7 +6313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6360,7 +6360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6382,7 +6382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6407,7 +6407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6432,7 +6432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6457,7 +6457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6497,7 +6497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6563,7 +6563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6650,7 +6650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6672,7 +6672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6694,7 +6694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6716,7 +6716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6741,7 +6741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6766,7 +6766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6845,7 +6845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6867,7 +6867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6889,7 +6889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6908,7 +6908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6927,7 +6927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6952,7 +6952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6974,7 +6974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6996,7 +6996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7018,7 +7018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7040,7 +7040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7059,7 +7059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7081,7 +7081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7100,7 +7100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7162,7 +7162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7184,7 +7184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7209,7 +7209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7231,7 +7231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7253,7 +7253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7275,7 +7275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7294,7 +7294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7332,7 +7332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7357,7 +7357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7379,7 +7379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7404,7 +7404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7423,7 +7423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7508,7 +7508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7551,7 +7551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7639,7 +7639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7706,7 +7706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7819,7 +7819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7866,7 +7866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7888,7 +7888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7907,7 +7907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7926,7 +7926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7945,7 +7945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7964,7 +7964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8001,7 +8001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8044,7 +8044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8069,7 +8069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8112,7 +8112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8178,7 +8178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8221,7 +8221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8240,7 +8240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8262,7 +8262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8284,7 +8284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8306,7 +8306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8328,7 +8328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8350,7 +8350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8372,7 +8372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8391,7 +8391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8486,7 +8486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8511,7 +8511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8536,7 +8536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8561,7 +8561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8734,7 +8734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8821,7 +8821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8865,7 +8865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8909,7 +8909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8931,7 +8931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8953,7 +8953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8975,7 +8975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8997,7 +8997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9016,7 +9016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9122,7 +9122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9144,7 +9144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9169,7 +9169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9191,7 +9191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9213,7 +9213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9238,7 +9238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9320,7 +9320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9339,7 +9339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9361,7 +9361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9383,7 +9383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9405,7 +9405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9427,7 +9427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9449,7 +9449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9474,7 +9474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9493,7 +9493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9512,7 +9512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9531,7 +9531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9550,7 +9550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9569,7 +9569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9628,7 +9628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9650,7 +9650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9675,7 +9675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9697,7 +9697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9738,7 +9738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9782,7 +9782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9804,7 +9804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9845,7 +9845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9864,7 +9864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9889,7 +9889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9911,7 +9911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9933,7 +9933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9952,7 +9952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9971,7 +9971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9996,7 +9996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10021,7 +10021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10084,7 +10084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10109,7 +10109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10131,7 +10131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10156,7 +10156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10178,7 +10178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10197,7 +10197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10219,7 +10219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10241,7 +10241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10263,7 +10263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10288,7 +10288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10331,7 +10331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10353,7 +10353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10375,7 +10375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10397,7 +10397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10419,7 +10419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10438,7 +10438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10457,7 +10457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10479,7 +10479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10564,7 +10564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10652,7 +10652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10674,7 +10674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10696,7 +10696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10715,7 +10715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10734,7 +10734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10784,7 +10784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10834,7 +10834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10978,7 +10978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10997,7 +10997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11016,7 +11016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11089,7 +11089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11133,7 +11133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11155,7 +11155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11174,7 +11174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11193,7 +11193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11215,7 +11215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11283,7 +11283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11308,7 +11308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11327,7 +11327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11346,7 +11346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11365,7 +11365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11390,7 +11390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11412,7 +11412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11452,7 +11452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11474,7 +11474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11499,7 +11499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11518,7 +11518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11537,7 +11537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11559,7 +11559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11600,7 +11600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11622,7 +11622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11641,7 +11641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11698,7 +11698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11723,7 +11723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11748,7 +11748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11773,7 +11773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11842,7 +11842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11861,7 +11861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11880,7 +11880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11899,7 +11899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11972,7 +11972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11994,7 +11994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12051,7 +12051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12073,7 +12073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12095,7 +12095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12114,7 +12114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12198,7 +12198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12236,7 +12236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12255,7 +12255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12277,7 +12277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12327,7 +12327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12349,7 +12349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12374,7 +12374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12421,7 +12421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12440,7 +12440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12459,7 +12459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12478,7 +12478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12500,7 +12500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12519,7 +12519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12538,7 +12538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12560,7 +12560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12582,7 +12582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12604,7 +12604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12623,7 +12623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12642,7 +12642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12667,7 +12667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12692,7 +12692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12714,7 +12714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12736,7 +12736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12758,7 +12758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12780,7 +12780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12802,7 +12802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12824,7 +12824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12846,7 +12846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12868,7 +12868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12893,7 +12893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12912,7 +12912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -12934,7 +12934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -12959,7 +12959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -12981,7 +12981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13003,7 +13003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13073,7 +13073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13152,7 +13152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13174,7 +13174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13196,7 +13196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13221,7 +13221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13513,7 +13513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13532,7 +13532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13551,7 +13551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13573,7 +13573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13595,7 +13595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13614,7 +13614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13663,7 +13663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13688,7 +13688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13713,7 +13713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13738,7 +13738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13763,7 +13763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13785,7 +13785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13807,7 +13807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13826,7 +13826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13845,7 +13845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13867,7 +13867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13889,7 +13889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13929,7 +13929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13948,7 +13948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13970,7 +13970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13989,7 +13989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14008,7 +14008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14030,7 +14030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14052,7 +14052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14071,7 +14071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14090,7 +14090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14109,7 +14109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14131,7 +14131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14150,7 +14150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14212,7 +14212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14234,7 +14234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14358,7 +14358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14380,7 +14380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14402,7 +14402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14446,7 +14446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14518,7 +14518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14543,7 +14543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14568,7 +14568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14593,7 +14593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14618,7 +14618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14640,7 +14640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14662,7 +14662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14706,7 +14706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14728,7 +14728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14750,7 +14750,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14772,7 +14772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14797,7 +14797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14819,7 +14819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14841,7 +14841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14866,7 +14866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14891,7 +14891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14916,7 +14916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14938,7 +14938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14957,7 +14957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14979,7 +14979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15001,7 +15001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15023,7 +15023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15045,7 +15045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15111,7 +15111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15196,7 +15196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15221,7 +15221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15240,7 +15240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15262,7 +15262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15306,7 +15306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15325,7 +15325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15350,7 +15350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15375,7 +15375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15397,7 +15397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15438,7 +15438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15457,7 +15457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15479,7 +15479,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15501,7 +15501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15523,7 +15523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15545,7 +15545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15570,7 +15570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15595,7 +15595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15633,7 +15633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15683,7 +15683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15702,7 +15702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15721,7 +15721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15740,7 +15740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15762,7 +15762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15784,7 +15784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15806,7 +15806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15828,7 +15828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15850,7 +15850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15922,7 +15922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15941,7 +15941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15966,7 +15966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15991,7 +15991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16016,7 +16016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16041,7 +16041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16066,7 +16066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16091,7 +16091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16116,7 +16116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16141,7 +16141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16166,7 +16166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16188,7 +16188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16210,7 +16210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16232,7 +16232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16257,7 +16257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16279,7 +16279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16298,7 +16298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16380,7 +16380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16402,7 +16402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16427,7 +16427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -16449,7 +16449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16524,7 +16524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16573,7 +16573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16592,7 +16592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16611,7 +16611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16633,7 +16633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16655,7 +16655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16677,7 +16677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16702,7 +16702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16721,7 +16721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16740,7 +16740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16762,7 +16762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16800,7 +16800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16819,7 +16819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16838,7 +16838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16884,7 +16884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16906,7 +16906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16946,7 +16946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17022,7 +17022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17044,7 +17044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17066,7 +17066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17088,7 +17088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17110,7 +17110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17132,7 +17132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17157,7 +17157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17182,7 +17182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17204,7 +17204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17226,7 +17226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17248,7 +17248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17291,7 +17291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17313,7 +17313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17335,7 +17335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17357,7 +17357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17382,7 +17382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17432,7 +17432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17454,7 +17454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17497,7 +17497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17519,7 +17519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17565,7 +17565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17590,7 +17590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17634,7 +17634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17659,7 +17659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17681,7 +17681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17706,7 +17706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17731,7 +17731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17753,7 +17753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17775,7 +17775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17797,7 +17797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17844,7 +17844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17866,7 +17866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17888,7 +17888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17932,7 +17932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17954,7 +17954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17973,7 +17973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17998,7 +17998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18020,7 +18020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18045,7 +18045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18067,7 +18067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18086,7 +18086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18123,7 +18123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18148,7 +18148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18170,7 +18170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18192,7 +18192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18232,7 +18232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18254,7 +18254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18279,7 +18279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18368,7 +18368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18450,7 +18450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18491,7 +18491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18516,7 +18516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18538,7 +18538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18557,7 +18557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18579,7 +18579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18598,7 +18598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18617,7 +18617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18636,7 +18636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18655,7 +18655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18674,7 +18674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18756,7 +18756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18794,7 +18794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18813,7 +18813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18853,7 +18853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18875,7 +18875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18894,7 +18894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18916,7 +18916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20068,7 +20068,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20114,7 +20114,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20145,12 +20145,12 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -20159,7 +20159,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20169,7 +20169,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20180,7 +20180,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20196,7 +20196,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20207,7 +20207,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -20216,17 +20216,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -20236,7 +20236,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20245,21 +20245,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -20267,10 +20267,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -20282,9 +20282,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />

--- a/src/search_service/search_service.cdx.xml
+++ b/src/search_service/search_service.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:da2af25a-2df3-4b9a-8881-80ce9c2f7542" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.936610000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0 bin-target-0">
+          <name>search_service</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/search_service@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -978,6 +993,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1153,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1599,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1617,42 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1661,51 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2642,6 +2783,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5290,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5382,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5905,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6237,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6654,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8117,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +9091,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9304,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9367,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10175,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10699,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10872,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11836,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12621,6 +13097,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13642,6 +14237,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14703,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14741,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14869,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14979,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15142,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15180,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15232,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15466,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15551,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15724,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15781,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16283,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16346,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15750,6 +16691,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/myrrlyn/tap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
         </reference>
       </externalReferences>
     </component>
@@ -16232,6 +17195,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17537,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17646,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17829,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +19324,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18863,6 +19922,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19005,6 +20077,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +20361,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +20473,37 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +20518,63 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +20585,146 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21028,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21713,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21722,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21797,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21879,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21956,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +22212,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +22406,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +22435,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +22467,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22623,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22714,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22743,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22928,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21724,6 +23182,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -22011,6 +23497,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23606,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23626,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23691,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23715,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23745,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23816,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23865,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23879,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +24095,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +24106,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +24172,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22677,6 +24257,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +24391,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24425,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +24460,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/search_service/search_service.cdx.xml
+++ b/src/search_service/search_service.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:da2af25a-2df3-4b9a-8881-80ce9c2f7542" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:5853b113-d8df-4f4c-ba18-c2783e4f835a" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.936610000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.513772000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0 bin-target-0">
           <name>search_service</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/search_service@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -815,7 +815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -837,7 +837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -845,7 +845,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -859,7 +859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -867,7 +867,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -888,7 +888,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -899,7 +899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -907,7 +907,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -921,7 +921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -929,7 +929,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -947,7 +947,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -965,7 +965,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -983,7 +983,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -994,24 +994,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1019,7 +1019,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1030,7 +1030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1038,7 +1038,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1049,7 +1049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1057,7 +1057,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1068,7 +1068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1076,7 +1076,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1087,7 +1087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1095,7 +1095,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1106,7 +1106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1114,7 +1114,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1125,7 +1125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1133,7 +1133,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1144,7 +1144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1152,7 +1152,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1163,7 +1163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1171,7 +1171,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1182,7 +1182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1190,7 +1190,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1201,7 +1201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1209,7 +1209,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1220,7 +1220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1228,7 +1228,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1239,7 +1239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1247,7 +1247,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1258,7 +1258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1266,7 +1266,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1277,7 +1277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1285,7 +1285,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1296,7 +1296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1304,7 +1304,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1315,7 +1315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1323,7 +1323,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1334,7 +1334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1342,7 +1342,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1353,7 +1353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1361,7 +1361,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1372,7 +1372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1380,7 +1380,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1391,7 +1391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1399,7 +1399,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1410,7 +1410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1418,7 +1418,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1429,7 +1429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1437,7 +1437,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1448,7 +1448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1456,7 +1456,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1467,7 +1467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1475,7 +1475,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1486,7 +1486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1494,7 +1494,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1505,7 +1505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1513,7 +1513,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1524,7 +1524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1532,7 +1532,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1543,7 +1543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1551,7 +1551,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1562,7 +1562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1570,7 +1570,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1581,7 +1581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1589,7 +1589,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1599,7 +1599,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1608,7 +1608,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1617,7 +1617,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1626,7 +1626,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1635,7 +1635,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1644,7 +1644,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1653,7 +1653,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1662,7 +1662,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1671,7 +1671,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1680,7 +1680,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1689,7 +1689,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1698,7 +1698,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1708,7 +1708,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1818,7 +1818,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1840,7 +1840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1862,7 +1862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1887,10 +1887,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1912,7 +1912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1937,7 +1937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1962,7 +1962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2059,7 +2059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2099,7 +2099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2121,7 +2121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2143,10 +2143,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2187,7 +2187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2231,7 +2231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2253,7 +2253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2275,7 +2275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2297,7 +2297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2319,7 +2319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2341,7 +2341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2363,7 +2363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2385,7 +2385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2407,7 +2407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2429,7 +2429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2451,7 +2451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2473,7 +2473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2495,7 +2495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2517,7 +2517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2539,7 +2539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2667,7 +2667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2686,7 +2686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2705,7 +2705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2724,7 +2724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2749,7 +2749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2768,7 +2768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2787,7 +2787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2812,7 +2812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2837,7 +2837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2856,7 +2856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2878,7 +2878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2897,7 +2897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2916,7 +2916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2935,7 +2935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2954,7 +2954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2976,7 +2976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3023,7 +3023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3042,7 +3042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3064,7 +3064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3083,7 +3083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3152,7 +3152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3171,7 +3171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3190,7 +3190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3209,7 +3209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3228,7 +3228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3247,7 +3247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3266,7 +3266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3285,7 +3285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3304,7 +3304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3323,7 +3323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3342,7 +3342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3361,7 +3361,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3380,7 +3380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3399,7 +3399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3418,7 +3418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3437,7 +3437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3456,7 +3456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3556,7 +3556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3578,7 +3578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3597,7 +3597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3687,7 +3687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3709,7 +3709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3753,7 +3753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3778,7 +3778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3803,7 +3803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3828,7 +3828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3878,7 +3878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3946,7 +3946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4034,7 +4034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4095,7 +4095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4117,7 +4117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4139,7 +4139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4186,7 +4186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4211,7 +4211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4233,7 +4233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4255,7 +4255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4277,7 +4277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4296,7 +4296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4315,7 +4315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4340,7 +4340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4362,7 +4362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4405,7 +4405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4451,7 +4451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4492,7 +4492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4517,7 +4517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4539,7 +4539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4583,7 +4583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4602,7 +4602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4693,7 +4693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4763,7 +4763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4785,7 +4785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4807,7 +4807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4829,7 +4829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4894,7 +4894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5031,7 +5031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5056,7 +5056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5099,7 +5099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5124,7 +5124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5143,7 +5143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5162,7 +5162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5181,7 +5181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5247,7 +5247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5269,7 +5269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5291,7 +5291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5329,7 +5329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5351,7 +5351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5370,7 +5370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5389,7 +5389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5408,7 +5408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5490,7 +5490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5559,7 +5559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5578,7 +5578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5597,7 +5597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5619,7 +5619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5746,7 +5746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5834,7 +5834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5859,7 +5859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5906,7 +5906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5952,7 +5952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5974,7 +5974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5996,7 +5996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6015,7 +6015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6034,7 +6034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6053,7 +6053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6072,7 +6072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6097,7 +6097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6181,7 +6181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6200,7 +6200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6222,7 +6222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6244,7 +6244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6266,7 +6266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6332,7 +6332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6389,7 +6389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6408,7 +6408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6433,7 +6433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6455,7 +6455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6477,7 +6477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6502,7 +6502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6527,7 +6527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6552,7 +6552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6592,7 +6592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6611,7 +6611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6636,7 +6636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6658,7 +6658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6745,7 +6745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6767,7 +6767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6789,7 +6789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6811,7 +6811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6836,7 +6836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6861,7 +6861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6940,7 +6940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6962,7 +6962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6984,7 +6984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7003,7 +7003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7022,7 +7022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7047,7 +7047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7091,7 +7091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7113,7 +7113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7135,7 +7135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7176,7 +7176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7195,7 +7195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7257,7 +7257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7279,7 +7279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7304,7 +7304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7348,7 +7348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7370,7 +7370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7389,7 +7389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7427,7 +7427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7452,7 +7452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7474,7 +7474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7499,7 +7499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7518,7 +7518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7603,7 +7603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7646,7 +7646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7734,7 +7734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7801,7 +7801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7914,7 +7914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7961,7 +7961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7983,7 +7983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8002,7 +8002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8021,7 +8021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8040,7 +8040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8059,7 +8059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8096,7 +8096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8139,7 +8139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8164,7 +8164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8207,7 +8207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8273,7 +8273,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8316,7 +8316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8335,7 +8335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8357,7 +8357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8379,7 +8379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8401,7 +8401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8423,7 +8423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8445,7 +8445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8467,7 +8467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8486,7 +8486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8581,7 +8581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8606,7 +8606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8631,7 +8631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8656,7 +8656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8829,7 +8829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8916,7 +8916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8960,7 +8960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9004,7 +9004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9026,7 +9026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9048,7 +9048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9070,7 +9070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9092,7 +9092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9111,7 +9111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9130,7 +9130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9236,7 +9236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9258,7 +9258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9283,7 +9283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9305,7 +9305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9327,7 +9327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9352,7 +9352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9371,7 +9371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9437,7 +9437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9456,7 +9456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9475,7 +9475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9497,7 +9497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9519,7 +9519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9541,7 +9541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9563,7 +9563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9585,7 +9585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9610,7 +9610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9629,7 +9629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9648,7 +9648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9667,7 +9667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9686,7 +9686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9705,7 +9705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9764,7 +9764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9786,7 +9786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9811,7 +9811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9833,7 +9833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9874,7 +9874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9918,7 +9918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9940,7 +9940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9981,7 +9981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10000,7 +10000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10025,7 +10025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10047,7 +10047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10069,7 +10069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10088,7 +10088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10132,7 +10132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10157,7 +10157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10176,7 +10176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10245,7 +10245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10270,7 +10270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10292,7 +10292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10317,7 +10317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10339,7 +10339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10358,7 +10358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10380,7 +10380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10402,7 +10402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10424,7 +10424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10449,7 +10449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10492,7 +10492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10514,7 +10514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10536,7 +10536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10558,7 +10558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10580,7 +10580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10599,7 +10599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10618,7 +10618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10640,7 +10640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10725,7 +10725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10813,7 +10813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10835,7 +10835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10857,7 +10857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10876,7 +10876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10895,7 +10895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10945,7 +10945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10995,7 +10995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11139,7 +11139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11158,7 +11158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11177,7 +11177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11250,7 +11250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11294,7 +11294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11316,7 +11316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11335,7 +11335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11354,7 +11354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11376,7 +11376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11444,7 +11444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11469,7 +11469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11488,7 +11488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11507,7 +11507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11526,7 +11526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11551,7 +11551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11573,7 +11573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11613,7 +11613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11635,7 +11635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11679,7 +11679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11698,7 +11698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11720,7 +11720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11802,7 +11802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11840,7 +11840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11884,7 +11884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11909,7 +11909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11934,7 +11934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11959,7 +11959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12028,7 +12028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12047,7 +12047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12066,7 +12066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12085,7 +12085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12158,7 +12158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12180,7 +12180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12237,7 +12237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12259,7 +12259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12281,7 +12281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12300,7 +12300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12384,7 +12384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12422,7 +12422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12441,7 +12441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12463,7 +12463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12513,7 +12513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12535,7 +12535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12560,7 +12560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12607,7 +12607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12626,7 +12626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12645,7 +12645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12664,7 +12664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12686,7 +12686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12724,7 +12724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12746,7 +12746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12768,7 +12768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12790,7 +12790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12809,7 +12809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12828,7 +12828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12853,7 +12853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12878,7 +12878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12900,7 +12900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12922,7 +12922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12944,7 +12944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12966,7 +12966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12988,7 +12988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13010,7 +13010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13032,7 +13032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13054,7 +13054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13079,7 +13079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13098,7 +13098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13145,7 +13145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13167,7 +13167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13189,7 +13189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13259,7 +13259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13338,7 +13338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13360,7 +13360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13382,7 +13382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13407,7 +13407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13699,7 +13699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13718,7 +13718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13737,7 +13737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13759,7 +13759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13781,7 +13781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13800,7 +13800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13849,7 +13849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13874,7 +13874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13899,7 +13899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13924,7 +13924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13949,7 +13949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13971,7 +13971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13993,7 +13993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14012,7 +14012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14031,7 +14031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14053,7 +14053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14075,7 +14075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14115,7 +14115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14134,7 +14134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14156,7 +14156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14175,7 +14175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14194,7 +14194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14216,7 +14216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14238,7 +14238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14257,7 +14257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14276,7 +14276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14295,7 +14295,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14317,7 +14317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14336,7 +14336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14398,7 +14398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14420,7 +14420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14544,7 +14544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14566,7 +14566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14588,7 +14588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14632,7 +14632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14679,7 +14679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14704,7 +14704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14729,7 +14729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14754,7 +14754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14779,7 +14779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14804,7 +14804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14826,7 +14826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14848,7 +14848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14870,7 +14870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14892,7 +14892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14914,7 +14914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14936,7 +14936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14958,7 +14958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14983,7 +14983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15002,7 +15002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15024,7 +15024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15046,7 +15046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15071,7 +15071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15096,7 +15096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15143,7 +15143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15162,7 +15162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15184,7 +15184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15206,7 +15206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15228,7 +15228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15250,7 +15250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15316,7 +15316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15401,7 +15401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15426,7 +15426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15445,7 +15445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15467,7 +15467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15511,7 +15511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15530,7 +15530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15555,7 +15555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15574,7 +15574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15599,7 +15599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15621,7 +15621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15662,7 +15662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15681,7 +15681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15703,7 +15703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15725,7 +15725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15747,7 +15747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15769,7 +15769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15791,7 +15791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15813,7 +15813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15838,7 +15838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15863,7 +15863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15901,7 +15901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15951,7 +15951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15970,7 +15970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15989,7 +15989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16008,7 +16008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16030,7 +16030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16052,7 +16052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16074,7 +16074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16096,7 +16096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16118,7 +16118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16190,7 +16190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16209,7 +16209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16234,7 +16234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16259,7 +16259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16284,7 +16284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16309,7 +16309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16334,7 +16334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16359,7 +16359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16384,7 +16384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16409,7 +16409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16434,7 +16434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16456,7 +16456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16478,7 +16478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16500,7 +16500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16525,7 +16525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16547,7 +16547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16566,7 +16566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16648,7 +16648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16670,7 +16670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16695,7 +16695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -16717,7 +16717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16792,7 +16792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16841,7 +16841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16860,7 +16860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16879,7 +16879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16901,7 +16901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16923,7 +16923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16945,7 +16945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16970,7 +16970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16989,7 +16989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17008,7 +17008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17030,7 +17030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17068,7 +17068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17087,7 +17087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17106,7 +17106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17152,7 +17152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17174,7 +17174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17214,7 +17214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17290,7 +17290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17312,7 +17312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17334,7 +17334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17356,7 +17356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17378,7 +17378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17400,7 +17400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17425,7 +17425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17450,7 +17450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17472,7 +17472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17494,7 +17494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17516,7 +17516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17559,7 +17559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17581,7 +17581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17603,7 +17603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17625,7 +17625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17650,7 +17650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17700,7 +17700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17722,7 +17722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17765,7 +17765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17787,7 +17787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17858,7 +17858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17883,7 +17883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17927,7 +17927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17952,7 +17952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17974,7 +17974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17999,7 +17999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18024,7 +18024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18046,7 +18046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18068,7 +18068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18090,7 +18090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18137,7 +18137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18159,7 +18159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18181,7 +18181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18225,7 +18225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18247,7 +18247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18266,7 +18266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18291,7 +18291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18313,7 +18313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18338,7 +18338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18360,7 +18360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18379,7 +18379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18416,7 +18416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18441,7 +18441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18463,7 +18463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18485,7 +18485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18525,7 +18525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18547,7 +18547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18572,7 +18572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18661,7 +18661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18743,7 +18743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18784,7 +18784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18809,7 +18809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18831,7 +18831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18850,7 +18850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18872,7 +18872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18891,7 +18891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18910,7 +18910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18929,7 +18929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18948,7 +18948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18967,7 +18967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19049,7 +19049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19087,7 +19087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19106,7 +19106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19146,7 +19146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19168,7 +19168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19187,7 +19187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19209,7 +19209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20361,18 +20361,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20391,12 +20391,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20442,7 +20442,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20473,24 +20473,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20501,15 +20501,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -20518,7 +20518,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20528,7 +20528,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20539,7 +20539,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20555,27 +20555,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20586,7 +20586,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -20595,17 +20595,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -20615,7 +20615,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20624,48 +20624,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -20673,11 +20673,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -20685,10 +20685,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -20700,9 +20700,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20710,16 +20710,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/sourcemaps/openobserve-sourcemaps.cdx.xml
+++ b/src/sourcemaps/openobserve-sourcemaps.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:dd2ef26f-5718-42eb-9496-135690f80b37" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:fcdceb54-54f2-47f9-9a7c-ca0d78e854e3" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.138736000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.690217000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <name>openobserve-sourcemaps</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0 bin-target-0">
           <name>openobserve_sourcemaps</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1610,7 +1610,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1619,7 +1619,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1628,7 +1628,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1638,7 +1638,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1726,7 +1726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1748,7 +1748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1770,7 +1770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1792,7 +1792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1817,10 +1817,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1842,7 +1842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1867,7 +1867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1892,7 +1892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2029,7 +2029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2051,7 +2051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2073,10 +2073,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2117,7 +2117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2161,7 +2161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2183,7 +2183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2205,7 +2205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2227,7 +2227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2249,7 +2249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2271,7 +2271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2293,7 +2293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2315,7 +2315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2337,7 +2337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2359,7 +2359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2381,7 +2381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2403,7 +2403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2425,7 +2425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2447,7 +2447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2469,7 +2469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2575,7 +2575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2594,7 +2594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2613,7 +2613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2632,7 +2632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2657,7 +2657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2676,7 +2676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2695,7 +2695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2720,7 +2720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2745,7 +2745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2764,7 +2764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2786,7 +2786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2805,7 +2805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2824,7 +2824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2843,7 +2843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2862,7 +2862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2884,7 +2884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2931,7 +2931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2950,7 +2950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2972,7 +2972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2991,7 +2991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3060,7 +3060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3079,7 +3079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3098,7 +3098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3117,7 +3117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3136,7 +3136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3155,7 +3155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3174,7 +3174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3193,7 +3193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3212,7 +3212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3231,7 +3231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3250,7 +3250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3269,7 +3269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3288,7 +3288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3307,7 +3307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3326,7 +3326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3345,7 +3345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3364,7 +3364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3464,7 +3464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3505,7 +3505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3548,7 +3548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3595,7 +3595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3617,7 +3617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3661,7 +3661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3686,7 +3686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3711,7 +3711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3736,7 +3736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3786,7 +3786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3854,7 +3854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3942,7 +3942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4003,7 +4003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4025,7 +4025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4047,7 +4047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4069,7 +4069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4094,7 +4094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4119,7 +4119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4141,7 +4141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4163,7 +4163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4185,7 +4185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4204,7 +4204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4223,7 +4223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4248,7 +4248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4270,7 +4270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4313,7 +4313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4359,7 +4359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4400,7 +4400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4425,7 +4425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4447,7 +4447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4491,7 +4491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4510,7 +4510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4601,7 +4601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4671,7 +4671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4693,7 +4693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4715,7 +4715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4737,7 +4737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4802,7 +4802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4939,7 +4939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4964,7 +4964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5007,7 +5007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5032,7 +5032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5051,7 +5051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5070,7 +5070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5089,7 +5089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5155,7 +5155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5177,7 +5177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5199,7 +5199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5237,7 +5237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5259,7 +5259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5278,7 +5278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5297,7 +5297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5316,7 +5316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5398,7 +5398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5467,7 +5467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5486,7 +5486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5505,7 +5505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5527,7 +5527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5654,7 +5654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5742,7 +5742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5767,7 +5767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5814,7 +5814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5860,7 +5860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5882,7 +5882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5904,7 +5904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5923,7 +5923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5942,7 +5942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5961,7 +5961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5980,7 +5980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6005,7 +6005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6070,7 +6070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>debugid</name>
       <version>0.8.0</version>
       <description>Common reusable types for implementing the sentry.io protocol.</description>
@@ -6095,7 +6095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
-      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <author>anatawa12 &lt;anatawa12@icloud.com></author>
       <name>deflate64</name>
       <version>0.1.11</version>
       <description>Deflate64 implementation based on .NET's implementation</description>
@@ -6136,7 +6136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6155,7 +6155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6177,7 +6177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6199,7 +6199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6221,7 +6221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6287,7 +6287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6344,7 +6344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6388,7 +6388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6410,7 +6410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6432,7 +6432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6457,7 +6457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6482,7 +6482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6507,7 +6507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6547,7 +6547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6566,7 +6566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6591,7 +6591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6613,7 +6613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6700,7 +6700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6722,7 +6722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6744,7 +6744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6766,7 +6766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6791,7 +6791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6816,7 +6816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6895,7 +6895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6917,7 +6917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6939,7 +6939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6958,7 +6958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6977,7 +6977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7002,7 +7002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7024,7 +7024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7046,7 +7046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7068,7 +7068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7090,7 +7090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7109,7 +7109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7131,7 +7131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7150,7 +7150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7212,7 +7212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7234,7 +7234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7259,7 +7259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7281,7 +7281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7303,7 +7303,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7325,7 +7325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7344,7 +7344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7382,7 +7382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7407,7 +7407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7429,7 +7429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7454,7 +7454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7473,7 +7473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7558,7 +7558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7601,7 +7601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7689,7 +7689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7756,7 +7756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7869,7 +7869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7916,7 +7916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7938,7 +7938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7957,7 +7957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7976,7 +7976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7995,7 +7995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8014,7 +8014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8051,7 +8051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8094,7 +8094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8119,7 +8119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8162,7 +8162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8228,7 +8228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8271,7 +8271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8312,7 +8312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8334,7 +8334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8356,7 +8356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8378,7 +8378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8400,7 +8400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8422,7 +8422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8441,7 +8441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8536,7 +8536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8561,7 +8561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8586,7 +8586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8611,7 +8611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8784,7 +8784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8850,7 +8850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com></author>
       <name>if_chain</name>
       <version>1.0.3</version>
       <description>Macro for writing nested `if let` expressions.</description>
@@ -8893,7 +8893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8937,7 +8937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8981,7 +8981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9003,7 +9003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9025,7 +9025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9047,7 +9047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9069,7 +9069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9088,7 +9088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9107,7 +9107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9213,7 +9213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9235,7 +9235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9260,7 +9260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9282,7 +9282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9307,7 +9307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9326,7 +9326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9392,7 +9392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9411,7 +9411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9430,7 +9430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9452,7 +9452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9474,7 +9474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9496,7 +9496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9518,7 +9518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9540,7 +9540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9565,7 +9565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9584,7 +9584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9603,7 +9603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9622,7 +9622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9660,7 +9660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9719,7 +9719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9741,7 +9741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9766,7 +9766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9788,7 +9788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9829,7 +9829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9873,7 +9873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9895,7 +9895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9936,7 +9936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9955,7 +9955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9980,7 +9980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10002,7 +10002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10045,7 +10045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10064,7 +10064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10083,7 +10083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10108,7 +10108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10133,7 +10133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10152,7 +10152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10221,7 +10221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10246,7 +10246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10268,7 +10268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10293,7 +10293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10315,7 +10315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10334,7 +10334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10356,7 +10356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10378,7 +10378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10400,7 +10400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10425,7 +10425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10468,7 +10468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10490,7 +10490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10512,7 +10512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10534,7 +10534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10556,7 +10556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10575,7 +10575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10594,7 +10594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10616,7 +10616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10701,7 +10701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10789,7 +10789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10811,7 +10811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10833,7 +10833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10852,7 +10852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10871,7 +10871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10921,7 +10921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10971,7 +10971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11115,7 +11115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11134,7 +11134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11153,7 +11153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11226,7 +11226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11270,7 +11270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11292,7 +11292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11311,7 +11311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11330,7 +11330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11352,7 +11352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11420,7 +11420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11445,7 +11445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11464,7 +11464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11483,7 +11483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11502,7 +11502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11527,7 +11527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11589,7 +11589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11611,7 +11611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11636,7 +11636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11655,7 +11655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11674,7 +11674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11696,7 +11696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11737,7 +11737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11781,7 +11781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11800,7 +11800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11838,7 +11838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11882,7 +11882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11907,7 +11907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11932,7 +11932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11957,7 +11957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12026,7 +12026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12045,7 +12045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12064,7 +12064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12083,7 +12083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12156,7 +12156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12178,7 +12178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12235,7 +12235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12257,7 +12257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12279,7 +12279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12298,7 +12298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12382,7 +12382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12441,7 +12441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12460,7 +12460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12482,7 +12482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12532,7 +12532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12554,7 +12554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12579,7 +12579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12626,7 +12626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12645,7 +12645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12664,7 +12664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12683,7 +12683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12724,7 +12724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12787,7 +12787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12809,7 +12809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12828,7 +12828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12847,7 +12847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12872,7 +12872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12897,7 +12897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12919,7 +12919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12941,7 +12941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12963,7 +12963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12985,7 +12985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13007,7 +13007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13029,7 +13029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13051,7 +13051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13073,7 +13073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13098,7 +13098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13159,7 +13159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13238,7 +13238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13260,7 +13260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13307,7 +13307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13618,7 +13618,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13637,7 +13637,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13659,7 +13659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13681,7 +13681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13700,7 +13700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13749,7 +13749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13774,7 +13774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13799,7 +13799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13824,7 +13824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13849,7 +13849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13871,7 +13871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13893,7 +13893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13912,7 +13912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13931,7 +13931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13953,7 +13953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13975,7 +13975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14015,7 +14015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14034,7 +14034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14056,7 +14056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14075,7 +14075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14094,7 +14094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14116,7 +14116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14138,7 +14138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14157,7 +14157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14176,7 +14176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14195,7 +14195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14217,7 +14217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14236,7 +14236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14298,7 +14298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14320,7 +14320,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14444,7 +14444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14466,7 +14466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14532,7 +14532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14579,7 +14579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14604,7 +14604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14629,7 +14629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14654,7 +14654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14679,7 +14679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14704,7 +14704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14726,7 +14726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14748,7 +14748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14770,7 +14770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14792,7 +14792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14814,7 +14814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14836,7 +14836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14858,7 +14858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14883,7 +14883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14902,7 +14902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14924,7 +14924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14946,7 +14946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14971,7 +14971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14996,7 +14996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15021,7 +15021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15043,7 +15043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15062,7 +15062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15084,7 +15084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15106,7 +15106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15128,7 +15128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15150,7 +15150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15216,7 +15216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15301,7 +15301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15326,7 +15326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15345,7 +15345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15367,7 +15367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15411,7 +15411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15430,7 +15430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15455,7 +15455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15474,7 +15474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15499,7 +15499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15521,7 +15521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15562,7 +15562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15581,7 +15581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15603,7 +15603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15625,7 +15625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15647,7 +15647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15669,7 +15669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15691,7 +15691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15713,7 +15713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15738,7 +15738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15763,7 +15763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
-      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <author>Sentry &lt;hello@sentry.io></author>
       <name>sourcemap</name>
       <version>9.3.2</version>
       <description>Basic sourcemap handling for Rust</description>
@@ -15785,7 +15785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15823,7 +15823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15873,7 +15873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15892,7 +15892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15911,7 +15911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15930,7 +15930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15952,7 +15952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15974,7 +15974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15996,7 +15996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16018,7 +16018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16040,7 +16040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16112,7 +16112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16131,7 +16131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16156,7 +16156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16181,7 +16181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16206,7 +16206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16231,7 +16231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16256,7 +16256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16281,7 +16281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16306,7 +16306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16356,7 +16356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16378,7 +16378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16400,7 +16400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16422,7 +16422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16447,7 +16447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16488,7 +16488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16570,7 +16570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16592,7 +16592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16617,7 +16617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16692,7 +16692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16741,7 +16741,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16760,7 +16760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16779,7 +16779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16801,7 +16801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16823,7 +16823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16845,7 +16845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16870,7 +16870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16889,7 +16889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16908,7 +16908,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16930,7 +16930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16968,7 +16968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16987,7 +16987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17006,7 +17006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17052,7 +17052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17074,7 +17074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17114,7 +17114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17190,7 +17190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17212,7 +17212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17234,7 +17234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17256,7 +17256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17278,7 +17278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17300,7 +17300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17325,7 +17325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17350,7 +17350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17372,7 +17372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17394,7 +17394,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17416,7 +17416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17459,7 +17459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17481,7 +17481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17503,7 +17503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17525,7 +17525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17550,7 +17550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17600,7 +17600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17622,7 +17622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
-      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <author>Chip Senkbeil &lt;chip@senkbeil.org></author>
       <name>typed-path</name>
       <version>0.12.3</version>
       <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
@@ -17644,7 +17644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17687,7 +17687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17709,7 +17709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17780,7 +17780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17805,7 +17805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17849,7 +17849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17874,7 +17874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Boshen &lt;boshenc@gmail.com></author>
       <name>unicode-id-start</name>
       <version>1.4.0</version>
       <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17896,7 +17896,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17918,7 +17918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17943,7 +17943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17968,7 +17968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17990,7 +17990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18012,7 +18012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18034,7 +18034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18081,7 +18081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18103,7 +18103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18125,7 +18125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18169,7 +18169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18191,7 +18191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18210,7 +18210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18235,7 +18235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18257,7 +18257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18282,7 +18282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18304,7 +18304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18323,7 +18323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18360,7 +18360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18385,7 +18385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18407,7 +18407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18429,7 +18429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18469,7 +18469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18491,7 +18491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18516,7 +18516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18605,7 +18605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18687,7 +18687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18728,7 +18728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18753,7 +18753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18775,7 +18775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18794,7 +18794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18816,7 +18816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18835,7 +18835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18854,7 +18854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18873,7 +18873,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18892,7 +18892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18911,7 +18911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18993,7 +18993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19031,7 +19031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19050,7 +19050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19069,7 +19069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com>, Chris Hennick &lt;hennickc@amazon.com></author>
       <name>zip</name>
       <version>8.2.0</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19109,7 +19109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19152,7 +19152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19171,7 +19171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19193,7 +19193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20314,18 +20314,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20344,12 +20344,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20395,7 +20395,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20426,24 +20426,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20454,10 +20454,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20467,7 +20467,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20478,7 +20478,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20494,27 +20494,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20525,23 +20525,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/sourcemaps#openobserve-sourcemaps@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20549,9 +20549,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/sourcemaps/openobserve-sourcemaps.cdx.xml
+++ b/src/sourcemaps/openobserve-sourcemaps.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:dd2ef26f-5718-42eb-9496-135690f80b37" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.138736000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+      <name>openobserve-sourcemaps</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0 bin-target-0">
+          <name>openobserve_sourcemaps</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-sourcemaps@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,33 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1618,24 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2292,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2691,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5198,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5290,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5813,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -5932,6 +6069,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
+      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <name>debugid</name>
+      <version>0.8.0</version>
+      <description>Common reusable types for implementing the sentry.io protocol.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/debugid@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/debugid</url>
+        </reference>
+        <reference type="website">
+          <url>https://sentry.io/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/getsentry/rust-debugid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11">
+      <author>anatawa12 &lt;anatawa12@icloud.com&gt;</author>
+      <name>deflate64</name>
+      <version>0.1.11</version>
+      <description>Deflate64 implementation based on .NET's implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/deflate64@0.1.11</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/anatawa12/deflate64-rs#readme</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/anatawa12/deflate64-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10">
       <author>RustCrypto Developers</author>
       <name>der</name>
@@ -6008,6 +6192,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6609,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8072,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8575,6 +8849,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3">
+      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;</author>
+      <name>if_chain</name>
+      <version>1.0.3</version>
+      <description>Macro for writing nested `if let` expressions.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/if_chain@1.0.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/if_chain</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/lambda-fairy/if_chain</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
       <version>2.14.0</version>
@@ -8769,6 +9065,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/krisprice/ipnet</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
         </reference>
       </externalReferences>
     </component>
@@ -9007,6 +9322,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9686,6 +10023,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2">
+      <name>lzma-rust2</name>
+      <version>0.16.2</version>
+      <description>LZMA / LZMA2 / LZIP / XZ compression ported from 'tukaani xz for java'</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lzma-rust2@0.16.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/hasenbanck/lzma-rust2/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hasenbanck/lzma-rust2/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
       <author>rep-nop &lt;repnop@outlook.com&gt;</author>
       <name>mac_address</name>
@@ -9790,6 +10148,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +10675,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10848,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11331,6 +11758,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2">
+      <author>RustCrypto Developers</author>
+      <name>pbkdf2</name>
+      <version>0.12.2</version>
+      <description>Generic implementation of PBKDF2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pbkdf2@0.12.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pbkdf2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
       <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
       <name>pco</name>
@@ -11385,6 +11834,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11923,6 +12397,27 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/jhpratt/powerfmt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0">
+      <name>ppmd-rust</name>
+      <version>1.4.0</version>
+      <description>PPMd compression / decompression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24</hash>
+      </hashes>
+      <licenses>
+        <expression>CC0-1.0 OR MIT-0</expression>
+      </licenses>
+      <purl>pkg:cargo/ppmd-rust@1.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/hasenbanck/ppmd-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hasenbanck/ppmd-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14137,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14603,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14641,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14769,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14879,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15042,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15080,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15132,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15366,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15451,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15624,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15681,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +15759,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
+      <author>Sentry &lt;hello@sentry.io&gt;</author>
+      <name>sourcemap</name>
+      <version>9.3.2</version>
+      <description>Basic sourcemap handling for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">314d62a489431668f719ada776ca1d49b924db951b7450f8974c9ae51ab05ad7</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/sourcemap@9.3.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/getsentry/rust-sourcemap</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/getsentry/rust-sourcemap</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16205,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16268,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +17095,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17437,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16647,6 +17549,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <author>Alexey Galakhov, Daniel Abramov</author>
       <name>tungstenite</name>
@@ -16691,6 +17618,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/shepmaster/twox-hash</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3">
+      <author>Chip Senkbeil &lt;chip@senkbeil.org&gt;</author>
+      <name>typed-path</name>
+      <version>0.12.3</version>
+      <description>Provides typed variants of Path and PathBuf for Unix and Windows</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/typed-path@0.12.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/chipsenkbeil/typed-path</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/chipsenkbeil/typed-path</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +17754,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16896,6 +17870,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/yeslogic/unicode-general-category</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Boshen &lt;boshenc@gmail.com&gt;</author>
+      <name>unicode-id-start</name>
+      <version>1.4.0</version>
+      <description>Determine whether characters have the ID_Start or ID_Continue properties according to Unicode Standard Annex #31</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007</hash>
+      </hashes>
+      <licenses>
+        <expression>(MIT OR Apache-2.0) AND Unicode-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unicode-id-start@1.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/unicode-id-start</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Boshen/unicode-id-start</url>
         </reference>
       </externalReferences>
     </component>
@@ -18072,6 +19068,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;, Chris Hennick &lt;hennickc@amazon.com&gt;</author>
+      <name>zip</name>
+      <version>8.2.0</version>
+      <description>Library to support the reading and writing of zip files. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zip@8.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/zip-rs/zip2.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3">
       <name>zlib-rs</name>
       <version>0.6.3</version>
@@ -18112,6 +19127,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/zmij</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3">
+      <name>zopfli</name>
+      <version>0.8.3</version>
+      <description>A Rust implementation of the Zopfli compression algorithm.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/zopfli@0.8.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/zopfli-rs/zopfli</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zopfli-rs/zopfli</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19899,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20314,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20426,93 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20524,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/sourcemaps#openobserve-sourcemaps@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20691,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20846,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21531,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21540,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20407,6 +21616,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
@@ -20460,6 +21675,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0" />
@@ -20481,6 +21701,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
@@ -20552,6 +21779,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +22035,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20959,6 +22199,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
@@ -20989,6 +22230,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +22282,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21174,6 +22425,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21187,6 +22441,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22532,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22561,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21465,6 +22737,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
@@ -21474,6 +22750,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21563,6 +22843,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40" />
     </dependency>
@@ -22011,6 +23292,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23401,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23421,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23486,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23510,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23540,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23611,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23660,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +23675,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sourcemap@9.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#if_chain@1.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +23902,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23913,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +24064,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +24197,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24231,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22835,6 +24248,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
@@ -22854,10 +24268,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-id-start@1.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
@@ -23119,8 +24542,35 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@8.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deflate64@0.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lzma-rust2@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pbkdf2@0.12.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ppmd-rust@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7" />
     </dependency>

--- a/src/stream/stream.cdx.xml
+++ b/src/stream/stream.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:8f07aa51-82d8-461b-843e-40fdf152b244" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.993971000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0 bin-target-0">
+          <name>stream</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/stream@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -978,6 +978,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1548,6 +1565,15 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1583,42 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1627,33 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2221,28 +2310,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2642,6 +2709,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -5124,6 +5216,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5308,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +5831,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6163,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6580,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -7819,6 +8043,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
       <name>hdrhistogram</name>
@@ -8772,6 +9017,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -9007,6 +9271,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9793,6 +10079,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <author>RustCrypto Developers</author>
       <name>md-5</name>
@@ -10292,6 +10603,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +10776,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +11740,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14022,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -14051,6 +14488,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +14526,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +14654,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +14764,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +14927,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +14965,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15017,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15251,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +15336,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +15509,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +15566,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -15392,6 +16068,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16131,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -16232,6 +16958,24 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
@@ -16556,6 +17300,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +17409,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16802,6 +17592,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/ua-parser/uap-rust/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -18863,6 +19678,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19265,6 +20093,41 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,19 +20205,100 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
       <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
@@ -19366,6 +20310,56 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +20494,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -19669,6 +20649,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20324,6 +21334,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +21343,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +21418,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +21500,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +21577,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20798,6 +21833,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
@@ -20989,6 +22027,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21040,6 +22079,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21187,6 +22235,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +22326,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +22355,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21474,6 +22540,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -22011,6 +23081,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22109,6 +23190,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +23210,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +23275,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +23299,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +23329,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +23400,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +23449,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22312,6 +23463,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
@@ -22525,6 +23679,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +23690,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22678,6 +23841,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -22796,6 +23974,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +24008,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22853,6 +24043,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />

--- a/src/stream/stream.cdx.xml
+++ b/src/stream/stream.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:8f07aa51-82d8-461b-843e-40fdf152b244" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3de03898-5823-4ac5-ab3d-4b4891ea89d4" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.993971000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.565758000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0 bin-target-0">
           <name>stream</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/stream@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1583,7 +1583,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1592,7 +1592,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1601,7 +1601,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1610,7 +1610,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1619,7 +1619,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1628,7 +1628,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1637,7 +1637,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1646,7 +1646,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1656,7 +1656,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1744,7 +1744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1766,7 +1766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1788,7 +1788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1810,7 +1810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1835,10 +1835,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1860,7 +1860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1885,7 +1885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1910,7 +1910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2007,7 +2007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2047,7 +2047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2069,7 +2069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2091,10 +2091,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2135,7 +2135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2179,7 +2179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2201,7 +2201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2223,7 +2223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2245,7 +2245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2267,7 +2267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2289,7 +2289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2311,7 +2311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2333,7 +2333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2355,7 +2355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2377,7 +2377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2399,7 +2399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2421,7 +2421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2443,7 +2443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2465,7 +2465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2487,7 +2487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2593,7 +2593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2612,7 +2612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2631,7 +2631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2650,7 +2650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2675,7 +2675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2694,7 +2694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2713,7 +2713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2738,7 +2738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2763,7 +2763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2782,7 +2782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2804,7 +2804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2823,7 +2823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2842,7 +2842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2861,7 +2861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2880,7 +2880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2902,7 +2902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2949,7 +2949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2968,7 +2968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2990,7 +2990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3009,7 +3009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3097,7 +3097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3116,7 +3116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3135,7 +3135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3154,7 +3154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3173,7 +3173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3192,7 +3192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3211,7 +3211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3230,7 +3230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3287,7 +3287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3306,7 +3306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3325,7 +3325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3344,7 +3344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3363,7 +3363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3382,7 +3382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3482,7 +3482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3504,7 +3504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3523,7 +3523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3566,7 +3566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3613,7 +3613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3635,7 +3635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3679,7 +3679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3704,7 +3704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3729,7 +3729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3754,7 +3754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3804,7 +3804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3872,7 +3872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3960,7 +3960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4021,7 +4021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4043,7 +4043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4065,7 +4065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4087,7 +4087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4112,7 +4112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4137,7 +4137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4159,7 +4159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4181,7 +4181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4203,7 +4203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4222,7 +4222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4241,7 +4241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4266,7 +4266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4288,7 +4288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4331,7 +4331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4377,7 +4377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4418,7 +4418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4443,7 +4443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4465,7 +4465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4509,7 +4509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4528,7 +4528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4689,7 +4689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4711,7 +4711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4733,7 +4733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4755,7 +4755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4820,7 +4820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4957,7 +4957,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4982,7 +4982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5025,7 +5025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5050,7 +5050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5069,7 +5069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5088,7 +5088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5107,7 +5107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5173,7 +5173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5195,7 +5195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5217,7 +5217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5255,7 +5255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5277,7 +5277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5296,7 +5296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5315,7 +5315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5334,7 +5334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5416,7 +5416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5485,7 +5485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5504,7 +5504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5523,7 +5523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5545,7 +5545,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5672,7 +5672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5760,7 +5760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5785,7 +5785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5832,7 +5832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5878,7 +5878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5900,7 +5900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5922,7 +5922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5941,7 +5941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5960,7 +5960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5979,7 +5979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5998,7 +5998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6023,7 +6023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6107,7 +6107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6126,7 +6126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6148,7 +6148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6170,7 +6170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6192,7 +6192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6258,7 +6258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6315,7 +6315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6334,7 +6334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6359,7 +6359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6381,7 +6381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6403,7 +6403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6428,7 +6428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6453,7 +6453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6478,7 +6478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6518,7 +6518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6537,7 +6537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6562,7 +6562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6584,7 +6584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6671,7 +6671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6693,7 +6693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6715,7 +6715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6737,7 +6737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6762,7 +6762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6787,7 +6787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6866,7 +6866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6888,7 +6888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6910,7 +6910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6929,7 +6929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6948,7 +6948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6973,7 +6973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6995,7 +6995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7017,7 +7017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7039,7 +7039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7061,7 +7061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7080,7 +7080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7102,7 +7102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7121,7 +7121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7183,7 +7183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7205,7 +7205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7230,7 +7230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7252,7 +7252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7274,7 +7274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7296,7 +7296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7315,7 +7315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7353,7 +7353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7378,7 +7378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7400,7 +7400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7425,7 +7425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7444,7 +7444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7529,7 +7529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7572,7 +7572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7660,7 +7660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7727,7 +7727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7840,7 +7840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7887,7 +7887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7909,7 +7909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7928,7 +7928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7947,7 +7947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7966,7 +7966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7985,7 +7985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8022,7 +8022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8065,7 +8065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8090,7 +8090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8133,7 +8133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8199,7 +8199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8242,7 +8242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8261,7 +8261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8283,7 +8283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8305,7 +8305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8327,7 +8327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8349,7 +8349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8371,7 +8371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8393,7 +8393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8412,7 +8412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8507,7 +8507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8532,7 +8532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8557,7 +8557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8582,7 +8582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8755,7 +8755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8842,7 +8842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8886,7 +8886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8930,7 +8930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8952,7 +8952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8974,7 +8974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8996,7 +8996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9018,7 +9018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9037,7 +9037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9056,7 +9056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9162,7 +9162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9184,7 +9184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9209,7 +9209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9231,7 +9231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9256,7 +9256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9275,7 +9275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9341,7 +9341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9360,7 +9360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9379,7 +9379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9401,7 +9401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9423,7 +9423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9445,7 +9445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9467,7 +9467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9489,7 +9489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9514,7 +9514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9533,7 +9533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9552,7 +9552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9571,7 +9571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9590,7 +9590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9609,7 +9609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9668,7 +9668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9690,7 +9690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9715,7 +9715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9737,7 +9737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9778,7 +9778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9822,7 +9822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9844,7 +9844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9885,7 +9885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9904,7 +9904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9992,7 +9992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10011,7 +10011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10036,7 +10036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10061,7 +10061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10080,7 +10080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10149,7 +10149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10174,7 +10174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10196,7 +10196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10221,7 +10221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10243,7 +10243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10262,7 +10262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10284,7 +10284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10306,7 +10306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10328,7 +10328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10353,7 +10353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10396,7 +10396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10418,7 +10418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10440,7 +10440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10462,7 +10462,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10484,7 +10484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10503,7 +10503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10522,7 +10522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10544,7 +10544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10629,7 +10629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10717,7 +10717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10739,7 +10739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10761,7 +10761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10780,7 +10780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10799,7 +10799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10849,7 +10849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10899,7 +10899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11043,7 +11043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11062,7 +11062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11081,7 +11081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11154,7 +11154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11198,7 +11198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11220,7 +11220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11239,7 +11239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11258,7 +11258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11280,7 +11280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11348,7 +11348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11373,7 +11373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11392,7 +11392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11430,7 +11430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11455,7 +11455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11477,7 +11477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11517,7 +11517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11539,7 +11539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11564,7 +11564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11583,7 +11583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11602,7 +11602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11624,7 +11624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11665,7 +11665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11687,7 +11687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11706,7 +11706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11744,7 +11744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -11788,7 +11788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11813,7 +11813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11838,7 +11838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11863,7 +11863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11932,7 +11932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11951,7 +11951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11970,7 +11970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11989,7 +11989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12062,7 +12062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12084,7 +12084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12141,7 +12141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12163,7 +12163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12185,7 +12185,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12204,7 +12204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12288,7 +12288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12326,7 +12326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12345,7 +12345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12367,7 +12367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12417,7 +12417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12439,7 +12439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12464,7 +12464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12511,7 +12511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12530,7 +12530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12549,7 +12549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12568,7 +12568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12590,7 +12590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12609,7 +12609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12628,7 +12628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12650,7 +12650,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12672,7 +12672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12694,7 +12694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12713,7 +12713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12732,7 +12732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12757,7 +12757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12782,7 +12782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12804,7 +12804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12826,7 +12826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12848,7 +12848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12870,7 +12870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12892,7 +12892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12914,7 +12914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12936,7 +12936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12958,7 +12958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12983,7 +12983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13044,7 +13044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13123,7 +13123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13145,7 +13145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13167,7 +13167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13192,7 +13192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13484,7 +13484,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13503,7 +13503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13522,7 +13522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13544,7 +13544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13566,7 +13566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13585,7 +13585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13634,7 +13634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13659,7 +13659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13684,7 +13684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13709,7 +13709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13734,7 +13734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13756,7 +13756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13778,7 +13778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13797,7 +13797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13816,7 +13816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13838,7 +13838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13860,7 +13860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13900,7 +13900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13919,7 +13919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13941,7 +13941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13960,7 +13960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13979,7 +13979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14001,7 +14001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14023,7 +14023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14042,7 +14042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14061,7 +14061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14121,7 +14121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14183,7 +14183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14205,7 +14205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14329,7 +14329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14351,7 +14351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14373,7 +14373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14417,7 +14417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14464,7 +14464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14489,7 +14489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14514,7 +14514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14539,7 +14539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14564,7 +14564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14589,7 +14589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14611,7 +14611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14633,7 +14633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14655,7 +14655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14677,7 +14677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14699,7 +14699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14721,7 +14721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14743,7 +14743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14768,7 +14768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -14787,7 +14787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14809,7 +14809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14831,7 +14831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14881,7 +14881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14906,7 +14906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14928,7 +14928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14947,7 +14947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14969,7 +14969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14991,7 +14991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15013,7 +15013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15035,7 +15035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15101,7 +15101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15186,7 +15186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15211,7 +15211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15230,7 +15230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15252,7 +15252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -15296,7 +15296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15315,7 +15315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15340,7 +15340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -15359,7 +15359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15384,7 +15384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15406,7 +15406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15447,7 +15447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15466,7 +15466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15488,7 +15488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15510,7 +15510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15532,7 +15532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15554,7 +15554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15576,7 +15576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -15598,7 +15598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15623,7 +15623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15648,7 +15648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15686,7 +15686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15736,7 +15736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15755,7 +15755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15793,7 +15793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15815,7 +15815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15837,7 +15837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15859,7 +15859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15881,7 +15881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15903,7 +15903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15975,7 +15975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15994,7 +15994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16019,7 +16019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16044,7 +16044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16069,7 +16069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16094,7 +16094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16119,7 +16119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16144,7 +16144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16169,7 +16169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16194,7 +16194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16219,7 +16219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -16241,7 +16241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -16263,7 +16263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -16285,7 +16285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -16310,7 +16310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -16351,7 +16351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16433,7 +16433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16455,7 +16455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16480,7 +16480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16555,7 +16555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16604,7 +16604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16623,7 +16623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16642,7 +16642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16664,7 +16664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16686,7 +16686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16708,7 +16708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16733,7 +16733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16752,7 +16752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16771,7 +16771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16793,7 +16793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16831,7 +16831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16850,7 +16850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16869,7 +16869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16915,7 +16915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16937,7 +16937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16977,7 +16977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17053,7 +17053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17075,7 +17075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17097,7 +17097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17119,7 +17119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17141,7 +17141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17163,7 +17163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17188,7 +17188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -17213,7 +17213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -17235,7 +17235,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -17257,7 +17257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -17279,7 +17279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -17322,7 +17322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -17344,7 +17344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -17366,7 +17366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -17388,7 +17388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -17413,7 +17413,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17463,7 +17463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17485,7 +17485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17528,7 +17528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17550,7 +17550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17621,7 +17621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17646,7 +17646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17690,7 +17690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17715,7 +17715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17737,7 +17737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17762,7 +17762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17787,7 +17787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17809,7 +17809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17831,7 +17831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17853,7 +17853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17900,7 +17900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17922,7 +17922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17944,7 +17944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17988,7 +17988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18010,7 +18010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18029,7 +18029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18054,7 +18054,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18076,7 +18076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18101,7 +18101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18123,7 +18123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18142,7 +18142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -18179,7 +18179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -18204,7 +18204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -18226,7 +18226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -18248,7 +18248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -18288,7 +18288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -18310,7 +18310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -18335,7 +18335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -18424,7 +18424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18506,7 +18506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18547,7 +18547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18572,7 +18572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18594,7 +18594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18613,7 +18613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18635,7 +18635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18654,7 +18654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18673,7 +18673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18692,7 +18692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18711,7 +18711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18730,7 +18730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18812,7 +18812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18850,7 +18850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18869,7 +18869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18909,7 +18909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18931,7 +18931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18950,7 +18950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18972,7 +18972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -20093,18 +20093,18 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -20123,12 +20123,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -20174,7 +20174,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -20205,24 +20205,24 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -20233,10 +20233,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -20246,7 +20246,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -20257,7 +20257,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -20273,34 +20273,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -20311,40 +20311,40 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20352,9 +20352,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/super_cluster_queue/super_cluster_queue.cdx.xml
+++ b/src/super_cluster_queue/super_cluster_queue.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:b227cfc8-264c-451f-80b6-47eb15129f8f" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.250980000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+      <name>super_cluster_queue</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0 bin-target-0">
+          <name>super_cluster_queue</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -169,6 +169,21 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <name>datafusion-functions-json</name>
+      <version>0.54.2</version>
+      <description>JSON functions for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
         </reference>
       </externalReferences>
     </component>
@@ -799,6 +814,22 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <author>The GreptimeDB Project Developers</author>
+      <name>promql-parser</name>
+      <version>0.6.0</version>
+      <description>Parse PromQL query into AST</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GreptimeTeam/promql-parser</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>tantivy</name>
@@ -978,6 +1009,23 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
       <name>vortex</name>
@@ -1121,6 +1169,25 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datafusion</name>
+      <version>0.1.0</version>
+      <description>Apache Datafusion integration for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,6 +1615,33 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <name>audit</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <name>common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <name>compaction</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
@@ -1557,6 +1651,96 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <name>openobserve-core</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../core</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <name>db</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <name>enrichment-data</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../enrichment_data</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+      <name>flight</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <name>infra</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <name>ingester</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <name>ingestion-common</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <name>openobserve-node</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <name>promql</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <name>promql-service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
+    </component>
     <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
@@ -1565,6 +1749,78 @@
         <expression>AGPL-3.0</expression>
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <name>schema</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <name>search</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <name>search_service</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <name>stream</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <name>tantivy_utils</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <name>wal</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
       <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
@@ -2645,6 +2901,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>async-nats</name>
+      <version>0.47.0</version>
+      <description>A async Rust NATS client</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-nats</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-net</name>
@@ -3586,6 +3867,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <name>bincode</name>
+      <version>1.3.3</version>
+      <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bincode@1.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bincode</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/bincode</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
       <name>bindgen</name>
@@ -3611,6 +3914,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-set</name>
+      <version>0.5.3</version>
+      <description>A set of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-set@0.5.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-set/bit_set</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
       <name>bit-set</name>
@@ -3633,6 +3961,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/contain-rs/bit-set</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.6.3</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.6.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://contain-rs.github.io/bit-vec/bit_vec</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
         </reference>
       </externalReferences>
     </component>
@@ -4044,6 +4397,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
       <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
       <name>bumpalo</name>
@@ -4235,6 +4613,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/trifectatechfoundation/bzip2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>cactus</name>
+      <version>1.0.7</version>
+      <description>Immutable parent pointer tree</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cactus@1.0.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/cactus/</url>
         </reference>
       </externalReferences>
     </component>
@@ -4457,6 +4854,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/katharostech/cfg_aliases</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>cfgrammar</name>
+      <version>0.13.10</version>
+      <description>Grammar manipulation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cfgrammar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
         </reference>
       </externalReferences>
     </component>
@@ -5033,6 +5449,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <name>const-hex</name>
+      <version>1.18.1</version>
+      <description>Fast byte array to hex string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/const-hex@1.18.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-hex</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danipopes/const-hex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -5124,6 +5565,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
       <author>Joachim Enggård Nebel</author>
       <name>const_for</name>
@@ -5197,6 +5657,25 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/convert_case@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rutrum/convert-case</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
+      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <name>convert_case</name>
+      <version>0.4.0</version>
+      <description>Convert strings into any case</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/convert_case@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rutrum/convert-case</url>
@@ -5701,6 +6180,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <name>curve25519-dalek</name>
+      <version>4.1.3</version>
+      <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/curve25519-dalek@4.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/curve25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <name>custom-labels</name>
       <version>0.4.6</version>
@@ -6008,6 +6512,28 @@
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/derive_more</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JelteF/derive_more</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <name>derive_more</name>
+      <version>0.99.20</version>
+      <description>Adds #[derive(x)] macros for more traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/derive_more@0.99.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jeltef.github.io/derive_more/derive_more/</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/JelteF/derive_more</url>
@@ -6403,6 +6929,53 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/dyn-clone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <name>ed25519-dalek</name>
+      <version>2.2.0</version>
+      <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519-dalek@2.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519-dalek</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <author>RustCrypto Developers</author>
+      <name>ed25519</name>
+      <version>2.2.3</version>
+      <description>Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032) support library providing signature type definitions and PKCS#8 private key decoding/encoding support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ed25519@2.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ed25519</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/signatures/tree/master/ed25519</url>
         </reference>
       </externalReferences>
     </component>
@@ -6814,6 +7387,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <name>fancy-regex</name>
+      <version>0.13.0</version>
+      <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fancy-regex@0.13.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/fancy-regex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fancy-regex/fancy-regex</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -6912,6 +7507,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/volo-rs/faststr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>filetime</name>
+      <version>0.2.27</version>
+      <description>Platform-agnostic accessors of timestamps in File metadata </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/filetime@0.2.27</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/filetime</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/alexcrichton/filetime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/alexcrichton/filetime</url>
         </reference>
       </externalReferences>
     </component>
@@ -7524,6 +8144,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <author>The Rust Project Developers</author>
+      <name>getopts</name>
+      <version>0.2.24</version>
+      <description>getopts-like option parsing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/getopts@0.2.24</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/getopts</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <author>The Rand Project Developers</author>
       <name>getrandom</name>
@@ -7810,6 +8449,27 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashlink@0.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hashlink</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/kyren/hashlink</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <name>hashlink</name>
+      <version>0.11.0</version>
+      <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashlink@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/hashlink</url>
@@ -8772,6 +9432,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>ipnetwork</name>
+      <version>0.21.1</version>
+      <description>A library to work with IP CIDRs in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnetwork@0.21.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/achanda/ipnetwork</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
       <name>iri-string</name>
@@ -8966,6 +9645,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <name>jiter</name>
+      <version>0.16.0</version>
+      <description>Fast Iterable JSON parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiter@0.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pydantic/jiter/</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
       <name>jobserver</name>
@@ -9007,6 +9708,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/Stranger6667/jsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <name>jsonwebtoken</name>
+      <version>10.3.0</version>
+      <description>Create and decode JWTs in a strongly typed way.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jsonwebtoken@10.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/Keats/jsonwebtoken</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Keats/jsonwebtoken</url>
         </reference>
       </externalReferences>
     </component>
@@ -9598,6 +10321,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrlex</name>
+      <version>0.13.10</version>
+      <description>Simple lexer generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrlex@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrpar</name>
+      <version>0.13.10</version>
+      <description>Yacc-compatible parser generator</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrpar@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>lrtable</name>
+      <version>0.13.10</version>
+      <description>LR grammar table generation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/lrtable@0.13.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/grmtools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
       <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
       <name>lru-slab</name>
@@ -9790,6 +10570,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <name>maxminddb</name>
+      <version>0.27.3</version>
+      <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/maxminddb@0.27.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/maxminddb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oschwald/maxminddb-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -10292,6 +11097,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <author>wasmCloud Team</author>
+      <name>nkeys</name>
+      <version>0.4.5</version>
+      <description>Rust implementation of the NATS nkeys library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nkeys@0.4.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nkeys</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/wasmcloud/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
       <author>Parity Technologies &lt;admin@parity.io&gt;</author>
       <name>nohash</name>
@@ -10440,6 +11270,25 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/nushell/nu-ansi-term</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <name>nuid</name>
+      <version>0.5.0</version>
+      <description>A highly performant unique identifier generator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nuid@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/casualjim/rs-nuid.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10971,6 +11820,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <name>opentelemetry-proto</name>
+      <version>0.32.0</version>
+      <description>Protobuf generated files and transformations.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry-proto@0.32.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
       <version>0.32.0</version>
@@ -10989,6 +11859,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <name>opentelemetry_sdk</name>
+      <version>0.32.1</version>
+      <description>The SDK for the OpenTelemetry metrics collection and distributed tracing framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/opentelemetry_sdk@0.32.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk</url>
         </reference>
       </externalReferences>
     </component>
@@ -11180,6 +12071,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/owo-colors/owo-colors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <name>packedvec</name>
+      <version>1.2.5</version>
+      <description>Store vectors of integers efficiently</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/packedvec@1.2.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/packedvec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -11385,6 +12295,31 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/formats/tree/master/pem-rfc7468</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <name>pem</name>
+      <version>3.0.6</version>
+      <description>Parse and encode PEM-encoded data.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pem@3.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pem/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jcreekmore/pem-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -12130,6 +13065,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <author>Jason Lingle</author>
+      <name>proptest</name>
+      <version>1.10.0</version>
+      <description>Hypothesis-like property-based testing and shrinking. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proptest@1.10.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proptest/latest/proptest/</url>
+        </reference>
+        <reference type="website">
+          <url>https://proptest-rs.github.io/proptest/proptest/index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/proptest-rs/proptest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>prost-build</name>
@@ -12621,6 +13581,125 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-build-config</name>
+      <version>0.29.0</version>
+      <description>Build configuration for the PyO3 ecosystem</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-build-config@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-ffi</name>
+      <version>0.29.0</version>
+      <description>Python-API bindings for the PyO3 ecosystem</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-ffi@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros-backend</name>
+      <version>0.29.0</version>
+      <description>Code generation for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros-backend@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3-macros</name>
+      <version>0.29.0</version>
+      <description>Proc macros for PyO3 package</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3-macros@0.29.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <name>pyo3</name>
+      <version>0.29.0</version>
+      <description>Bindings to Python interpreter</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pyo3@0.29.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/pyo3/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+        <reference type="other">
+          <url>pyo3-python</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pyo3/pyo3</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <name>quick-xml</name>
       <version>0.38.4</version>
@@ -13030,6 +14109,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-random/rand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <author>The Rand Project Developers, The Rust Project Developers</author>
+      <name>rand_xorshift</name>
+      <version>0.4.0</version>
+      <description>Xorshift random number generator </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rand_xorshift@0.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rand_xorshift</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-random.github.io/book</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +14746,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -13702,6 +14863,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/paupino/rust-decimal</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0">
+      <author>The Rust Project Developers</author>
+      <name>rustc-hash</name>
+      <version>1.1.0</version>
+      <description>speed, non-cryptographic hash used in rustc</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rustc-hash@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/rustc-hash</url>
         </reference>
       </externalReferences>
     </component>
@@ -14051,6 +15231,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-cli</name>
+      <version>1.1.20</version>
+      <description>Command line utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
@@ -14064,6 +15269,31 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-orm</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.sea-ql.org/SeaORM</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-orm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <name>sea-orm-migration</name>
+      <version>1.1.20</version>
+      <description>Migration utility for SeaORM</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -14167,6 +15397,50 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema-derive</name>
+      <version>0.3.0</version>
+      <description>Derive macro for sea-schema's Name trait</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema-derive@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <name>sea-schema</name>
+      <version>0.16.2</version>
+      <description>🌿 SQL schema definition and discovery</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sea-schema@0.16.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sea-schema</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeaQL/sea-schema</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
       <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
       <name>seahash</name>
@@ -14233,6 +15507,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <name>segment</name>
+      <version>0.2.6</version>
+      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/segment@0.2.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -14377,6 +15670,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <name>serde_nanos</name>
+      <version>0.1.4</version>
+      <description>Wrapper to process duration and timestamps as nanoseconds</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_nanos@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/caspervonb/serde_nanos</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>serde_path_to_error</name>
@@ -14396,6 +15708,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_repr</name>
+      <version>0.1.20</version>
+      <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_repr@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_repr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/serde-repr</url>
         </reference>
       </externalReferences>
     </component>
@@ -14426,7 +15760,7 @@
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47</hash>
       </hashes>
@@ -14660,6 +15994,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <name>signatory</name>
+      <version>0.27.1</version>
+      <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/signatory@0.27.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/iqlusioninc/crates</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/iqlusioninc/crates/tree/main/signatory</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <author>RustCrypto Developers</author>
       <name>signature</name>
@@ -14723,6 +16079,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rusticstuff/simdutf8</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <name>simple_asn1</name>
+      <version>0.6.4</version>
+      <description>A simple DER/ASN.1 encoding/decoding library.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/simple_asn1@0.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/acw/simple_asn1</url>
         </reference>
       </externalReferences>
     </component>
@@ -14877,6 +16252,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu-derive</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu-derive@0.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
       <name>snafu</name>
@@ -14912,6 +16309,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/snafu@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/snafu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/shepmaster/snafu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <name>snafu</name>
+      <version>0.9.0</version>
+      <description>An ergonomic error handling library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/snafu@0.9.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/snafu</url>
@@ -14968,6 +16387,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <name>sparsevec</name>
+      <version>0.2.2</version>
+      <description>Compress vectors using row displacement</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/sparsevec@0.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/sparsevec/</url>
         </reference>
       </externalReferences>
     </component>
@@ -15392,6 +16830,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +16893,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -15753,6 +17241,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
+      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <name>target-lexicon</name>
+      <version>0.13.5</version>
+      <description>LLVM target triple types</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 WITH LLVM-exception</expression>
+      </licenses>
+      <purl>pkg:cargo/target-lexicon@0.13.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/target-lexicon/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bytecodealliance/target-lexicon</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
       <name>tempfile</name>
@@ -16006,6 +17516,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <name>tiktoken-rs</name>
+      <version>0.9.1</version>
+      <description>Library for encoding and decoding with the tiktoken library in Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tiktoken-rs@0.9.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crate/tiktoken-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zurawiki/tiktoken-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
       <name>time-core</name>
@@ -16229,6 +17764,24 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <name>tokio-websockets</name>
+      <version>0.10.1</version>
+      <description>High performance, strict, tokio-util based WebSockets implementation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-websockets@0.10.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gelbpunkt/tokio-websockets/</url>
         </reference>
       </externalReferences>
     </component>
@@ -16556,6 +18109,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <name>tracing-opentelemetry</name>
+      <version>0.33.0</version>
+      <description>OpenTelemetry integration for tracing</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -16644,6 +18218,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <name>tryhard</name>
+      <version>0.5.2</version>
+      <description>Easily retry futures</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/tryhard@0.5.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tryhard</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/EmbarkStudios/tryhard</url>
         </reference>
       </externalReferences>
     </component>
@@ -16805,6 +18404,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <author>Ocean Lewis</author>
+      <name>uaparser</name>
+      <version>0.6.4</version>
+      <description>A Rust implementation of the UA Parser</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/uaparser@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/uap-rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/davidarmstronglewis/uap-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>ucd-trie</name>
@@ -16827,6 +18451,46 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/ucd-generate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4">
+      <name>unarray</name>
+      <version>0.1.4</version>
+      <description>Utilities for working with uninitialized arrays</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unarray@0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cameron1024/unarray</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <name>unescaper</name>
+      <version>0.1.8</version>
+      <description>Unescape strings with escape sequences written out as literal characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e</hash>
+      </hashes>
+      <licenses>
+        <expression>GPL-3.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/unescaper@0.1.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://hack.ink/unescaper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hack-ink/unescaper</url>
         </reference>
       </externalReferences>
     </component>
@@ -17410,6 +19074,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <name>vergen</name>
+      <version>8.3.2</version>
+      <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vergen@8.3.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vergen</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rustyhorde/vergen</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <name>version-compare</name>
+      <version>0.2.1</version>
+      <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/version-compare@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version-compare</url>
+        </reference>
+        <reference type="website">
+          <url>https://timvisee.com/projects/version-compare/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/timvisee/version-compare</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>version_check</name>
@@ -17429,6 +19143,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <name>vob</name>
+      <version>3.0.6</version>
+      <description>Vector of Bits with Vec-like API and usize backing storage</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/vob@3.0.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/softdevteam/vob/</url>
         </reference>
       </externalReferences>
     </component>
@@ -18272,6 +20005,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -18769,6 +20509,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
@@ -18862,6 +20611,19 @@
     </dependency>
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
@@ -19005,6 +20767,30 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
     </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
@@ -19265,6 +21051,74 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19342,6 +21196,142 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -19356,6 +21346,127 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +21477,196 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19669,6 +21970,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
@@ -20060,6 +22391,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
@@ -20072,9 +22406,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20151,6 +22489,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12" />
@@ -20175,6 +22518,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20207,6 +22551,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
@@ -20314,6 +22666,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
@@ -20324,6 +22681,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -20332,6 +22690,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
     </dependency>
@@ -20406,6 +22765,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
@@ -20482,6 +22847,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1" />
     </dependency>
@@ -20552,6 +22924,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
@@ -20617,6 +22999,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -20636,6 +23023,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
@@ -20733,6 +23124,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
@@ -20797,6 +23191,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -20989,6 +23386,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -21017,6 +23415,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
@@ -21040,6 +23447,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -21164,6 +23580,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getopts@0.2.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21187,6 +23639,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -21271,6 +23730,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519@2.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
@@ -21292,6 +23759,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -21381,12 +23851,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.32.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
@@ -21418,6 +23909,10 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -21474,6 +23969,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
@@ -21605,6 +24104,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proptest@1.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
@@ -21725,6 +24233,34 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
@@ -21807,6 +24343,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
@@ -22011,6 +24550,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22039,6 +24589,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
@@ -22109,6 +24660,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -22116,6 +24680,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
@@ -22171,6 +24745,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -22182,6 +24769,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -22204,9 +24799,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
@@ -22267,12 +24870,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -22304,6 +24919,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5" />
@@ -22313,9 +24934,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
@@ -22525,6 +25155,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +25166,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
@@ -22593,6 +25232,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
@@ -22628,6 +25268,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
@@ -22677,6 +25326,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22796,6 +25460,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -22822,6 +25494,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -22854,7 +25530,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
@@ -22908,7 +25596,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes@0.8.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />

--- a/src/super_cluster_queue/super_cluster_queue.cdx.xml
+++ b/src/super_cluster_queue/super_cluster_queue.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:b227cfc8-264c-451f-80b6-47eb15129f8f" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:0b2a3ddf-0247-491c-99aa-72d255ab2562" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.250980000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.798912000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0">
       <name>super_cluster_queue</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0 bin-target-0">
           <name>super_cluster_queue</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/super_cluster_queue@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -180,7 +180,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%3Frev=0df53d710425cc91cf109e77a050bbe1e374e4fe%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
+      <purl>pkg:cargo/datafusion-functions-json@0.54.2?vcs_url=git%2Bhttps://github.com/openobserve/datafusion-functions-json%400df53d710425cc91cf109e77a050bbe1e374e4fe</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/datafusion-contrib/datafusion-functions-json/</url>
@@ -188,7 +188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -196,7 +196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -207,7 +207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -215,7 +215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -226,7 +226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -234,7 +234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -245,7 +245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -253,7 +253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -264,7 +264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -272,7 +272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -283,7 +283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -291,7 +291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -302,7 +302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -310,7 +310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -321,7 +321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -329,7 +329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -340,7 +340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -348,7 +348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -359,7 +359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -367,7 +367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -378,7 +378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -386,7 +386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -397,7 +397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -405,7 +405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -416,7 +416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -424,7 +424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -435,7 +435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -443,7 +443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -454,7 +454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -462,7 +462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -473,7 +473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -481,7 +481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -492,7 +492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -500,7 +500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -511,7 +511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -519,7 +519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -530,7 +530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -538,7 +538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -549,7 +549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -557,7 +557,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -568,7 +568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -576,7 +576,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -587,7 +587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -595,7 +595,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -606,7 +606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -614,7 +614,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -625,7 +625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -633,7 +633,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -644,7 +644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -652,7 +652,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -663,7 +663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -671,7 +671,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -682,7 +682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -690,7 +690,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -701,7 +701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -709,7 +709,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -720,7 +720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -728,7 +728,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -739,7 +739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -747,7 +747,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -758,7 +758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -766,7 +766,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -777,7 +777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -785,7 +785,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -796,7 +796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -804,7 +804,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -823,7 +823,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%3Fbranch=openobserve%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
+      <purl>pkg:cargo/promql-parser@0.6.0?vcs_url=git%2Bhttps://github.com/openobserve/promql-parser%40621826255a3b5fa083decab7419aa2ca6c6e14dd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GreptimeTeam/promql-parser</url>
@@ -831,7 +831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -839,7 +839,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -853,7 +853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -861,7 +861,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -875,7 +875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -883,7 +883,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -904,7 +904,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -915,7 +915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -923,7 +923,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -937,7 +937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -945,7 +945,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -963,7 +963,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -981,7 +981,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -999,7 +999,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -1010,24 +1010,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1035,7 +1035,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1046,7 +1046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1054,7 +1054,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1065,7 +1065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1073,7 +1073,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1084,7 +1084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1092,7 +1092,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1103,7 +1103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1111,7 +1111,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1122,7 +1122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1130,7 +1130,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1141,7 +1141,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1149,7 +1149,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1160,7 +1160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1168,7 +1168,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1179,7 +1179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datafusion</name>
       <version>0.1.0</version>
       <description>Apache Datafusion integration for Vortex</description>
@@ -1187,7 +1187,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datafusion@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1206,7 +1206,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1217,7 +1217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1225,7 +1225,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1236,7 +1236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1244,7 +1244,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1255,7 +1255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1263,7 +1263,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1274,7 +1274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1282,7 +1282,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1293,7 +1293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1301,7 +1301,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1312,7 +1312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1320,7 +1320,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1331,7 +1331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1339,7 +1339,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1350,7 +1350,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1358,7 +1358,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1369,7 +1369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1377,7 +1377,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1388,7 +1388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1396,7 +1396,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1407,7 +1407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1415,7 +1415,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1426,7 +1426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1434,7 +1434,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1445,7 +1445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1453,7 +1453,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1464,7 +1464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1472,7 +1472,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1483,7 +1483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1491,7 +1491,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1502,7 +1502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1510,7 +1510,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1529,7 +1529,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1548,7 +1548,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1559,7 +1559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1567,7 +1567,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1578,7 +1578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1586,7 +1586,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1597,7 +1597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1605,7 +1605,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1615,7 +1615,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <name>audit</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1624,7 +1624,7 @@
       </licenses>
       <purl>pkg:cargo/audit@0.1.0?download_url=file://../audit</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <name>common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1633,7 +1633,7 @@
       </licenses>
       <purl>pkg:cargo/common@0.1.0?download_url=file://../common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <name>compaction</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1642,7 +1642,7 @@
       </licenses>
       <purl>pkg:cargo/compaction@0.1.0?download_url=file://../compaction</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1651,7 +1651,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <name>openobserve-core</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1660,7 +1660,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-core@0.1.0?download_url=file://../core</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <name>db</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1669,7 +1669,7 @@
       </licenses>
       <purl>pkg:cargo/db@0.1.0?download_url=file://../db</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <name>enrichment-data</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1678,7 +1678,7 @@
       </licenses>
       <purl>pkg:cargo/enrichment-data@0.1.0?download_url=file://../enrichment_data</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <name>flight</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1687,7 +1687,7 @@
       </licenses>
       <purl>pkg:cargo/flight@0.1.0?download_url=file://../flight</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1696,7 +1696,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <name>ingester</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1705,7 +1705,7 @@
       </licenses>
       <purl>pkg:cargo/ingester@0.1.0?download_url=file://../ingester</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <name>ingestion-common</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1714,7 +1714,7 @@
       </licenses>
       <purl>pkg:cargo/ingestion-common@0.1.0?download_url=file://../ingestion_common</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <name>openobserve-node</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1723,7 +1723,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-node@0.1.0?download_url=file://../node</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <name>promql</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1732,7 +1732,7 @@
       </licenses>
       <purl>pkg:cargo/promql@0.1.0?download_url=file://../promql</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <name>promql-service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1741,7 +1741,7 @@
       </licenses>
       <purl>pkg:cargo/promql-service@0.1.0?download_url=file://../promql_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1750,7 +1750,7 @@
       </licenses>
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <name>schema</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1759,7 +1759,7 @@
       </licenses>
       <purl>pkg:cargo/schema@0.1.0?download_url=file://../schema</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <name>search</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1768,7 +1768,7 @@
       </licenses>
       <purl>pkg:cargo/search@0.1.0?download_url=file://../search</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <name>search_service</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1777,7 +1777,7 @@
       </licenses>
       <purl>pkg:cargo/search_service@0.1.0?download_url=file://../search_service</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <name>stream</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1786,7 +1786,7 @@
       </licenses>
       <purl>pkg:cargo/stream@0.1.0?download_url=file://../stream</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1795,7 +1795,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://../tantivy_utils</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1804,7 +1804,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://../transform</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1813,7 +1813,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://../usage_reporting</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1823,7 +1823,7 @@
       <purl>pkg:cargo/wal@0.1.0?download_url=file://../wal</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1911,7 +1911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1933,7 +1933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1955,7 +1955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1977,7 +1977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -2027,7 +2027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -2052,7 +2052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -2077,7 +2077,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -2174,7 +2174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -2214,7 +2214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -2236,7 +2236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2258,10 +2258,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2302,7 +2302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2346,7 +2346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2368,7 +2368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2390,7 +2390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2412,7 +2412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2434,7 +2434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2456,7 +2456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2478,7 +2478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-flight</name>
       <version>58.3.0</version>
       <description>Apache Arrow Flight</description>
@@ -2500,7 +2500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2522,7 +2522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2544,7 +2544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2566,7 +2566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2588,7 +2588,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2610,7 +2610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2632,7 +2632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2654,7 +2654,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2676,7 +2676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2782,7 +2782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2801,7 +2801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2820,7 +2820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2839,7 +2839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2864,7 +2864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2883,7 +2883,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2902,7 +2902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2927,7 +2927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2952,7 +2952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2971,7 +2971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2993,7 +2993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -3012,7 +3012,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -3031,7 +3031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -3050,7 +3050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -3069,7 +3069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -3091,7 +3091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -3138,7 +3138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -3157,7 +3157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -3179,7 +3179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -3198,7 +3198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3267,7 +3267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3286,7 +3286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3305,7 +3305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3324,7 +3324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3343,7 +3343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3362,7 +3362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3381,7 +3381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3400,7 +3400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3419,7 +3419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3438,7 +3438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3457,7 +3457,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3476,7 +3476,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3495,7 +3495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3514,7 +3514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3533,7 +3533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3552,7 +3552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3571,7 +3571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3671,7 +3671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3693,7 +3693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3712,7 +3712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3755,7 +3755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3802,7 +3802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3824,7 +3824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3868,7 +3868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bincode@1.3.3">
-      <author>Ty Overby &lt;ty@pre-alpha.com&gt;, Francesco Mazzoli &lt;f@mazzo.li&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;, Zoey Riordan &lt;zoey@dos.cafe&gt;</author>
+      <author>Ty Overby &lt;ty@pre-alpha.com>, Francesco Mazzoli &lt;f@mazzo.li>, David Tolnay &lt;dtolnay@gmail.com>, Zoey Riordan &lt;zoey@dos.cafe></author>
       <name>bincode</name>
       <version>1.3.3</version>
       <description>A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!</description>
@@ -3890,7 +3890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3915,7 +3915,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.5.3</version>
       <description>A set of bits</description>
@@ -3940,7 +3940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3965,7 +3965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.6.3</version>
       <description>A vector of bits</description>
@@ -3990,7 +3990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -4015,7 +4015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -4065,7 +4065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -4133,7 +4133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -4221,7 +4221,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -4282,7 +4282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4326,7 +4326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4348,7 +4348,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4373,7 +4373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4398,7 +4398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -4423,7 +4423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4445,7 +4445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4467,7 +4467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4489,7 +4489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4508,7 +4508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4527,7 +4527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4552,7 +4552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4574,7 +4574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4617,7 +4617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cactus@1.0.7">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>cactus</name>
       <version>1.0.7</version>
       <description>Immutable parent pointer tree</description>
@@ -4636,7 +4636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4682,7 +4682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4723,7 +4723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4748,7 +4748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4770,7 +4770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4814,7 +4814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4833,7 +4833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4858,7 +4858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfgrammar@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>cfgrammar</name>
       <version>0.13.10</version>
       <description>Grammar manipulation</description>
@@ -4943,7 +4943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -5013,7 +5013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -5035,7 +5035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -5057,7 +5057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -5079,7 +5079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -5281,7 +5281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -5306,7 +5306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -5349,7 +5349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5374,7 +5374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5412,7 +5412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5431,7 +5431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5450,7 +5450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-hex@1.18.1">
-      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com&gt;</author>
+      <author>DaniPopes &lt;57450786+DaniPopes@users.noreply.github.com></author>
       <name>const-hex</name>
       <version>1.18.1</version>
       <description>Fast byte array to hex string conversion</description>
@@ -5522,7 +5522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5544,7 +5544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5566,7 +5566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5604,7 +5604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5626,7 +5626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5645,7 +5645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5664,7 +5664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.4.0">
-      <author>David Purdum &lt;purdum41@gmail.com&gt;</author>
+      <author>David Purdum &lt;purdum41@gmail.com></author>
       <name>convert_case</name>
       <version>0.4.0</version>
       <description>Convert strings into any case</description>
@@ -5683,7 +5683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5765,7 +5765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5834,7 +5834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5853,7 +5853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5872,7 +5872,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5894,7 +5894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -6021,7 +6021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -6109,7 +6109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -6134,7 +6134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -6181,7 +6181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -6227,7 +6227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6249,7 +6249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -6271,7 +6271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6290,7 +6290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6309,7 +6309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6328,7 +6328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -6347,7 +6347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -6372,7 +6372,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -6456,7 +6456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6475,7 +6475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6497,7 +6497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6519,7 +6519,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@0.99.20">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>0.99.20</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6607,7 +6607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6708,7 +6708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6730,7 +6730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6752,7 +6752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6777,7 +6777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6802,7 +6802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6827,7 +6827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6867,7 +6867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6886,7 +6886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6911,7 +6911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6933,7 +6933,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -7020,7 +7020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -7042,7 +7042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -7064,7 +7064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -7086,7 +7086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -7111,7 +7111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -7136,7 +7136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -7215,7 +7215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -7237,7 +7237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -7259,7 +7259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -7278,7 +7278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -7297,7 +7297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -7322,7 +7322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -7344,7 +7344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7366,7 +7366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -7388,7 +7388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.13.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org></author>
       <name>fancy-regex</name>
       <version>0.13.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7410,7 +7410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -7432,7 +7432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -7451,7 +7451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -7473,7 +7473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -7492,7 +7492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7511,7 +7511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>filetime</name>
       <version>0.2.27</version>
       <description>Platform-agnostic accessors of timestamps in File metadata </description>
@@ -7579,7 +7579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7601,7 +7601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7626,7 +7626,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7648,7 +7648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7670,7 +7670,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7692,7 +7692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7711,7 +7711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7749,7 +7749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7774,7 +7774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7796,7 +7796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7821,7 +7821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7840,7 +7840,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7925,7 +7925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7968,7 +7968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -8056,7 +8056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -8123,7 +8123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -8255,7 +8255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -8302,7 +8302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -8324,7 +8324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -8343,7 +8343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8362,7 +8362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8381,7 +8381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8400,7 +8400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -8437,7 +8437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -8480,7 +8480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -8505,7 +8505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -8548,7 +8548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8614,7 +8614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8657,7 +8657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8676,7 +8676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8698,7 +8698,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8720,7 +8720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8742,7 +8742,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8764,7 +8764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8786,7 +8786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8808,7 +8808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8827,7 +8827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8922,7 +8922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8947,7 +8947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8972,7 +8972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8997,7 +8997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -9170,7 +9170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -9257,7 +9257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -9345,7 +9345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -9367,7 +9367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -9389,7 +9389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -9411,7 +9411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -9433,7 +9433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnetwork@0.21.1">
-      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com&gt;, Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Abhishek Chanda &lt;abhishek.becs@gmail.com>, Linus Färnstrand &lt;faern@faern.net></author>
       <name>ipnetwork</name>
       <version>0.21.1</version>
       <description>A library to work with IP CIDRs in Rust</description>
@@ -9452,7 +9452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -9471,7 +9471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9599,7 +9599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9624,7 +9624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9646,7 +9646,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiter@0.16.0">
-      <author>Samuel Colvin &lt;samuel@pydantic.dev&gt;</author>
+      <author>Samuel Colvin &lt;samuel@pydantic.dev></author>
       <name>jiter</name>
       <version>0.16.0</version>
       <description>Fast Iterable JSON parser</description>
@@ -9668,7 +9668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9693,7 +9693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9712,7 +9712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0">
-      <author>Vincent Prouillet &lt;hello@vincentprouillet.com&gt;</author>
+      <author>Vincent Prouillet &lt;hello@vincentprouillet.com></author>
       <name>jsonwebtoken</name>
       <version>10.3.0</version>
       <description>Create and decode JWTs in a strongly typed way.</description>
@@ -9778,7 +9778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9797,7 +9797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9838,7 +9838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9860,7 +9860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9882,7 +9882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9904,7 +9904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9926,7 +9926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9970,7 +9970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9989,7 +9989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -10008,7 +10008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -10027,7 +10027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -10046,7 +10046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -10105,7 +10105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -10127,7 +10127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -10152,7 +10152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -10174,7 +10174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -10215,7 +10215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -10259,7 +10259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -10281,7 +10281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -10322,7 +10322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrlex@0.13.10">
-      <author>Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrlex</name>
       <version>0.13.10</version>
       <description>Simple lexer generator</description>
@@ -10341,7 +10341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrpar@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrpar</name>
       <version>0.13.10</version>
       <description>Yacc-compatible parser generator</description>
@@ -10360,7 +10360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lrtable@0.13.10">
-      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Lukas Diekmann &lt;http://lukasdiekmann.com/>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>lrtable</name>
       <version>0.13.10</version>
       <description>LR grammar table generation</description>
@@ -10379,7 +10379,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -10398,7 +10398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -10423,7 +10423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10445,7 +10445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -10467,7 +10467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -10486,7 +10486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -10505,7 +10505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -10530,7 +10530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -10555,7 +10555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -10574,7 +10574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3">
-      <author>Gregory J. Oschwald &lt;oschwald@gmail.com&gt;</author>
+      <author>Gregory J. Oschwald &lt;oschwald@gmail.com></author>
       <name>maxminddb</name>
       <version>0.27.3</version>
       <description>Library for reading MaxMind DB format used by GeoIP2 and GeoLite2</description>
@@ -10643,7 +10643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -10668,7 +10668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -10690,7 +10690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10715,7 +10715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10737,7 +10737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10756,7 +10756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10778,7 +10778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10800,7 +10800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10822,7 +10822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10847,7 +10847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10890,7 +10890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10912,7 +10912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10934,7 +10934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10956,7 +10956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10978,7 +10978,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10997,7 +10997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -11016,7 +11016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -11038,7 +11038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -11123,7 +11123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -11211,7 +11211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -11233,7 +11233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -11255,7 +11255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -11274,7 +11274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -11293,7 +11293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -11343,7 +11343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -11393,7 +11393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -11537,7 +11537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -11556,7 +11556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -11575,7 +11575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -11648,7 +11648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -11692,7 +11692,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11714,7 +11714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11733,7 +11733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11752,7 +11752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11774,7 +11774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11884,7 +11884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11909,7 +11909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11928,7 +11928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11947,7 +11947,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11966,7 +11966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11991,7 +11991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -12013,7 +12013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -12053,7 +12053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -12075,7 +12075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#packedvec@1.2.5">
-      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com&gt;, Laurence Tratt &lt;http://tratt.net/laurie/&gt;</author>
+      <author>Gabriela Alexandra Moldovan &lt;gabi_250@live.com>, Laurence Tratt &lt;http://tratt.net/laurie/></author>
       <name>packedvec</name>
       <version>1.2.5</version>
       <description>Store vectors of integers efficiently</description>
@@ -12094,7 +12094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -12119,7 +12119,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -12138,7 +12138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -12157,7 +12157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -12179,7 +12179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -12220,7 +12220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -12242,7 +12242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -12261,7 +12261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pem@3.0.6">
-      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org&gt;</author>
+      <author>Jonathan Creekmore &lt;jonathan@thecreekmores.org></author>
       <name>pem</name>
       <version>3.0.6</version>
       <description>Parse and encode PEM-encoded data.</description>
@@ -12343,7 +12343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -12368,7 +12368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -12393,7 +12393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -12418,7 +12418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -12487,7 +12487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -12506,7 +12506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -12525,7 +12525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -12544,7 +12544,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -12617,7 +12617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -12639,7 +12639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -12696,7 +12696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -12718,7 +12718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -12740,7 +12740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -12759,7 +12759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12843,7 +12843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12881,7 +12881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12900,7 +12900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12922,7 +12922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12972,7 +12972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12994,7 +12994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -13019,7 +13019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -13091,7 +13091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -13110,7 +13110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13129,7 +13129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -13148,7 +13148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -13170,7 +13170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13189,7 +13189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -13208,7 +13208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13230,7 +13230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13252,7 +13252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -13274,7 +13274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13293,7 +13293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -13312,7 +13312,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -13337,7 +13337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -13362,7 +13362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -13384,7 +13384,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13406,7 +13406,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -13428,7 +13428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13450,7 +13450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -13472,7 +13472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -13494,7 +13494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -13516,7 +13516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -13538,7 +13538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -13563,7 +13563,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -13582,7 +13582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-build-config@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-build-config</name>
       <version>0.29.0</version>
       <description>Build configuration for the PyO3 ecosystem</description>
@@ -13604,7 +13604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-ffi@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-ffi</name>
       <version>0.29.0</version>
       <description>Python-API bindings for the PyO3 ecosystem</description>
@@ -13629,7 +13629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros-backend@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros-backend</name>
       <version>0.29.0</version>
       <description>Code generation for PyO3 package</description>
@@ -13651,7 +13651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3-macros@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3-macros</name>
       <version>0.29.0</version>
       <description>Proc macros for PyO3 package</description>
@@ -13673,7 +13673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pyo3@0.29.0">
-      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3&gt;</author>
+      <author>PyO3 Project and Contributors &lt;https://github.com/PyO3></author>
       <name>pyo3</name>
       <version>0.29.0</version>
       <description>Bindings to Python interpreter</description>
@@ -13743,7 +13743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -13822,7 +13822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -13844,7 +13844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -13866,7 +13866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -13891,7 +13891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -14208,7 +14208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -14227,7 +14227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -14246,7 +14246,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -14268,7 +14268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -14290,7 +14290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -14358,7 +14358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -14383,7 +14383,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -14408,7 +14408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -14433,7 +14433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -14458,7 +14458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -14480,7 +14480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -14502,7 +14502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -14521,7 +14521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -14540,7 +14540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -14562,7 +14562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -14584,7 +14584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -14624,7 +14624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14643,7 +14643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -14665,7 +14665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -14703,7 +14703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -14725,7 +14725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -14747,7 +14747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14766,7 +14766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -14785,7 +14785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -14804,7 +14804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -14826,7 +14826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -14845,7 +14845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -14926,7 +14926,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14948,7 +14948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -15072,7 +15072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -15094,7 +15094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -15116,7 +15116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -15160,7 +15160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -15207,7 +15207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -15232,7 +15232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -15257,7 +15257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -15282,7 +15282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -15307,7 +15307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -15332,7 +15332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -15354,7 +15354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -15376,7 +15376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -15398,7 +15398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -15420,7 +15420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -15442,7 +15442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -15464,7 +15464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -15486,7 +15486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -15511,7 +15511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
+      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com>, Ulysse Carion &lt;ulysse@segment.com></author>
       <name>segment</name>
       <version>0.2.6</version>
       <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
@@ -15530,7 +15530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -15552,7 +15552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -15574,7 +15574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -15599,7 +15599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -15624,7 +15624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -15649,7 +15649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -15671,7 +15671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -15690,7 +15690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -15712,7 +15712,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -15734,7 +15734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -15756,7 +15756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -15778,7 +15778,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -15844,7 +15844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -15929,7 +15929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -15954,7 +15954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -15973,7 +15973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -15995,7 +15995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -16039,7 +16039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -16058,7 +16058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -16083,7 +16083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simple_asn1@0.6.4">
-      <author>Adam Wick &lt;awick@uhsure.com&gt;</author>
+      <author>Adam Wick &lt;awick@uhsure.com></author>
       <name>simple_asn1</name>
       <version>0.6.4</version>
       <description>A simple DER/ASN.1 encoding/decoding library.</description>
@@ -16102,7 +16102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -16127,7 +16127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -16149,7 +16149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -16190,7 +16190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -16209,7 +16209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16231,7 +16231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16253,7 +16253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16275,7 +16275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -16297,7 +16297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -16319,7 +16319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -16341,7 +16341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -16366,7 +16366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -16391,7 +16391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sparsevec@0.2.2">
-      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com&gt;</author>
+      <author>Lukas Diekmann &lt;lukas.diekmann@gmail.com></author>
       <name>sparsevec</name>
       <version>0.2.2</version>
       <description>Compress vectors using row displacement</description>
@@ -16410,7 +16410,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -16448,7 +16448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -16498,7 +16498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -16536,7 +16536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -16555,7 +16555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16577,7 +16577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16599,7 +16599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -16621,7 +16621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -16643,7 +16643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -16665,7 +16665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -16737,7 +16737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -16756,7 +16756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -16781,7 +16781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -16806,7 +16806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16831,7 +16831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16856,7 +16856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16881,7 +16881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16906,7 +16906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16931,7 +16931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -16956,7 +16956,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -16981,7 +16981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -17003,7 +17003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -17025,7 +17025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -17047,7 +17047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -17072,7 +17072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -17094,7 +17094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -17113,7 +17113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -17195,7 +17195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -17242,7 +17242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#target-lexicon@0.13.5">
-      <author>Dan Gohman &lt;sunfish@mozilla.com&gt;</author>
+      <author>Dan Gohman &lt;sunfish@mozilla.com></author>
       <name>target-lexicon</name>
       <version>0.13.5</version>
       <description>LLVM target triple types</description>
@@ -17264,7 +17264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -17339,7 +17339,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -17388,7 +17388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17407,7 +17407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -17426,7 +17426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -17448,7 +17448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -17470,7 +17470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -17492,7 +17492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -17517,7 +17517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1">
-      <author>Roger Zurawicki &lt;roger@zura.wiki&gt;</author>
+      <author>Roger Zurawicki &lt;roger@zura.wiki></author>
       <name>tiktoken-rs</name>
       <version>0.9.1</version>
       <description>Library for encoding and decoding with the tiktoken library in Rust</description>
@@ -17542,7 +17542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -17561,7 +17561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -17580,7 +17580,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -17602,7 +17602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -17640,7 +17640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -17659,7 +17659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -17678,7 +17678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -17724,7 +17724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -17746,7 +17746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -17786,7 +17786,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -17862,7 +17862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -17884,7 +17884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -17906,7 +17906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -17928,7 +17928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -17950,7 +17950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -17972,7 +17972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -17997,7 +17997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -18022,7 +18022,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -18044,7 +18044,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -18066,7 +18066,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -18088,7 +18088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -18131,7 +18131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -18153,7 +18153,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -18175,7 +18175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -18197,7 +18197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -18222,7 +18222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -18272,7 +18272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -18294,7 +18294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -18337,7 +18337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -18359,7 +18359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -18430,7 +18430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -18473,7 +18473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unescaper@0.1.8">
-      <author>Hack Ink &lt;hi@hack.ink&gt;, Xavier Lau &lt;x@acg.box&gt;</author>
+      <author>Hack Ink &lt;hi@hack.ink>, Xavier Lau &lt;x@acg.box></author>
       <name>unescaper</name>
       <version>0.1.8</version>
       <description>Unescape strings with escape sequences written out as literal characters.</description>
@@ -18495,7 +18495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -18539,7 +18539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -18564,7 +18564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -18586,7 +18586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -18611,7 +18611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -18636,7 +18636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -18658,7 +18658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18680,7 +18680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -18702,7 +18702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -18749,7 +18749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -18771,7 +18771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18793,7 +18793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -18837,7 +18837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -18859,7 +18859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -18878,7 +18878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -18903,7 +18903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -18925,7 +18925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -18950,7 +18950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -18972,7 +18972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -18991,7 +18991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -19028,7 +19028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -19053,7 +19053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -19075,7 +19075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vergen@8.3.2">
-      <author>Jason Ozias &lt;jason.g.ozias@gmail.com&gt;</author>
+      <author>Jason Ozias &lt;jason.g.ozias@gmail.com></author>
       <name>vergen</name>
       <version>8.3.2</version>
       <description>Generate 'cargo:rustc-env' instructions via 'build.rs' for use in your code via the 'env!' macro</description>
@@ -19100,7 +19100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1">
-      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email&gt;</author>
+      <author>Tim Visee &lt;3a4fb3964f@sinenomine.email></author>
       <name>version-compare</name>
       <version>0.2.1</version>
       <description>Rust library to easily compare version numbers with no specific format, and test against various comparison operators.</description>
@@ -19125,7 +19125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -19147,7 +19147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vob@3.0.6">
-      <author>Laurence Tratt &lt;laurie@tratt.net&gt;</author>
+      <author>Laurence Tratt &lt;laurie@tratt.net></author>
       <name>vob</name>
       <version>3.0.6</version>
       <description>Vector of Bits with Vec-like API and usize backing storage</description>
@@ -19166,7 +19166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -19206,7 +19206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -19228,7 +19228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -19253,7 +19253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -19342,7 +19342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -19424,7 +19424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -19465,7 +19465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -19490,7 +19490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -19512,7 +19512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -19531,7 +19531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -19553,7 +19553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -19572,7 +19572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -19591,7 +19591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -19610,7 +19610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -19629,7 +19629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -19648,7 +19648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -19730,7 +19730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -19768,7 +19768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -19787,7 +19787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -19827,7 +19827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -19849,7 +19849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -19868,7 +19868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -19890,7 +19890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -21051,27 +21051,27 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
@@ -21090,36 +21090,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uaparser@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -21165,7 +21165,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -21196,25 +21196,25 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/audit#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/audit#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21222,36 +21222,36 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonwebtoken@10.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tiktoken-rs@0.9.1" />
@@ -21260,31 +21260,31 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version-compare@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
@@ -21295,10 +21295,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
@@ -21306,38 +21306,38 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#maxminddb@0.27.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
@@ -21346,7 +21346,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -21356,7 +21356,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -21367,7 +21367,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -21383,55 +21383,55 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/node#openobserve-node@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/node#openobserve-node@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
@@ -21441,33 +21441,33 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql_service#promql-service@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql_service#promql-service@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/promql#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/promql#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/promql-parser?branch=openobserve#0.6.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -21478,24 +21478,24 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingestion_common#ingestion-common@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingestion_common#ingestion-common@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
@@ -21504,17 +21504,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
@@ -21524,7 +21524,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21533,48 +21533,48 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datafusion@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search_service#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search_service#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion-functions-json?rev=0df53d710425cc91cf109e77a050bbe1e374e4fe#0.54.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/flight#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/ingester#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/ingester#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/search#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/search#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
@@ -21582,44 +21582,44 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/schema#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/schema#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/super_cluster_queue#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/super_cluster_queue#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/common#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/compaction#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/db#0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/enrichment_data#enrichment-data@0.1.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/common#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/compaction#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/db#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/enrichment_data#enrichment-data@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/core#openobserve-core@0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/core#openobserve-core@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/stream#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/stream#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -21627,10 +21627,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
@@ -21642,9 +21642,9 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -21652,16 +21652,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/tantivy_utils/tantivy_utils.cdx.xml
+++ b/src/tantivy_utils/tantivy_utils.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:01735649-2f69-4564-be2b-775595636a2a" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:54a049d9-6945-490e-a447-4e2ff361a4ab" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.318548000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.918232000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/tantivy_utils#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0 bin-target-0">
           <name>tantivy_utils</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -125,7 +157,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -134,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -143,7 +1566,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -503,19 +1926,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -565,25 +1988,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -653,19 +2098,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -675,19 +2120,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -697,19 +2142,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -719,19 +2164,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -741,19 +2186,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -763,19 +2208,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -785,19 +2230,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -807,19 +2252,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -829,19 +2274,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -851,19 +2296,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -873,19 +2318,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -895,19 +2340,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -917,19 +2362,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -939,19 +2384,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1105,6 +2550,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1130,6 +2594,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1149,19 +2632,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
       <name>async-nats</name>
-      <version>0.46.0</version>
+      <version>0.47.0</version>
       <description>A async Rust NATS client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0</hash>
+        <hash alg="SHA-256">07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/async-nats@0.46.0</purl>
+      <purl>pkg:cargo/async-nats@0.47.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/async-nats</url>
@@ -1171,6 +2654,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/nats-io/nats.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1193,6 +2720,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1470,19 +3016,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1717,19 +3263,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1771,6 +3317,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -1990,6 +3554,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -2012,6 +3595,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2053,6 +3661,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2193,6 +3826,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2595,6 +4250,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2661,6 +4381,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2866,25 +4608,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -3016,6 +4739,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3085,6 +4833,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3279,6 +5045,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3342,6 +5133,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3487,6 +5297,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/core_detect</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
       <author>RustCrypto Developers</author>
       <name>cpufeatures</name>
@@ -3500,6 +5335,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3633,18 +5490,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3731,6 +5588,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3856,6 +5735,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -4026,729 +5926,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4891,6 +6086,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5160,6 +6377,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5385,6 +6621,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5546,6 +6832,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5584,6 +6936,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5907,6 +7281,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6353,28 +7746,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6486,6 +7857,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6882,6 +8271,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6906,27 +8320,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -7004,31 +8416,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -7051,31 +8438,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7318,18 +8680,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7574,6 +8936,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7637,6 +9021,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7706,6 +9115,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7766,6 +9197,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7788,19 +9241,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -7970,22 +9467,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8203,19 +9722,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8250,25 +9769,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8329,6 +9911,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8432,6 +10036,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8451,6 +10074,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8501,19 +10146,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8651,22 +10296,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8689,6 +10356,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8821,6 +10507,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -9106,6 +10836,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
       <name>num_threads</name>
@@ -9176,24 +10944,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9282,6 +11032,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9351,18 +11120,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9541,31 +11310,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9651,19 +11395,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9733,6 +11477,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -10190,6 +11953,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10403,44 +12207,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10616,7 +12382,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -11025,6 +12791,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -11050,18 +12837,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -11195,19 +12982,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11395,28 +13182,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11819,6 +13606,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11938,19 +13747,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -12129,27 +13938,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <name>rustls-native-certs</name>
-      <version>0.7.3</version>
-      <description>rustls-native-certs allows rustls to use the platform native certificate store</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-native-certs@0.7.3</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <name>rustls-native-certs</name>
       <version>0.8.3</version>
@@ -12168,27 +13956,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rustls/rustls-native-certs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <name>rustls-pemfile</name>
-      <version>2.2.0</version>
-      <description>Basic .pem file parser for keys and certificates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-pemfile@2.2.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/pemfile</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/pemfile</url>
         </reference>
       </externalReferences>
     </component>
@@ -12216,78 +13983,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <name>rustls-webpki</name>
-      <version>0.102.8</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.102.8</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12447,28 +14175,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12494,19 +14200,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-cli</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad</hash>
+        <hash alg="SHA-256">da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-cli@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-cli@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12519,19 +14225,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12544,19 +14250,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-migration</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4</hash>
+        <hash alg="SHA-256">07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-migration@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-migration@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12569,19 +14275,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12748,31 +14454,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
-      <name>security-framework</name>
-      <version>2.11.1</version>
-      <description>Security.framework bindings for macOS and iOS</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/security-framework@2.11.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/security_framework</url>
-        </reference>
-        <reference type="website">
-          <url>https://lib.rs/crates/security_framework</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>security-framework</name>
@@ -12795,25 +14476,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -13172,6 +14834,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -13373,19 +15057,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -13433,6 +15117,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13549,19 +15252,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13574,44 +15277,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13637,19 +15315,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -14274,6 +15952,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -14296,77 +16012,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -14386,116 +16031,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14621,6 +16156,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14889,49 +16448,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -15021,19 +16556,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -15345,18 +16880,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
       <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
+      <version>0.33.0</version>
       <description>OpenTelemetry integration for tracing</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
+        <hash alg="SHA-256">adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
+      <purl>pkg:cargo/tracing-opentelemetry@0.33.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
@@ -15551,19 +17086,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15671,7 +17205,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -16199,19 +17733,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16870,6 +18404,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -16997,6 +18550,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -17013,7 +18576,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -17025,12 +18588,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -17048,23 +18611,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17072,7 +19658,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -17080,127 +19666,121 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/tantivy_utils#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
@@ -17260,16 +19840,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -17277,40 +19858,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -17320,41 +19901,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -17364,58 +19946,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -17458,41 +20041,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.46.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
@@ -17501,10 +20102,32 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -17530,7 +20153,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -17549,7 +20172,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17557,7 +20180,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -17565,7 +20188,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17586,7 +20209,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17596,9 +20219,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17608,7 +20231,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17626,7 +20249,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17644,7 +20267,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17663,7 +20286,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17676,7 +20299,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17691,35 +20314,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17733,23 +20350,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17759,7 +20376,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17769,10 +20386,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17788,7 +20405,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17798,9 +20415,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17843,7 +20465,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17861,6 +20483,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17869,10 +20492,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -17894,10 +20532,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -17967,16 +20607,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -18010,10 +20667,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -18031,6 +20684,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -18048,6 +20706,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -18059,7 +20720,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -18085,6 +20746,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -18094,6 +20756,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -18107,14 +20770,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -18132,10 +20799,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -18146,7 +20813,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -18174,6 +20844,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -18218,511 +20894,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18757,6 +20929,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18765,10 +20942,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18778,8 +20955,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18800,16 +20977,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
@@ -18839,6 +21017,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18856,7 +21042,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18868,12 +21054,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18901,7 +21105,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -18917,6 +21121,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -18970,21 +21177,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -18995,19 +21202,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19015,9 +21209,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -19044,6 +21238,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -19066,7 +21265,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -19096,15 +21295,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19113,7 +21309,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19122,7 +21318,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -19134,31 +21330,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -19174,11 +21353,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -19234,9 +21410,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -19269,9 +21445,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -19279,12 +21458,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -19301,10 +21486,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -19328,13 +21518,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -19348,8 +21554,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -19378,10 +21584,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -19400,21 +21609,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -19424,27 +21642,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -19453,7 +21683,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19463,7 +21693,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -19476,13 +21706,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nkeys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
@@ -19502,6 +21740,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
@@ -19551,48 +21798,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19602,8 +21828,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19614,7 +21843,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19650,9 +21879,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19661,17 +21887,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19679,18 +21905,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19701,6 +21927,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19727,12 +21959,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19774,11 +22006,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19810,16 +22047,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19834,7 +22061,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19856,14 +22083,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19962,14 +22189,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -19983,21 +22214,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -20008,13 +22239,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20039,9 +22270,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -20082,7 +22312,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -20104,7 +22334,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -20113,7 +22343,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -20122,7 +22352,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -20148,7 +22378,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20157,6 +22387,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -20164,7 +22429,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -20177,19 +22442,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -20201,7 +22466,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -20243,47 +22508,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.7.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pemfile@2.2.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.102.8">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -20291,7 +22542,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -20299,7 +22550,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -20313,18 +22564,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
@@ -20332,12 +22579,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20345,17 +22592,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20363,10 +22610,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20377,7 +22625,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -20387,7 +22635,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -20406,7 +22654,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20424,31 +22672,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@2.11.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20461,6 +22696,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -20485,14 +22721,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20513,12 +22749,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -20530,7 +22771,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2" />
@@ -20545,12 +22786,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -20574,20 +22826,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20613,7 +22862,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -20626,11 +22875,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -20649,7 +22898,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20697,7 +22946,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20733,7 +22982,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20755,7 +23004,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20768,7 +23017,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20831,7 +23080,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20840,100 +23089,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -20947,6 +23116,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20979,7 +23149,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -20998,32 +23168,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-websockets@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -21035,26 +23200,26 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -21099,9 +23264,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -21121,13 +23286,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21135,11 +23300,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -21158,8 +23323,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
@@ -21194,7 +23359,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
@@ -21210,7 +23375,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -21253,6 +23418,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -21267,7 +23433,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -21276,7 +23442,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -21322,7 +23488,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -21377,13 +23543,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -21483,6 +23649,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/tantivy_utils/tantivy_utils.cdx.xml
+++ b/src/tantivy_utils/tantivy_utils.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:54a049d9-6945-490e-a447-4e2ff361a4ab" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f922a67d-8f04-4aa1-a6f6-04bc2998d830" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.918232000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.495950000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <name>tantivy_utils</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0 bin-target-0">
           <name>tantivy_utils</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/tantivy_utils@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <name>infra</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1566,7 +1566,7 @@
       </licenses>
       <purl>pkg:cargo/infra@0.1.0?download_url=file://../infra</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1576,7 +1576,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1664,7 +1664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1686,7 +1686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1708,7 +1708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1730,7 +1730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1755,10 +1755,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1780,7 +1780,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1805,7 +1805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1830,7 +1830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1927,7 +1927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1967,7 +1967,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1989,7 +1989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2011,10 +2011,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2055,7 +2055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2099,7 +2099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2121,7 +2121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2143,7 +2143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2165,7 +2165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2187,7 +2187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2209,7 +2209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2231,7 +2231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2253,7 +2253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2275,7 +2275,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2297,7 +2297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2319,7 +2319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2341,7 +2341,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2363,7 +2363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2385,7 +2385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2407,7 +2407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2513,7 +2513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2532,7 +2532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2551,7 +2551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2595,7 +2595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2614,7 +2614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2633,7 +2633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-nats@0.47.0">
-      <author>Tomasz Pietrek &lt;tomasz@nats.io&gt;, Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Tomasz Pietrek &lt;tomasz@nats.io>, Casper Beyer &lt;caspervonb@pm.me></author>
       <name>async-nats</name>
       <version>0.47.0</version>
       <description>A async Rust NATS client</description>
@@ -2658,7 +2658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2683,7 +2683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2702,7 +2702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2724,7 +2724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2743,7 +2743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2762,7 +2762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2781,7 +2781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2800,7 +2800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2822,7 +2822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2869,7 +2869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2888,7 +2888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2910,7 +2910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2929,7 +2929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2998,7 +2998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3017,7 +3017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3036,7 +3036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3055,7 +3055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3074,7 +3074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3093,7 +3093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3112,7 +3112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3131,7 +3131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3150,7 +3150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3169,7 +3169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3188,7 +3188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3207,7 +3207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3226,7 +3226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3245,7 +3245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3264,7 +3264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3283,7 +3283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3302,7 +3302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3402,7 +3402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3424,7 +3424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3443,7 +3443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3486,7 +3486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3533,7 +3533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3555,7 +3555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3599,7 +3599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3624,7 +3624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3649,7 +3649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3674,7 +3674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3724,7 +3724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3792,7 +3792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3880,7 +3880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3941,7 +3941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3963,7 +3963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3985,7 +3985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4007,7 +4007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4032,7 +4032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4057,7 +4057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4079,7 +4079,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4101,7 +4101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4123,7 +4123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4142,7 +4142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4161,7 +4161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4186,7 +4186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4208,7 +4208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4251,7 +4251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4297,7 +4297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4338,7 +4338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4363,7 +4363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4385,7 +4385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4429,7 +4429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4448,7 +4448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4539,7 +4539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4609,7 +4609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4631,7 +4631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4653,7 +4653,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4675,7 +4675,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4740,7 +4740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4877,7 +4877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4902,7 +4902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4945,7 +4945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4970,7 +4970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4989,7 +4989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5008,7 +5008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5027,7 +5027,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5093,7 +5093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5115,7 +5115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5156,7 +5156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5178,7 +5178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5197,7 +5197,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5216,7 +5216,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5298,7 +5298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5367,7 +5367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5386,7 +5386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5405,7 +5405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5427,7 +5427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5554,7 +5554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5642,7 +5642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5667,7 +5667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5714,7 +5714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#curve25519-dalek@4.1.3">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>curve25519-dalek</name>
       <version>4.1.3</version>
       <description>A pure-Rust implementation of group operations on ristretto255 and Curve25519</description>
@@ -5760,7 +5760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5782,7 +5782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5804,7 +5804,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5823,7 +5823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5842,7 +5842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5861,7 +5861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5880,7 +5880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5905,7 +5905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5989,7 +5989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6008,7 +6008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6030,7 +6030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6052,7 +6052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6118,7 +6118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6175,7 +6175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6194,7 +6194,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6219,7 +6219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6241,7 +6241,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6263,7 +6263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6288,7 +6288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6313,7 +6313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6378,7 +6378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6397,7 +6397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6422,7 +6422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6444,7 +6444,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ed25519-dalek@2.2.0">
-      <author>isis lovecruft &lt;isis@patternsinthevoid.net&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Michael Rosenberg &lt;michael@mrosenberg.pub&gt;</author>
+      <author>isis lovecruft &lt;isis@patternsinthevoid.net>, Tony Arcieri &lt;bascule@gmail.com>, Michael Rosenberg &lt;michael@mrosenberg.pub></author>
       <name>ed25519-dalek</name>
       <version>2.2.0</version>
       <description>Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust.</description>
@@ -6531,7 +6531,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6553,7 +6553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6575,7 +6575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6597,7 +6597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6622,7 +6622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6647,7 +6647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6726,7 +6726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6748,7 +6748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6770,7 +6770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6789,7 +6789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6808,7 +6808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6833,7 +6833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6855,7 +6855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6877,7 +6877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6899,7 +6899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6921,7 +6921,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6940,7 +6940,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6962,7 +6962,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6981,7 +6981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7043,7 +7043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7065,7 +7065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7090,7 +7090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7112,7 +7112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7134,7 +7134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7156,7 +7156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7175,7 +7175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7213,7 +7213,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7238,7 +7238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7260,7 +7260,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7285,7 +7285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7304,7 +7304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7389,7 +7389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7432,7 +7432,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7520,7 +7520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7587,7 +7587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7700,7 +7700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7747,7 +7747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7769,7 +7769,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7788,7 +7788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7807,7 +7807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7826,7 +7826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7845,7 +7845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7882,7 +7882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7925,7 +7925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7950,7 +7950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7993,7 +7993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8059,7 +8059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8102,7 +8102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8121,7 +8121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8143,7 +8143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8165,7 +8165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8187,7 +8187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8209,7 +8209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8231,7 +8231,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8253,7 +8253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8272,7 +8272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8367,7 +8367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8392,7 +8392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8417,7 +8417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8442,7 +8442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8615,7 +8615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8702,7 +8702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8746,7 +8746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8790,7 +8790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8812,7 +8812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8834,7 +8834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8856,7 +8856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8878,7 +8878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8897,7 +8897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -9003,7 +9003,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -9025,7 +9025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9050,7 +9050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9072,7 +9072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9097,7 +9097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9160,7 +9160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9179,7 +9179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9198,7 +9198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9220,7 +9220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9242,7 +9242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9264,7 +9264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9286,7 +9286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9308,7 +9308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9333,7 +9333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9352,7 +9352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9371,7 +9371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9390,7 +9390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9409,7 +9409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9428,7 +9428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9487,7 +9487,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9509,7 +9509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9534,7 +9534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9556,7 +9556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9597,7 +9597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9641,7 +9641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9663,7 +9663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9704,7 +9704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9723,7 +9723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9748,7 +9748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9770,7 +9770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9792,7 +9792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9811,7 +9811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9830,7 +9830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9855,7 +9855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9880,7 +9880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9943,7 +9943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9968,7 +9968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9990,7 +9990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -10015,7 +10015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -10037,7 +10037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10056,7 +10056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10078,7 +10078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10100,7 +10100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10122,7 +10122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10147,7 +10147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10190,7 +10190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10212,7 +10212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10234,7 +10234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10256,7 +10256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10278,7 +10278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10297,7 +10297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10316,7 +10316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10338,7 +10338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10423,7 +10423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10511,7 +10511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10533,7 +10533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10555,7 +10555,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10574,7 +10574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nuid@0.5.0">
-      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz&gt;</author>
+      <author>Ivan Porto Carrero &lt;ivan@oflanders.co.nz></author>
       <name>nuid</name>
       <version>0.5.0</version>
       <description>A highly performant unique identifier generator.</description>
@@ -10593,7 +10593,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10643,7 +10643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10693,7 +10693,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10837,7 +10837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10856,7 +10856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10875,7 +10875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10948,7 +10948,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10992,7 +10992,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -11014,7 +11014,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11033,7 +11033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -11052,7 +11052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11074,7 +11074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11142,7 +11142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11167,7 +11167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11186,7 +11186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11205,7 +11205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11224,7 +11224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11249,7 +11249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11271,7 +11271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11311,7 +11311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11333,7 +11333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11358,7 +11358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11377,7 +11377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11396,7 +11396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11418,7 +11418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11459,7 +11459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11481,7 +11481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11500,7 +11500,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11557,7 +11557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11582,7 +11582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11607,7 +11607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11632,7 +11632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11701,7 +11701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11720,7 +11720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11758,7 +11758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11831,7 +11831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11853,7 +11853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11910,7 +11910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11932,7 +11932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11954,7 +11954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11973,7 +11973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -12057,7 +12057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12095,7 +12095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12114,7 +12114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12136,7 +12136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12186,7 +12186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12208,7 +12208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12233,7 +12233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12280,7 +12280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12299,7 +12299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12318,7 +12318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12337,7 +12337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12359,7 +12359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12378,7 +12378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12397,7 +12397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12419,7 +12419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12441,7 +12441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12463,7 +12463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12482,7 +12482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12501,7 +12501,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12526,7 +12526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12551,7 +12551,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12573,7 +12573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12595,7 +12595,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12617,7 +12617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12639,7 +12639,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12661,7 +12661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12683,7 +12683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12705,7 +12705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12727,7 +12727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12752,7 +12752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12813,7 +12813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12892,7 +12892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12914,7 +12914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12936,7 +12936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12961,7 +12961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13253,7 +13253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13272,7 +13272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13291,7 +13291,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13313,7 +13313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13335,7 +13335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13403,7 +13403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13428,7 +13428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13453,7 +13453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13478,7 +13478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13503,7 +13503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13525,7 +13525,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13547,7 +13547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13566,7 +13566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13585,7 +13585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13607,7 +13607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13629,7 +13629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13669,7 +13669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13688,7 +13688,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13710,7 +13710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13729,7 +13729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13748,7 +13748,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13770,7 +13770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13792,7 +13792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13814,7 +13814,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13833,7 +13833,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13895,7 +13895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13917,7 +13917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14041,7 +14041,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14063,7 +14063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14085,7 +14085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14129,7 +14129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14176,7 +14176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14201,7 +14201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-cli@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-cli</name>
       <version>1.1.20</version>
       <description>Command line utility for SeaORM</description>
@@ -14226,7 +14226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14251,7 +14251,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-migration</name>
       <version>1.1.20</version>
       <description>Migration utility for SeaORM</description>
@@ -14276,7 +14276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14301,7 +14301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14323,7 +14323,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14345,7 +14345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14367,7 +14367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema-derive@0.3.0">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema-derive</name>
       <version>0.3.0</version>
       <description>Derive macro for sea-schema's Name trait</description>
@@ -14389,7 +14389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-schema@0.16.2">
-      <author>Chris Tsang &lt;tyt2y7@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;tyt2y7@gmail.com></author>
       <name>sea-schema</name>
       <version>0.16.2</version>
       <description>🌿 SQL schema definition and discovery</description>
@@ -14411,7 +14411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14433,7 +14433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14455,7 +14455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14480,7 +14480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14502,7 +14502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14524,7 +14524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14549,7 +14549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14574,7 +14574,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14599,7 +14599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14621,7 +14621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_nanos@0.1.4">
-      <author>Casper Beyer &lt;caspervonb@pm.me&gt;</author>
+      <author>Casper Beyer &lt;caspervonb@pm.me></author>
       <name>serde_nanos</name>
       <version>0.1.4</version>
       <description>Wrapper to process duration and timestamps as nanoseconds</description>
@@ -14640,7 +14640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14662,7 +14662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_repr</name>
       <version>0.1.20</version>
       <description>Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.</description>
@@ -14684,7 +14684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14706,7 +14706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14728,7 +14728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14794,7 +14794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14879,7 +14879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14904,7 +14904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14923,7 +14923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14945,7 +14945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signatory@0.27.1">
-      <author>Tony Arcieri &lt;tony@iqlusion.io&gt;</author>
+      <author>Tony Arcieri &lt;tony@iqlusion.io></author>
       <name>signatory</name>
       <version>0.27.1</version>
       <description>Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support</description>
@@ -14989,7 +14989,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -15008,7 +15008,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -15033,7 +15033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -15058,7 +15058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -15080,7 +15080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -15121,7 +15121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -15140,7 +15140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15162,7 +15162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15184,7 +15184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15206,7 +15206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15228,7 +15228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15253,7 +15253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15278,7 +15278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15316,7 +15316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15366,7 +15366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15385,7 +15385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15404,7 +15404,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15423,7 +15423,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15445,7 +15445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15467,7 +15467,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15489,7 +15489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15511,7 +15511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15533,7 +15533,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15605,7 +15605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15624,7 +15624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15649,7 +15649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15674,7 +15674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15699,7 +15699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15724,7 +15724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15749,7 +15749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15774,7 +15774,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15799,7 +15799,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15821,7 +15821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15843,7 +15843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15865,7 +15865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15890,7 +15890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15912,7 +15912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15931,7 +15931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -16013,7 +16013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -16035,7 +16035,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -16060,7 +16060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -16135,7 +16135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -16184,7 +16184,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16203,7 +16203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16222,7 +16222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16244,7 +16244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16266,7 +16266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16288,7 +16288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16313,7 +16313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16351,7 +16351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16373,7 +16373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16411,7 +16411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16430,7 +16430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16449,7 +16449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16495,7 +16495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16517,7 +16517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16633,7 +16633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16655,7 +16655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16677,7 +16677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16699,7 +16699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16721,7 +16721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16743,7 +16743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16768,7 +16768,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16793,7 +16793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16815,7 +16815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16837,7 +16837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16859,7 +16859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16902,7 +16902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16924,7 +16924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16946,7 +16946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16968,7 +16968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16993,7 +16993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tryhard@0.5.2">
-      <author>Embark &lt;opensource@embark-studios.com&gt;</author>
+      <author>Embark &lt;opensource@embark-studios.com></author>
       <name>tryhard</name>
       <version>0.5.2</version>
       <description>Easily retry futures</description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -17065,7 +17065,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -17108,7 +17108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -17130,7 +17130,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -17176,7 +17176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -17201,7 +17201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -17245,7 +17245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17270,7 +17270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17292,7 +17292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17317,7 +17317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17364,7 +17364,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17386,7 +17386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17408,7 +17408,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17455,7 +17455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17477,7 +17477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17565,7 +17565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17584,7 +17584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17609,7 +17609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17656,7 +17656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17678,7 +17678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17697,7 +17697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17734,7 +17734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17759,7 +17759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17781,7 +17781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17803,7 +17803,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17843,7 +17843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17865,7 +17865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17890,7 +17890,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -18061,7 +18061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -18102,7 +18102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -18127,7 +18127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -18149,7 +18149,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -18168,7 +18168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -18190,7 +18190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -18209,7 +18209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -18228,7 +18228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18247,7 +18247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18266,7 +18266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18285,7 +18285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18367,7 +18367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18405,7 +18405,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18424,7 +18424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18464,7 +18464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18486,7 +18486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18505,7 +18505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18527,7 +18527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19635,7 +19635,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19681,7 +19681,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19712,7 +19712,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
@@ -19722,7 +19722,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
@@ -19733,7 +19733,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-migration@1.1.20" />
@@ -19749,7 +19749,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.33.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19760,7 +19760,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tantivy_utils#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tantivy_utils#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
@@ -19768,10 +19768,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/infra#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/infra#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />

--- a/src/tls/openobserve-tls.cdx.xml
+++ b/src/tls/openobserve-tls.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:917d6c61-b2bc-489f-b1a6-75059a9b7893" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:37.214177000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+      <name>openobserve-tls</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0 bin-target-0">
+          <name>openobserve_tls</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -2221,28 +2221,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
@@ -2522,6 +2500,72 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/askama-rs/askama</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>asn1-rs-derive</name>
+      <version>0.6.0</version>
+      <description>Derive macros for the `asn1-rs` crate</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/asn1-rs-derive@0.6.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/asn1-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/asn1-rs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>asn1-rs-impl</name>
+      <version>0.2.0</version>
+      <description>Implementation details for the `asn1-rs` crate</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/asn1-rs-impl@0.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/asn1-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/asn1-rs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>asn1-rs</name>
+      <version>0.7.1</version>
+      <description>Parser/encoder for ASN.1 BER/DER data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/asn1-rs@0.7.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/asn1-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/asn1-rs.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -5929,6 +5973,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>der-parser</name>
+      <version>10.0.0</version>
+      <description>Parser/encoder for ASN.1 BER/DER data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/der-parser@10.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/der-parser</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/der-parser.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -10842,6 +10908,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>oid-registry</name>
+      <version>0.8.1</version>
+      <description>Object Identifier (OID) database</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oid-registry@0.8.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/oid-registry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/oid-registry.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
       <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
       <name>once_cell</name>
@@ -13742,6 +13830,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/djc/rustc-version-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>rusticata-macros</name>
+      <version>4.1.0</version>
+      <description>Helper macros for Rusticata</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rusticata-macros@4.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/rusticata-macros</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/rusticata-macros.git</url>
         </reference>
       </externalReferences>
     </component>
@@ -17756,6 +17866,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1">
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <name>x509-parser</name>
+      <version>0.18.1</version>
+      <description>Parser for the X.509 v3 format (RFC 5280 certificates)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/x509-parser@0.18.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rusticata/x509-parser</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rusticata/x509-parser.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
       <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
       <name>xmlparser</name>
@@ -19342,20 +19474,6 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +19484,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19501,20 +19630,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
@@ -19628,6 +19743,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
@@ -20459,6 +20595,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
@@ -21366,6 +21510,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
     </dependency>
@@ -22042,6 +22189,9 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
@@ -23056,6 +23206,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />

--- a/src/tls/openobserve-tls.cdx.xml
+++ b/src/tls/openobserve-tls.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:917d6c61-b2bc-489f-b1a6-75059a9b7893" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:4361f443-e793-4429-af16-5e358ad413e8" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.214177000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.761366000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <name>openobserve-tls</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0 bin-target-0">
           <name>openobserve_tls</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/openobserve-tls@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-derive@0.6.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-derive</name>
       <version>0.6.0</version>
       <description>Derive macros for the `asn1-rs` crate</description>
@@ -2526,7 +2526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs-impl@0.2.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs-impl</name>
       <version>0.2.0</version>
       <description>Implementation details for the `asn1-rs` crate</description>
@@ -2548,7 +2548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#asn1-rs@0.7.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>asn1-rs</name>
       <version>0.7.1</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2589,7 +2589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2608,7 +2608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2627,7 +2627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2652,7 +2652,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2671,7 +2671,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2715,7 +2715,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2734,7 +2734,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2756,7 +2756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2775,7 +2775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2794,7 +2794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2813,7 +2813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2832,7 +2832,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2854,7 +2854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2901,7 +2901,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2920,7 +2920,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2942,7 +2942,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2961,7 +2961,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -3030,7 +3030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3049,7 +3049,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3068,7 +3068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3087,7 +3087,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3106,7 +3106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3125,7 +3125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3144,7 +3144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3163,7 +3163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3182,7 +3182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3201,7 +3201,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3220,7 +3220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3239,7 +3239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3258,7 +3258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3277,7 +3277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3296,7 +3296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3315,7 +3315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3334,7 +3334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3434,7 +3434,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3456,7 +3456,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3475,7 +3475,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3518,7 +3518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3565,7 +3565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3587,7 +3587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3631,7 +3631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3656,7 +3656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3681,7 +3681,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3706,7 +3706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3756,7 +3756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3824,7 +3824,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3912,7 +3912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3995,7 +3995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4017,7 +4017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -4039,7 +4039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4064,7 +4064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4111,7 +4111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4133,7 +4133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4155,7 +4155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4193,7 +4193,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4218,7 +4218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4240,7 +4240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4283,7 +4283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4370,7 +4370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4417,7 +4417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4461,7 +4461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4480,7 +4480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4571,7 +4571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4663,7 +4663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4685,7 +4685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4707,7 +4707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4772,7 +4772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4909,7 +4909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4934,7 +4934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4977,7 +4977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -5002,7 +5002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -5021,7 +5021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -5040,7 +5040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5059,7 +5059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5125,7 +5125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5147,7 +5147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5188,7 +5188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5210,7 +5210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5229,7 +5229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5248,7 +5248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5330,7 +5330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5399,7 +5399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5418,7 +5418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5437,7 +5437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5459,7 +5459,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5586,7 +5586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5674,7 +5674,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5699,7 +5699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5767,7 +5767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5789,7 +5789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5811,7 +5811,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5830,7 +5830,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5849,7 +5849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5868,7 +5868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5887,7 +5887,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5912,7 +5912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5977,7 +5977,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#der-parser@10.0.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>der-parser</name>
       <version>10.0.0</version>
       <description>Parser/encoder for ASN.1 BER/DER data</description>
@@ -6018,7 +6018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -6037,7 +6037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6081,7 +6081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6147,7 +6147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6223,7 +6223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6248,7 +6248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6270,7 +6270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6292,7 +6292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6317,7 +6317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6342,7 +6342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6367,7 +6367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6407,7 +6407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6426,7 +6426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6451,7 +6451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6513,7 +6513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6535,7 +6535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6557,7 +6557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6579,7 +6579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6604,7 +6604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6629,7 +6629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6708,7 +6708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6730,7 +6730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6752,7 +6752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6790,7 +6790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6837,7 +6837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6859,7 +6859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6881,7 +6881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6903,7 +6903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6922,7 +6922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6944,7 +6944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6963,7 +6963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -7025,7 +7025,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -7047,7 +7047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7072,7 +7072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7094,7 +7094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7116,7 +7116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7138,7 +7138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7157,7 +7157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7195,7 +7195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7220,7 +7220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7242,7 +7242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7267,7 +7267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7286,7 +7286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7371,7 +7371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7502,7 +7502,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7569,7 +7569,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7729,7 +7729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7751,7 +7751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7770,7 +7770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7789,7 +7789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7808,7 +7808,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7827,7 +7827,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7864,7 +7864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7886,7 +7886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7911,7 +7911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7954,7 +7954,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -8020,7 +8020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8063,7 +8063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8148,7 +8148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8170,7 +8170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8192,7 +8192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8214,7 +8214,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8233,7 +8233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8328,7 +8328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8353,7 +8353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8378,7 +8378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8403,7 +8403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8576,7 +8576,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8663,7 +8663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8773,7 +8773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8795,7 +8795,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8817,7 +8817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8839,7 +8839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8858,7 +8858,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8964,7 +8964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8986,7 +8986,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -9011,7 +9011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -9033,7 +9033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9058,7 +9058,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9121,7 +9121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9140,7 +9140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9203,7 +9203,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9225,7 +9225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9247,7 +9247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9269,7 +9269,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9294,7 +9294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9313,7 +9313,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9332,7 +9332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9351,7 +9351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9370,7 +9370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9389,7 +9389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9448,7 +9448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9495,7 +9495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9517,7 +9517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9558,7 +9558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9602,7 +9602,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9624,7 +9624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9709,7 +9709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9731,7 +9731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9753,7 +9753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9772,7 +9772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9791,7 +9791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9841,7 +9841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9904,7 +9904,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9976,7 +9976,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9998,7 +9998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -10017,7 +10017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -10039,7 +10039,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10061,7 +10061,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10083,7 +10083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10108,7 +10108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10173,7 +10173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10195,7 +10195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10217,7 +10217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10239,7 +10239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10258,7 +10258,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10277,7 +10277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10299,7 +10299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10447,7 +10447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10469,7 +10469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10491,7 +10491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10510,7 +10510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10560,7 +10560,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10610,7 +10610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10754,7 +10754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10773,7 +10773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10792,7 +10792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10865,7 +10865,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10909,7 +10909,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oid-registry@0.8.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>oid-registry</name>
       <version>0.8.1</version>
       <description>Object Identifier (OID) database</description>
@@ -10931,7 +10931,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10953,7 +10953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10972,7 +10972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10991,7 +10991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -11013,7 +11013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11081,7 +11081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11106,7 +11106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11125,7 +11125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11144,7 +11144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11163,7 +11163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11188,7 +11188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11210,7 +11210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11250,7 +11250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11272,7 +11272,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11297,7 +11297,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11316,7 +11316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11335,7 +11335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11357,7 +11357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11398,7 +11398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11420,7 +11420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11439,7 +11439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11496,7 +11496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11521,7 +11521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11546,7 +11546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11571,7 +11571,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11640,7 +11640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11659,7 +11659,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11678,7 +11678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11697,7 +11697,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11770,7 +11770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11792,7 +11792,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11849,7 +11849,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11871,7 +11871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11893,7 +11893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11912,7 +11912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11996,7 +11996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -12034,7 +12034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -12053,7 +12053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12075,7 +12075,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12125,7 +12125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12172,7 +12172,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12219,7 +12219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12238,7 +12238,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12257,7 +12257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12276,7 +12276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12298,7 +12298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12317,7 +12317,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12336,7 +12336,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12358,7 +12358,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12380,7 +12380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12421,7 +12421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12440,7 +12440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12465,7 +12465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12578,7 +12578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12600,7 +12600,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12622,7 +12622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12644,7 +12644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12666,7 +12666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12691,7 +12691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12752,7 +12752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12831,7 +12831,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12853,7 +12853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12875,7 +12875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12900,7 +12900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13192,7 +13192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13211,7 +13211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13230,7 +13230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13252,7 +13252,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13274,7 +13274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13293,7 +13293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13342,7 +13342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13367,7 +13367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13392,7 +13392,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13417,7 +13417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13442,7 +13442,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13464,7 +13464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13486,7 +13486,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13505,7 +13505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13524,7 +13524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13546,7 +13546,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13568,7 +13568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13608,7 +13608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13627,7 +13627,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13649,7 +13649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13668,7 +13668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13687,7 +13687,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13709,7 +13709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13731,7 +13731,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13753,7 +13753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13772,7 +13772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13834,7 +13834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rusticata-macros@4.1.0">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>rusticata-macros</name>
       <version>4.1.0</version>
       <description>Helper macros for Rusticata</description>
@@ -13856,7 +13856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13878,7 +13878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -14002,7 +14002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -14024,7 +14024,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14046,7 +14046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14090,7 +14090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14137,7 +14137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14162,7 +14162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14187,7 +14187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14212,7 +14212,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14234,7 +14234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14256,7 +14256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14278,7 +14278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14300,7 +14300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14322,7 +14322,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14347,7 +14347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14369,7 +14369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14391,7 +14391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14416,7 +14416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14441,7 +14441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14466,7 +14466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14510,7 +14510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14532,7 +14532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14554,7 +14554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14620,7 +14620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14705,7 +14705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14749,7 +14749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14837,7 +14837,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14862,7 +14862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14884,7 +14884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14925,7 +14925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14944,7 +14944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14966,7 +14966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14988,7 +14988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -15010,7 +15010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -15032,7 +15032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15057,7 +15057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15082,7 +15082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15120,7 +15120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15170,7 +15170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15189,7 +15189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15208,7 +15208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15227,7 +15227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15249,7 +15249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15271,7 +15271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15293,7 +15293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15315,7 +15315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15337,7 +15337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15409,7 +15409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15428,7 +15428,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15453,7 +15453,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15478,7 +15478,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15503,7 +15503,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15528,7 +15528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15553,7 +15553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15578,7 +15578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15603,7 +15603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15625,7 +15625,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15647,7 +15647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15669,7 +15669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15694,7 +15694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15716,7 +15716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15735,7 +15735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15817,7 +15817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15839,7 +15839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15864,7 +15864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15939,7 +15939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15988,7 +15988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16007,7 +16007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16026,7 +16026,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16048,7 +16048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16070,7 +16070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16092,7 +16092,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16117,7 +16117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16136,7 +16136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16155,7 +16155,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16177,7 +16177,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16215,7 +16215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16234,7 +16234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16253,7 +16253,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16299,7 +16299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16321,7 +16321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16343,7 +16343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16419,7 +16419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16441,7 +16441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16463,7 +16463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16485,7 +16485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16507,7 +16507,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16529,7 +16529,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16554,7 +16554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16623,7 +16623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16645,7 +16645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16667,7 +16667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16689,7 +16689,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16711,7 +16711,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16733,7 +16733,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16783,7 +16783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16805,7 +16805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16848,7 +16848,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16870,7 +16870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16916,7 +16916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16941,7 +16941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16985,7 +16985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17010,7 +17010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17032,7 +17032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17057,7 +17057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17082,7 +17082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17104,7 +17104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17126,7 +17126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17148,7 +17148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17195,7 +17195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17283,7 +17283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17305,7 +17305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17324,7 +17324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17349,7 +17349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17371,7 +17371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17396,7 +17396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17418,7 +17418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17437,7 +17437,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17474,7 +17474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17499,7 +17499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17521,7 +17521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17543,7 +17543,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17583,7 +17583,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17605,7 +17605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17630,7 +17630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17719,7 +17719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17801,7 +17801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17842,7 +17842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17867,7 +17867,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#x509-parser@0.18.1">
-      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net&gt;</author>
+      <author>Pierre Chifflier &lt;chifflier@wzdftpd.net></author>
       <name>x509-parser</name>
       <version>0.18.1</version>
       <description>Parser for the X.509 v3 format (RFC 5280 certificates)</description>
@@ -17889,7 +17889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17911,7 +17911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17930,7 +17930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17952,7 +17952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17971,7 +17971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17990,7 +17990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -18009,7 +18009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18028,7 +18028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18047,7 +18047,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18129,7 +18129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18167,7 +18167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18186,7 +18186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18226,7 +18226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18248,7 +18248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18267,7 +18267,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18289,7 +18289,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19397,7 +19397,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19443,7 +19443,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19474,7 +19474,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19485,9 +19485,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/tls#openobserve-tls@0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/tls#openobserve-tls@0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />

--- a/src/transform/transform.cdx.xml
+++ b/src/transform/transform.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:75397c08-662c-4905-bac1-5bcd39628de2" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:bb74b1c7-c4f8-4724-a298-707ad852bd14" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.682554000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.268654000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/transform@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0 bin-target-0">
           <name>transform</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/transform@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,24 +979,24 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>enrichment</name>
       <version>0.1.0</version>
       <scope>required</scope>
-      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vector-vrl-category</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>MPL-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -1004,7 +1004,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1015,7 +1015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1023,7 +1023,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1034,7 +1034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1042,7 +1042,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1053,7 +1053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1061,7 +1061,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1072,7 +1072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1080,7 +1080,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1091,7 +1091,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1099,7 +1099,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1110,7 +1110,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1118,7 +1118,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1129,7 +1129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1137,7 +1137,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1148,7 +1148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1156,7 +1156,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1167,7 +1167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1175,7 +1175,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1186,7 +1186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1194,7 +1194,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1205,7 +1205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1213,7 +1213,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1224,7 +1224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1232,7 +1232,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1243,7 +1243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1251,7 +1251,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1262,7 +1262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1270,7 +1270,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1281,7 +1281,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1289,7 +1289,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1300,7 +1300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1308,7 +1308,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1319,7 +1319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1327,7 +1327,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1338,7 +1338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1346,7 +1346,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1357,7 +1357,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1365,7 +1365,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1376,7 +1376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1384,7 +1384,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1403,7 +1403,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1414,7 +1414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1422,7 +1422,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1433,7 +1433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1441,7 +1441,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1452,7 +1452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1460,7 +1460,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1471,7 +1471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1479,7 +1479,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1490,7 +1490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1498,7 +1498,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1509,7 +1509,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1517,7 +1517,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1528,7 +1528,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1536,7 +1536,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1547,7 +1547,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1555,7 +1555,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1565,7 +1565,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1574,7 +1574,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1584,7 +1584,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1672,7 +1672,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1694,7 +1694,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1716,7 +1716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1738,7 +1738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1763,10 +1763,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1788,7 +1788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1813,7 +1813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1838,7 +1838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1935,7 +1935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1975,7 +1975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1997,7 +1997,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2019,10 +2019,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2063,7 +2063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2107,7 +2107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2129,7 +2129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2151,7 +2151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2173,7 +2173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2195,7 +2195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2217,7 +2217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2239,7 +2239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2261,7 +2261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2283,7 +2283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2305,7 +2305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2327,7 +2327,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2349,7 +2349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2371,7 +2371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2393,7 +2393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2415,7 +2415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2521,7 +2521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2540,7 +2540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2559,7 +2559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2578,7 +2578,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2603,7 +2603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2622,7 +2622,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2641,7 +2641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2666,7 +2666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2685,7 +2685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2707,7 +2707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2726,7 +2726,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2745,7 +2745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2764,7 +2764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2783,7 +2783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2805,7 +2805,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2852,7 +2852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2871,7 +2871,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2893,7 +2893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2912,7 +2912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2981,7 +2981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -3000,7 +3000,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3019,7 +3019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3038,7 +3038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3057,7 +3057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3076,7 +3076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3095,7 +3095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3114,7 +3114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3133,7 +3133,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3152,7 +3152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3171,7 +3171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3190,7 +3190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3209,7 +3209,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3228,7 +3228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3247,7 +3247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3266,7 +3266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3285,7 +3285,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3385,7 +3385,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3407,7 +3407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3426,7 +3426,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3469,7 +3469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3516,7 +3516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3538,7 +3538,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3582,7 +3582,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3607,7 +3607,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3632,7 +3632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3657,7 +3657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3707,7 +3707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3775,7 +3775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3863,7 +3863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3924,7 +3924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3946,7 +3946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3968,7 +3968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3990,7 +3990,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -4015,7 +4015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4040,7 +4040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4062,7 +4062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4084,7 +4084,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4106,7 +4106,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4125,7 +4125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4144,7 +4144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4169,7 +4169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4191,7 +4191,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4234,7 +4234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4280,7 +4280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4321,7 +4321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4346,7 +4346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4368,7 +4368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4412,7 +4412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4431,7 +4431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4522,7 +4522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4592,7 +4592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4614,7 +4614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4636,7 +4636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4658,7 +4658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4723,7 +4723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4860,7 +4860,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4885,7 +4885,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4928,7 +4928,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4953,7 +4953,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4972,7 +4972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4991,7 +4991,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -5010,7 +5010,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5076,7 +5076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5098,7 +5098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5120,7 +5120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
-      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <author>Nugine &lt;nugine@foxmail.com></author>
       <name>const-str</name>
       <version>1.1.0</version>
       <description>compile-time string operations</description>
@@ -5158,7 +5158,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5180,7 +5180,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5199,7 +5199,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5218,7 +5218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5300,7 +5300,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5369,7 +5369,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5388,7 +5388,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5407,7 +5407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5429,7 +5429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5556,7 +5556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5644,7 +5644,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5669,7 +5669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5737,7 +5737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5759,7 +5759,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5781,7 +5781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5800,7 +5800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5819,7 +5819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5838,7 +5838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5857,7 +5857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5882,7 +5882,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5966,7 +5966,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5985,7 +5985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -6007,7 +6007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -6029,7 +6029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6095,7 +6095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6152,7 +6152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6171,7 +6171,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6196,7 +6196,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6218,7 +6218,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6240,7 +6240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6265,7 +6265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6290,7 +6290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6315,7 +6315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6355,7 +6355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6374,7 +6374,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6399,7 +6399,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6461,7 +6461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6483,7 +6483,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6505,7 +6505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6527,7 +6527,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6552,7 +6552,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6577,7 +6577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6656,7 +6656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6678,7 +6678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6700,7 +6700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6719,7 +6719,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6738,7 +6738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6763,7 +6763,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6785,7 +6785,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6807,7 +6807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6829,7 +6829,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6851,7 +6851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6870,7 +6870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6892,7 +6892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6911,7 +6911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6973,7 +6973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6995,7 +6995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -7020,7 +7020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7042,7 +7042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7064,7 +7064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7086,7 +7086,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7105,7 +7105,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7143,7 +7143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7168,7 +7168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7190,7 +7190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7215,7 +7215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7234,7 +7234,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7319,7 +7319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7362,7 +7362,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7450,7 +7450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7517,7 +7517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7630,7 +7630,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7677,7 +7677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7699,7 +7699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7718,7 +7718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7737,7 +7737,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7756,7 +7756,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7775,7 +7775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7812,7 +7812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7834,7 +7834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7859,7 +7859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7902,7 +7902,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7968,7 +7968,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -8011,7 +8011,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -8030,7 +8030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8052,7 +8052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8074,7 +8074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8096,7 +8096,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8118,7 +8118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8140,7 +8140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8162,7 +8162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8181,7 +8181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8276,7 +8276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8301,7 +8301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8326,7 +8326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8351,7 +8351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8524,7 +8524,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8611,7 +8611,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8655,7 +8655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8699,7 +8699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8721,7 +8721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8743,7 +8743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8765,7 +8765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8787,7 +8787,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8806,7 +8806,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8912,7 +8912,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8934,7 +8934,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8959,7 +8959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8981,7 +8981,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -9006,7 +9006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9069,7 +9069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9088,7 +9088,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9107,7 +9107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9129,7 +9129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9151,7 +9151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9173,7 +9173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9195,7 +9195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9217,7 +9217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9242,7 +9242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9261,7 +9261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9280,7 +9280,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9299,7 +9299,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9318,7 +9318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9337,7 +9337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9396,7 +9396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9418,7 +9418,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9443,7 +9443,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9465,7 +9465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9506,7 +9506,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9550,7 +9550,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9572,7 +9572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9613,7 +9613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9632,7 +9632,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9657,7 +9657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9679,7 +9679,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9701,7 +9701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9720,7 +9720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9739,7 +9739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9764,7 +9764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9789,7 +9789,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9852,7 +9852,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9877,7 +9877,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9899,7 +9899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9924,7 +9924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9946,7 +9946,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9965,7 +9965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9987,7 +9987,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -10009,7 +10009,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -10031,7 +10031,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10056,7 +10056,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10099,7 +10099,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10121,7 +10121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10143,7 +10143,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10165,7 +10165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10187,7 +10187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10206,7 +10206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10225,7 +10225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10247,7 +10247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10307,7 +10307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10395,7 +10395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10417,7 +10417,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10439,7 +10439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10458,7 +10458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10508,7 +10508,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10558,7 +10558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10702,7 +10702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10721,7 +10721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10740,7 +10740,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10813,7 +10813,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10857,7 +10857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10879,7 +10879,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10898,7 +10898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10917,7 +10917,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10939,7 +10939,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -11007,7 +11007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -11032,7 +11032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11051,7 +11051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11070,7 +11070,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11089,7 +11089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11114,7 +11114,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11136,7 +11136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11176,7 +11176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11198,7 +11198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11223,7 +11223,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11242,7 +11242,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11261,7 +11261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11283,7 +11283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11324,7 +11324,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11346,7 +11346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11365,7 +11365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11422,7 +11422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11447,7 +11447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11472,7 +11472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11497,7 +11497,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11566,7 +11566,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11585,7 +11585,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11604,7 +11604,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11623,7 +11623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11696,7 +11696,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11718,7 +11718,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11775,7 +11775,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11797,7 +11797,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11819,7 +11819,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11838,7 +11838,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11922,7 +11922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11960,7 +11960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11979,7 +11979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -12001,7 +12001,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12051,7 +12051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12073,7 +12073,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12098,7 +12098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12145,7 +12145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12164,7 +12164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12183,7 +12183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12202,7 +12202,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12224,7 +12224,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12243,7 +12243,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12262,7 +12262,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12284,7 +12284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12306,7 +12306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12328,7 +12328,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12347,7 +12347,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12366,7 +12366,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12391,7 +12391,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12416,7 +12416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12438,7 +12438,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12460,7 +12460,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12482,7 +12482,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12504,7 +12504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12526,7 +12526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12548,7 +12548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12570,7 +12570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12592,7 +12592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12617,7 +12617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12678,7 +12678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12757,7 +12757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12779,7 +12779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12801,7 +12801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12826,7 +12826,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13118,7 +13118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13137,7 +13137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13156,7 +13156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13178,7 +13178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13200,7 +13200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13219,7 +13219,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13268,7 +13268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13293,7 +13293,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13318,7 +13318,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13343,7 +13343,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13368,7 +13368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13390,7 +13390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13412,7 +13412,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13431,7 +13431,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13450,7 +13450,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13472,7 +13472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13494,7 +13494,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13534,7 +13534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13553,7 +13553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13575,7 +13575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13594,7 +13594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13613,7 +13613,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13635,7 +13635,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13657,7 +13657,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs-core</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -13676,7 +13676,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com></author>
       <name>rquickjs-sys</name>
       <version>0.11.0</version>
       <description>QuickJS bindings for rquickjs</description>
@@ -13695,7 +13695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
-      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com>, K. &lt;kayo@illumium.org></author>
       <name>rquickjs</name>
       <version>0.11.0</version>
       <description>High level bindings to the QuickJS JavaScript engine</description>
@@ -13714,7 +13714,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13736,7 +13736,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13755,7 +13755,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13817,7 +13817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13839,7 +13839,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13963,7 +13963,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13985,7 +13985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -14007,7 +14007,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -14051,7 +14051,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14098,7 +14098,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14123,7 +14123,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14148,7 +14148,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14173,7 +14173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14195,7 +14195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14217,7 +14217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14239,7 +14239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14261,7 +14261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14283,7 +14283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14308,7 +14308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14330,7 +14330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14352,7 +14352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14377,7 +14377,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14402,7 +14402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14427,7 +14427,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14449,7 +14449,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14471,7 +14471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14493,7 +14493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14515,7 +14515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14581,7 +14581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14666,7 +14666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14691,7 +14691,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14710,7 +14710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14754,7 +14754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14773,7 +14773,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14798,7 +14798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14823,7 +14823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14845,7 +14845,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14886,7 +14886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14905,7 +14905,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14927,7 +14927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14949,7 +14949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14971,7 +14971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14993,7 +14993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -15018,7 +15018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -15043,7 +15043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15081,7 +15081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15131,7 +15131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15150,7 +15150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15169,7 +15169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15188,7 +15188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15210,7 +15210,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15232,7 +15232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15254,7 +15254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15276,7 +15276,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15298,7 +15298,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15370,7 +15370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15389,7 +15389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15414,7 +15414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15439,7 +15439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15464,7 +15464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15489,7 +15489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15514,7 +15514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15539,7 +15539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.27.2</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15564,7 +15564,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15589,7 +15589,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15614,7 +15614,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15636,7 +15636,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15658,7 +15658,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15680,7 +15680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15705,7 +15705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15727,7 +15727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15746,7 +15746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15828,7 +15828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15850,7 +15850,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15875,7 +15875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15950,7 +15950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15999,7 +15999,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16018,7 +16018,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -16037,7 +16037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -16059,7 +16059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -16081,7 +16081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16103,7 +16103,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16128,7 +16128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16147,7 +16147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16166,7 +16166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16188,7 +16188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16226,7 +16226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16245,7 +16245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16264,7 +16264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16310,7 +16310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16332,7 +16332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16354,7 +16354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16430,7 +16430,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16452,7 +16452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16474,7 +16474,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16496,7 +16496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16518,7 +16518,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16540,7 +16540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16565,7 +16565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16590,7 +16590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16612,7 +16612,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16634,7 +16634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16656,7 +16656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16678,7 +16678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16700,7 +16700,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16722,7 +16722,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16744,7 +16744,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16794,7 +16794,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16816,7 +16816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16859,7 +16859,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16881,7 +16881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16927,7 +16927,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16952,7 +16952,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16996,7 +16996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -17021,7 +17021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -17043,7 +17043,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -17068,7 +17068,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -17093,7 +17093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17115,7 +17115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17137,7 +17137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17159,7 +17159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17206,7 +17206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17228,7 +17228,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17250,7 +17250,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17294,7 +17294,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17316,7 +17316,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17335,7 +17335,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17360,7 +17360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17382,7 +17382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17407,7 +17407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17429,7 +17429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17448,7 +17448,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17485,7 +17485,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17510,7 +17510,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17532,7 +17532,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17554,7 +17554,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17594,7 +17594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17616,7 +17616,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17641,7 +17641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17730,7 +17730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17812,7 +17812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17853,7 +17853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17878,7 +17878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17900,7 +17900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17919,7 +17919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17941,7 +17941,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17960,7 +17960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17979,7 +17979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17998,7 +17998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -18017,7 +18017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -18036,7 +18036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18118,7 +18118,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18156,7 +18156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18175,7 +18175,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18215,7 +18215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18237,7 +18237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18256,7 +18256,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18278,7 +18278,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19399,7 +19399,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19445,7 +19445,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19476,7 +19476,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19487,9 +19487,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/transform#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />

--- a/src/transform/transform.cdx.xml
+++ b/src/transform/transform.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:75397c08-662c-4905-bac1-5bcd39628de2" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.682554000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <name>transform</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/transform@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0 bin-target-0">
+          <name>transform</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/transform@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -977,6 +977,23 @@
           <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>enrichment</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <purl>pkg:cargo/enrichment@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <name>vector-vrl-category</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vector-vrl-category@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vector%3Fbranch=branch-v0.54%405b87303cb89c1279407f9b64f267ff6a546fc679</purl>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
@@ -2212,28 +2229,6 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/arrow-data@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -5121,6 +5116,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0">
+      <author>Nugine &lt;nugine@foxmail.com&gt;</author>
+      <name>const-str</name>
+      <version>1.1.0</version>
+      <description>compile-time string operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-str@1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Nugine/const-str</url>
         </reference>
       </externalReferences>
     </component>
@@ -13642,6 +13656,63 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs-core</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-core@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;</author>
+      <name>rquickjs-sys</name>
+      <version>0.11.0</version>
+      <description>QuickJS bindings for rquickjs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs-sys@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <author>Mees Delzenne &lt;mees.delzenne@gmail.com&gt;, K. &lt;kayo@illumium.org&gt;</author>
+      <name>rquickjs</name>
+      <version>0.11.0</version>
+      <description>High level bindings to the QuickJS JavaScript engine</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rquickjs@0.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/DelSkayn/rquickjs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
       <name>rsa</name>
@@ -15392,6 +15463,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum@0.27.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
       <name>strum</name>
@@ -15430,6 +15526,31 @@
         <expression>MIT</expression>
       </licenses>
       <purl>pkg:cargo/strum_macros@0.26.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/strum</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Peternator7/strum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <name>strum_macros</name>
+      <version>0.27.2</version>
+      <description>Helpful macros for working with enums and strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/strum_macros@0.27.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/strum</url>
@@ -18863,6 +18984,19 @@
     <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#vector-vrl-category@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2" />
+    </dependency>
     <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
@@ -19342,20 +19476,6 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +19486,16 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/transform#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vector?branch=branch-v0.54#enrichment@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +19630,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
@@ -20324,6 +20440,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-str@1.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
@@ -22011,6 +22128,17 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-sys@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rquickjs-core@0.11.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -22525,6 +22653,9 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0" />
     </dependency>
@@ -22533,6 +22664,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.27.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">

--- a/src/usage_reporting/usage_reporting.cdx.xml
+++ b/src/usage_reporting/usage_reporting.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:63387a1a-a5b0-45cc-8d47-57e0b349d209" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:0ee088e4-f357-4364-9864-8bdfd3956413" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.900496000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.955766000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,19 +9,19 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <name>flight</name>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
       <licenses>
         <expression>AGPL-3.0</expression>
       </licenses>
-      <purl>pkg:cargo/flight@0.1.0?download_url=file://.</purl>
+      <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0 bin-target-0">
-          <name>flight</name>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0 bin-target-0">
+          <name>usage_reporting</name>
           <version>0.1.0</version>
-          <purl>pkg:cargo/flight@0.1.0?download_url=file://.#src/lib.rs</purl>
+          <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://.#src/lib.rs</purl>
         </component>
       </components>
     </component>
@@ -2212,28 +2212,6 @@
         <expression>Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/arrow-data@58.3.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
-      <name>arrow-flight</name>
-      <version>58.3.0</version>
-      <description>Apache Arrow Flight</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/arrow-flight@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -19342,20 +19320,6 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/flight#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
-      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-    </dependency>
     <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
@@ -19366,6 +19330,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2">
@@ -19500,20 +19471,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-flight@58.3.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />

--- a/src/usage_reporting/usage_reporting.cdx.xml
+++ b/src/usage_reporting/usage_reporting.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:0ee088e4-f357-4364-9864-8bdfd3956413" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:662efbdf-06ed-460e-a9e7-ccaf156a9da7" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.955766000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.530787000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <name>usage_reporting</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0 bin-target-0">
           <name>usage_reporting</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/usage_reporting@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2542,7 +2542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2709,7 +2709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2747,7 +2747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2766,7 +2766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2835,7 +2835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2854,7 +2854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2876,7 +2876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2895,7 +2895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2964,7 +2964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -2983,7 +2983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3002,7 +3002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3021,7 +3021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3040,7 +3040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3059,7 +3059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3097,7 +3097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3116,7 +3116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3135,7 +3135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3154,7 +3154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3173,7 +3173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3192,7 +3192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3211,7 +3211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3230,7 +3230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3368,7 +3368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3390,7 +3390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3409,7 +3409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3452,7 +3452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3499,7 +3499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3565,7 +3565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3690,7 +3690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3758,7 +3758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3846,7 +3846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3907,7 +3907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3929,7 +3929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4108,7 +4108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4127,7 +4127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4152,7 +4152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4217,7 +4217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4263,7 +4263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4505,7 +4505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4575,7 +4575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4597,7 +4597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4706,7 +4706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4843,7 +4843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4868,7 +4868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4911,7 +4911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4936,7 +4936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4974,7 +4974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -4993,7 +4993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5059,7 +5059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5081,7 +5081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5122,7 +5122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5163,7 +5163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5182,7 +5182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5264,7 +5264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5333,7 +5333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5352,7 +5352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5371,7 +5371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5520,7 +5520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5608,7 +5608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5701,7 +5701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5723,7 +5723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5745,7 +5745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5764,7 +5764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5783,7 +5783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5802,7 +5802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5821,7 +5821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5846,7 +5846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5930,7 +5930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5949,7 +5949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -5993,7 +5993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6135,7 +6135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6160,7 +6160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6182,7 +6182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6229,7 +6229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6279,7 +6279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6425,7 +6425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6620,7 +6620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6642,7 +6642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6702,7 +6702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6727,7 +6727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6749,7 +6749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6875,7 +6875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6937,7 +6937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6959,7 +6959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -6984,7 +6984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7006,7 +7006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7028,7 +7028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7050,7 +7050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7107,7 +7107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7132,7 +7132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7179,7 +7179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7198,7 +7198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7283,7 +7283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7481,7 +7481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7594,7 +7594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7641,7 +7641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7663,7 +7663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7701,7 +7701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7720,7 +7720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7739,7 +7739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7776,7 +7776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7823,7 +7823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7866,7 +7866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7932,7 +7932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7975,7 +7975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -7994,7 +7994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8016,7 +8016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8060,7 +8060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8145,7 +8145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8240,7 +8240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8265,7 +8265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8488,7 +8488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8575,7 +8575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8619,7 +8619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8663,7 +8663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8685,7 +8685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8729,7 +8729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8770,7 +8770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8876,7 +8876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8923,7 +8923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8970,7 +8970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9033,7 +9033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9052,7 +9052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9071,7 +9071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9093,7 +9093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9115,7 +9115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9137,7 +9137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9206,7 +9206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9225,7 +9225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9244,7 +9244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9263,7 +9263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9282,7 +9282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9360,7 +9360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9382,7 +9382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9514,7 +9514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9596,7 +9596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9621,7 +9621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9728,7 +9728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9753,7 +9753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9841,7 +9841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9863,7 +9863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9888,7 +9888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -9995,7 +9995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10020,7 +10020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10063,7 +10063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10085,7 +10085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10170,7 +10170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10189,7 +10189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10211,7 +10211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10271,7 +10271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10381,7 +10381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10403,7 +10403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10422,7 +10422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10522,7 +10522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10666,7 +10666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10685,7 +10685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10704,7 +10704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10777,7 +10777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10821,7 +10821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10843,7 +10843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10862,7 +10862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10971,7 +10971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -10996,7 +10996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11015,7 +11015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11053,7 +11053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11078,7 +11078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11140,7 +11140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11162,7 +11162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11187,7 +11187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11206,7 +11206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11225,7 +11225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11288,7 +11288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11310,7 +11310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11329,7 +11329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11386,7 +11386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11436,7 +11436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11461,7 +11461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11568,7 +11568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11587,7 +11587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11682,7 +11682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11802,7 +11802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11886,7 +11886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11943,7 +11943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12015,7 +12015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12037,7 +12037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12062,7 +12062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12166,7 +12166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12188,7 +12188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12207,7 +12207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12226,7 +12226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12248,7 +12248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12292,7 +12292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12311,7 +12311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12330,7 +12330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12355,7 +12355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12380,7 +12380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12424,7 +12424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12581,7 +12581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12642,7 +12642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12721,7 +12721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12790,7 +12790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13142,7 +13142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13164,7 +13164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13183,7 +13183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13232,7 +13232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13257,7 +13257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13307,7 +13307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13332,7 +13332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13376,7 +13376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13395,7 +13395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13414,7 +13414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13436,7 +13436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13498,7 +13498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13558,7 +13558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13577,7 +13577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13662,7 +13662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13746,7 +13746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13870,7 +13870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13958,7 +13958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14005,7 +14005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14030,7 +14030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14055,7 +14055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14124,7 +14124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14146,7 +14146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14168,7 +14168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14215,7 +14215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14334,7 +14334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14378,7 +14378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14400,7 +14400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14573,7 +14573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14598,7 +14598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14617,7 +14617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14661,7 +14661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14680,7 +14680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14705,7 +14705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14834,7 +14834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14878,7 +14878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14900,7 +14900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14925,7 +14925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14950,7 +14950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -14988,7 +14988,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15038,7 +15038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15057,7 +15057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15076,7 +15076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15095,7 +15095,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15117,7 +15117,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15139,7 +15139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15161,7 +15161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15183,7 +15183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15277,7 +15277,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15296,7 +15296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15321,7 +15321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15346,7 +15346,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15371,7 +15371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15396,7 +15396,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15421,7 +15421,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15446,7 +15446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15471,7 +15471,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15493,7 +15493,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15515,7 +15515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15537,7 +15537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15562,7 +15562,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15584,7 +15584,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15603,7 +15603,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15685,7 +15685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15707,7 +15707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15732,7 +15732,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15807,7 +15807,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15856,7 +15856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15875,7 +15875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15894,7 +15894,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15916,7 +15916,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15938,7 +15938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -15960,7 +15960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -15985,7 +15985,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16004,7 +16004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16023,7 +16023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16045,7 +16045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16083,7 +16083,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16102,7 +16102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16121,7 +16121,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16167,7 +16167,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16189,7 +16189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16211,7 +16211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16287,7 +16287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16309,7 +16309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16353,7 +16353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16375,7 +16375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16397,7 +16397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16422,7 +16422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16447,7 +16447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16469,7 +16469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16491,7 +16491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16513,7 +16513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16651,7 +16651,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16673,7 +16673,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16716,7 +16716,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16738,7 +16738,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16784,7 +16784,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16809,7 +16809,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16853,7 +16853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16878,7 +16878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16900,7 +16900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16925,7 +16925,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16950,7 +16950,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -16972,7 +16972,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17063,7 +17063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17085,7 +17085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17107,7 +17107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17151,7 +17151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17173,7 +17173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17192,7 +17192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17239,7 +17239,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17264,7 +17264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17286,7 +17286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17305,7 +17305,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17342,7 +17342,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17367,7 +17367,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17389,7 +17389,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17411,7 +17411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17451,7 +17451,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17473,7 +17473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17498,7 +17498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17587,7 +17587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17669,7 +17669,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17710,7 +17710,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17735,7 +17735,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17757,7 +17757,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17776,7 +17776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17798,7 +17798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17817,7 +17817,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17836,7 +17836,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17855,7 +17855,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17874,7 +17874,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17893,7 +17893,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -17975,7 +17975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18013,7 +18013,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18032,7 +18032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18072,7 +18072,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18094,7 +18094,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18113,7 +18113,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18135,7 +18135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19243,7 +19243,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19289,7 +19289,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19320,7 +19320,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19331,10 +19331,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/usage_reporting#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/usage_reporting#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>

--- a/src/wal/wal.cdx.xml
+++ b/src/wal/wal.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:7e0253b1-c714-449c-bb77-07912771d585" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:ca27568e-52cb-4290-82e9-5265d5393c11" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:36.737330000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.322364000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/wal@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0 bin-target-0">
           <name>wal</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/wal@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error-attr2</name>
       <version>2.0.0</version>
       <description>Attribute macro for the proc-macro-error2 crate</description>
@@ -39,7 +39,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -47,7 +47,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru>, GnomedDev &lt;david2005thomas@gmail.com></author>
       <name>proc-macro-error2</name>
       <version>2.0.1</version>
       <description>Almost drop-in replacement to panics in proc-macros</description>
@@ -55,7 +55,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/GnomedDev/proc-macro-error-2</url>
@@ -63,7 +63,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide</name>
       <version>0.7.0</version>
       <description>Library for interacting with a chrome instance with the chrome devtools protocol</description>
@@ -71,7 +71,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -82,7 +82,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_cdp@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_cdp</name>
       <version>0.7.0</version>
       <description>Contains all the generated types for chromiumoxide</description>
@@ -90,7 +90,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_cdp@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -101,7 +101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_fetcher</name>
       <version>0.7.0</version>
       <description>Contains a chromium fetcher</description>
@@ -109,7 +109,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_fetcher@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -120,7 +120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_pdl</name>
       <version>0.7.0</version>
       <description>Contains a PDL parser and rust generator</description>
@@ -128,7 +128,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_pdl@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -139,7 +139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_types@0.7.0">
-      <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
+      <author>Matthias Seitz &lt;matthias.seitz@outlook.de></author>
       <name>chromiumoxide_types</name>
       <version>0.7.0</version>
       <description>Contains the essential types necessary for using chromiumoxide</description>
@@ -147,7 +147,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%3Frev=6f2392f78ae851e2acf33df8e9764cc299d837db%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
+      <purl>pkg:cargo/chromiumoxide_types@0.7.0?vcs_url=git%2Bhttps://github.com/mattsse/chromiumoxide%406f2392f78ae851e2acf33df8e9764cc299d837db</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mattsse/chromiumoxide</url>
@@ -165,7 +165,7 @@
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/apache/arrow-rs-object-store</url>
@@ -173,7 +173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion</name>
       <version>54.0.0</version>
       <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
@@ -181,7 +181,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -192,7 +192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog-listing</name>
       <version>54.0.0</version>
       <description>datafusion-catalog-listing</description>
@@ -200,7 +200,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -211,7 +211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-catalog</name>
       <version>54.0.0</version>
       <description>datafusion-catalog</description>
@@ -219,7 +219,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -230,7 +230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common-runtime</name>
       <version>54.0.0</version>
       <description>Common Runtime functionality for DataFusion query engine</description>
@@ -238,7 +238,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -249,7 +249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-common</name>
       <version>54.0.0</version>
       <description>Common functionality for DataFusion query engine</description>
@@ -257,7 +257,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -268,7 +268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-arrow</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-arrow</description>
@@ -276,7 +276,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -287,7 +287,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-csv</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-csv</description>
@@ -295,7 +295,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -306,7 +306,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-json</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-json</description>
@@ -314,7 +314,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -325,7 +325,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource-parquet</name>
       <version>54.0.0</version>
       <description>datafusion-datasource-parquet</description>
@@ -333,7 +333,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -344,7 +344,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-datasource</name>
       <version>54.0.0</version>
       <description>datafusion-datasource</description>
@@ -352,7 +352,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -363,7 +363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-doc</name>
       <version>54.0.0</version>
       <description>Documentation module for DataFusion query engine</description>
@@ -371,7 +371,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -382,7 +382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-execution</name>
       <version>54.0.0</version>
       <description>Execution configuration support for DataFusion query engine</description>
@@ -390,7 +390,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -401,7 +401,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr-common</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -409,7 +409,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-expr</name>
       <version>54.0.0</version>
       <description>Logical plan and expression representation for DataFusion query engine</description>
@@ -428,7 +428,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -439,7 +439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate-common</name>
       <version>54.0.0</version>
       <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
@@ -447,7 +447,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -458,7 +458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-aggregate</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -466,7 +466,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -477,7 +477,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-nested</name>
       <version>54.0.0</version>
       <description>Nested Type Function packages for the DataFusion query engine</description>
@@ -485,7 +485,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -496,7 +496,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-table</name>
       <version>54.0.0</version>
       <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
@@ -504,7 +504,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -515,7 +515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window-common</name>
       <version>54.0.0</version>
       <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
@@ -523,7 +523,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -534,7 +534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions-window</name>
       <version>54.0.0</version>
       <description>Window function packages for the DataFusion query engine</description>
@@ -542,7 +542,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -553,7 +553,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-functions</name>
       <version>54.0.0</version>
       <description>Function packages for the DataFusion query engine</description>
@@ -561,7 +561,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -572,7 +572,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-macros</name>
       <version>54.0.0</version>
       <description>Procedural macros for DataFusion query engine</description>
@@ -580,7 +580,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -591,7 +591,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Query Optimizer</description>
@@ -599,7 +599,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -610,7 +610,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-adapter</name>
       <version>54.0.0</version>
       <description>Physical expression schema adaptation utilities for DataFusion</description>
@@ -618,7 +618,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -629,7 +629,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr-common</name>
       <version>54.0.0</version>
       <description>Common functionality of physical expression for DataFusion query engine</description>
@@ -637,7 +637,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -648,7 +648,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-expr</name>
       <version>54.0.0</version>
       <description>Physical expression implementation for DataFusion query engine</description>
@@ -656,7 +656,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -667,7 +667,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-optimizer</name>
       <version>54.0.0</version>
       <description>DataFusion Physical Optimizer</description>
@@ -675,7 +675,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-physical-plan</name>
       <version>54.0.0</version>
       <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
@@ -694,7 +694,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto-common</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion common types</description>
@@ -713,7 +713,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-proto</name>
       <version>54.0.0</version>
       <description>Protobuf serialization of DataFusion logical plan expressions</description>
@@ -732,7 +732,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -743,7 +743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-pruning</name>
       <version>54.0.0</version>
       <description>DataFusion Pruning Logic</description>
@@ -751,7 +751,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -762,7 +762,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-session</name>
       <version>54.0.0</version>
       <description>datafusion-session</description>
@@ -770,7 +770,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -781,7 +781,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>datafusion-sql</name>
       <version>54.0.0</version>
       <description>DataFusion SQL Query Planner</description>
@@ -789,7 +789,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
       <externalReferences>
         <reference type="website">
           <url>https://datafusion.apache.org</url>
@@ -800,7 +800,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy</name>
       <version>0.26.1</version>
       <description>Search engine library</description>
@@ -808,7 +808,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy/</url>
@@ -822,7 +822,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>ownedbytes</name>
       <version>0.9.0</version>
       <description>Expose data as static slice</description>
@@ -830,7 +830,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/ownedbytes/</url>
@@ -844,7 +844,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-bitpacker</name>
       <version>0.10.0</version>
       <description>Tantivy-sub crate: bitpacking</description>
@@ -852,7 +852,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
@@ -873,7 +873,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -884,7 +884,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <author>Paul Masurel &lt;paul@quickwit.io>, Pascal Seitz &lt;pascal@quickwit.io></author>
       <name>tantivy-common</name>
       <version>0.11.0</version>
       <description>common traits and utility functions used by multiple tantivy subcrates</description>
@@ -892,7 +892,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/tantivy_common/</url>
@@ -906,7 +906,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>tantivy-query-grammar</name>
       <version>0.26.0</version>
       <description>Search engine library</description>
@@ -914,7 +914,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -932,7 +932,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -950,7 +950,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -968,7 +968,7 @@
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/quickwit-oss/tantivy</url>
@@ -979,7 +979,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex</name>
       <version>0.1.0</version>
       <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
@@ -987,7 +987,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -998,7 +998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-alp</name>
       <version>0.1.0</version>
       <description>Vortex ALP array</description>
@@ -1006,7 +1006,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1017,7 +1017,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array-macros</name>
       <version>0.1.0</version>
       <description>Proc macros for slot-oriented Vortex array helpers</description>
@@ -1025,7 +1025,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1036,7 +1036,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-array</name>
       <version>0.1.0</version>
       <description>Vortex in memory columnar data format</description>
@@ -1044,7 +1044,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1055,7 +1055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-btrblocks</name>
       <version>0.1.0</version>
       <description>BtrBlocks style compressor</description>
@@ -1063,7 +1063,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1074,7 +1074,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-buffer</name>
       <version>0.1.0</version>
       <description>A byte buffer implementation for Vortex</description>
@@ -1082,7 +1082,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1093,7 +1093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-bytebool</name>
       <version>0.1.0</version>
       <description>Vortex byte-boolean array</description>
@@ -1101,7 +1101,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1112,7 +1112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-compressor</name>
       <version>0.1.0</version>
       <description>Encoding-agnostic compression framework for Vortex arrays</description>
@@ -1120,7 +1120,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1131,7 +1131,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-datetime-parts</name>
       <version>0.1.0</version>
       <description>Vortex physical encoding that compresses temporal components individually</description>
@@ -1139,7 +1139,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1150,7 +1150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-decimal-byte-parts</name>
       <version>0.1.0</version>
       <description>Vortex decimal array (non-canonical) encodings</description>
@@ -1158,7 +1158,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1169,7 +1169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-error</name>
       <version>0.1.0</version>
       <description>Vortex errors</description>
@@ -1177,7 +1177,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1188,7 +1188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fastlanes</name>
       <version>0.1.0</version>
       <description>Vortex fastlanes arrays</description>
@@ -1196,7 +1196,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1207,7 +1207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-file</name>
       <version>0.1.0</version>
       <description>Vortex file readers and writers</description>
@@ -1215,7 +1215,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1226,7 +1226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-flatbuffers</name>
       <version>0.1.0</version>
       <description>Flatbuffers definitions for Vortex types</description>
@@ -1234,7 +1234,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1245,7 +1245,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-fsst</name>
       <version>0.1.0</version>
       <description>Vortex FSST string array encoding</description>
@@ -1253,7 +1253,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1264,7 +1264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-io</name>
       <version>0.1.0</version>
       <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
@@ -1272,7 +1272,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1283,7 +1283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-ipc</name>
       <version>0.1.0</version>
       <description>IPC message format to exchange Vortex arrays across processes</description>
@@ -1291,7 +1291,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1302,7 +1302,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-layout</name>
       <version>0.1.0</version>
       <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
@@ -1310,7 +1310,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1321,7 +1321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-mask</name>
       <version>0.1.0</version>
       <description>Vortex Mask - sorted, unique, non-negative integers</description>
@@ -1329,7 +1329,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1340,7 +1340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-metrics</name>
       <version>0.1.0</version>
       <description>Vortex Metrics</description>
@@ -1348,7 +1348,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1359,7 +1359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-pco</name>
       <version>0.1.0</version>
       <description>Vortex Pco array</description>
@@ -1367,7 +1367,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1378,7 +1378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-proto</name>
       <version>0.1.0</version>
       <description>Protocol buffer definitions for Vortex types</description>
@@ -1386,7 +1386,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1397,7 +1397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-runend</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1405,7 +1405,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1416,7 +1416,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-scan</name>
       <version>0.1.0</version>
       <description>Scanning operations for Vortex</description>
@@ -1424,7 +1424,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1435,7 +1435,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sequence</name>
       <version>0.1.0</version>
       <description>Vortex run end encoded array</description>
@@ -1443,7 +1443,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1454,7 +1454,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-session</name>
       <version>0.1.0</version>
       <description>Session object for Vortex</description>
@@ -1462,7 +1462,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1473,7 +1473,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-sparse</name>
       <version>0.1.0</version>
       <description>Vortex Sparse array</description>
@@ -1481,7 +1481,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1492,7 +1492,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-utils</name>
       <version>0.1.0</version>
       <description>Common definitions across crates</description>
@@ -1500,7 +1500,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1511,7 +1511,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zigzag</name>
       <version>0.1.0</version>
       <description>Vortex zig zag array</description>
@@ -1519,7 +1519,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1530,7 +1530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
-      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <author>Vortex Authors &lt;hello@vortex.dev></author>
       <name>vortex-zstd</name>
       <version>0.1.0</version>
       <description>Vortex zstd compression array encoding</description>
@@ -1538,7 +1538,7 @@
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/spiraldb/vortex</url>
@@ -1548,7 +1548,7 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1557,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -1567,7 +1567,7 @@
       <purl>pkg:cargo/proto@0.1.0?download_url=file://../proto</purl>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -1655,7 +1655,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.8">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.7.8</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1677,7 +1677,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>ahash</name>
       <version>0.8.12</version>
       <description>A non-cryptographic hash function using AES-NI for high performance</description>
@@ -1699,7 +1699,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -1721,7 +1721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aliasable@0.1.3">
-      <author>avitex &lt;avitex@wfxlabs.com&gt;</author>
+      <author>avitex &lt;avitex@wfxlabs.com></author>
       <name>aliasable</name>
       <version>0.1.3</version>
       <description>Basic aliasable (non unique pointer) types</description>
@@ -1746,10 +1746,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -1771,7 +1771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -1796,7 +1796,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -1821,7 +1821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ansi_term@0.12.1">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>ansi_term</name>
       <version>0.12.1</version>
       <description>Library for ANSI terminal colours and styles (bold, underline)</description>
@@ -1918,7 +1918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>anyhow</name>
       <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
@@ -1958,7 +1958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me&gt;, Brian L. Troutwine &lt;brian@troutwine.us&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Simonas Kazlauskas &lt;arbitrary@kazlauskas.me>, Brian L. Troutwine &lt;brian@troutwine.us>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>arbitrary</name>
       <version>1.4.2</version>
       <description>The trait for generating structured data from unstructured data</description>
@@ -1980,7 +1980,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>arc-swap</name>
       <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
@@ -2002,10 +2002,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
-      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Authors &lt;hello@spiraldb.com></author>
       <name>arcref</name>
       <version>0.2.0</version>
-      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T></description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
@@ -2046,7 +2046,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9">
-      <author>David Roundy &lt;roundyd@physics.oregonstate.edu&gt;</author>
+      <author>David Roundy &lt;roundyd@physics.oregonstate.edu></author>
       <name>arrayref</name>
       <version>0.3.9</version>
       <description>Macros to take array references of slices</description>
@@ -2090,7 +2090,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-arith</name>
       <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
@@ -2112,7 +2112,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-array</name>
       <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
@@ -2134,7 +2134,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-buffer</name>
       <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
@@ -2156,7 +2156,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-cast</name>
       <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
@@ -2178,7 +2178,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-csv</name>
       <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
@@ -2200,7 +2200,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-data</name>
       <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
@@ -2222,7 +2222,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ipc</name>
       <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
@@ -2244,7 +2244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-json</name>
       <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
@@ -2266,7 +2266,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-ord</name>
       <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
@@ -2288,7 +2288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-row</name>
       <version>58.3.0</version>
       <description>Arrow row format</description>
@@ -2310,7 +2310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-schema</name>
       <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
@@ -2332,7 +2332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-select</name>
       <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
@@ -2354,7 +2354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow-string</name>
       <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
@@ -2376,7 +2376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>arrow</name>
       <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
@@ -2398,7 +2398,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ascii-canvas</name>
       <version>4.0.0</version>
       <description>simple canvas for drawing lines and styled text and emitting to the terminal</description>
@@ -2504,7 +2504,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-channel</name>
       <version>2.5.0</version>
       <description>Async multi-producer multi-consumer channel</description>
@@ -2523,7 +2523,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>async-compression</name>
       <version>0.4.41</version>
       <description>Adaptors between compression crates and Rust's modern asynchronous IO types. </description>
@@ -2542,7 +2542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>async-executor</name>
       <version>1.14.0</version>
       <description>Async executor</description>
@@ -2561,7 +2561,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-fs</name>
       <version>2.2.0</version>
       <description>Async filesystem primitives</description>
@@ -2586,7 +2586,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-io</name>
       <version>2.6.0</version>
       <description>Async I/O and timers</description>
@@ -2605,7 +2605,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-lock</name>
       <version>3.4.2</version>
       <description>Async synchronization primitives</description>
@@ -2624,7 +2624,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-net</name>
       <version>2.0.0</version>
       <description>Async networking primitives for TCP/UDP/Unix communication</description>
@@ -2649,7 +2649,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-process</name>
       <version>2.5.0</version>
       <description>Async interface for working with processes</description>
@@ -2668,7 +2668,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
-      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com&gt;</author>
+      <author>Robert Usher &lt;266585+dcchut@users.noreply.github.com></author>
       <name>async-recursion</name>
       <version>1.1.1</version>
       <description>Recursion for async functions</description>
@@ -2690,7 +2690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>async-signal</name>
       <version>0.2.14</version>
       <description>Async signal handling</description>
@@ -2709,7 +2709,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream-impl</name>
       <version>0.3.6</version>
       <description>proc macros for async-stream crate</description>
@@ -2728,7 +2728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>async-stream</name>
       <version>0.3.6</version>
       <description>Asynchronous streams using async &amp; await notation</description>
@@ -2747,7 +2747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>async-task</name>
       <version>4.7.1</version>
       <description>Task abstraction for building executors</description>
@@ -2766,7 +2766,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>async-trait</name>
       <version>0.1.89</version>
       <description>Type erasure for async trait methods</description>
@@ -2788,7 +2788,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2">
-      <author>Sebastian Dröge &lt;sebastian@centricular.com&gt;</author>
+      <author>Sebastian Dröge &lt;sebastian@centricular.com></author>
       <name>async-tungstenite</name>
       <version>0.28.2</version>
       <description>Async binding for Tungstenite, the Lightweight stream-based WebSocket implementation</description>
@@ -2835,7 +2835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -2854,7 +2854,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -2876,7 +2876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-config</name>
       <version>1.8.15</version>
       <description>AWS SDK config and credential provider implementations.</description>
@@ -2895,7 +2895,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-credential-types</name>
       <version>1.2.14</version>
       <description>Types for AWS SDK credentials.</description>
@@ -2964,7 +2964,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-runtime</name>
       <version>1.7.2</version>
       <description>Runtime support code for the AWS SDK. This crate isn't intended to be used directly.</description>
@@ -2983,7 +2983,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sns</name>
       <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
@@ -3002,7 +3002,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sso@1.96.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sso</name>
       <version>1.96.0</version>
       <description>AWS SDK for AWS Single Sign-On</description>
@@ -3021,7 +3021,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-ssooidc@1.98.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-ssooidc</name>
       <version>1.98.0</version>
       <description>AWS SDK for AWS SSO OIDC</description>
@@ -3040,7 +3040,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sts@1.100.0">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-sdk-sts</name>
       <version>1.100.0</version>
       <description>AWS SDK for AWS Security Token Service</description>
@@ -3059,7 +3059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sigv4@1.4.2">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, David Barsky &lt;me@davidbarsky.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, David Barsky &lt;me@davidbarsky.com></author>
       <name>aws-sigv4</name>
       <version>1.4.2</version>
       <description>SigV4 signer for HTTP requests and Event Stream messages.</description>
@@ -3078,7 +3078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-async</name>
       <version>1.2.14</version>
       <description>Async runtime agnostic abstractions for smithy-rs.</description>
@@ -3097,7 +3097,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-http-client</name>
       <version>1.1.12</version>
       <description>HTTP client abstractions for generated smithy clients</description>
@@ -3116,7 +3116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-http</name>
       <version>0.63.6</version>
       <description>Smithy HTTP logic for smithy-rs.</description>
@@ -3135,7 +3135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-json</name>
       <version>0.62.5</version>
       <description>Token streaming JSON parser for smithy-rs.</description>
@@ -3154,7 +3154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com></author>
       <name>aws-smithy-observability</name>
       <version>0.2.6</version>
       <description>Smithy observability implementation.</description>
@@ -3173,7 +3173,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, John DiSanti &lt;jdisanti@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, John DiSanti &lt;jdisanti@amazon.com></author>
       <name>aws-smithy-query</name>
       <version>0.60.15</version>
       <description>AWSQuery and EC2Query Smithy protocol logic for smithy-rs.</description>
@@ -3192,7 +3192,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime-api</name>
       <version>1.11.6</version>
       <description>Smithy runtime types.</description>
@@ -3211,7 +3211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Zelda Hessler &lt;zhessler@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Zelda Hessler &lt;zhessler@amazon.com></author>
       <name>aws-smithy-runtime</name>
       <version>1.10.3</version>
       <description>The new smithy runtime crate</description>
@@ -3230,7 +3230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-types</name>
       <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
@@ -3249,7 +3249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-smithy-xml</name>
       <version>0.60.15</version>
       <description>XML parsing logic for Smithy protocols.</description>
@@ -3268,7 +3268,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14">
-      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
+      <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com>, Russell Cohen &lt;rcoh@amazon.com></author>
       <name>aws-types</name>
       <version>1.3.14</version>
       <description>Cross-service types for the AWS SDK.</description>
@@ -3368,7 +3368,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base-encode@0.3.1">
-      <author>Janis Pritzkau &lt;janispritzkau@gmail.com&gt;</author>
+      <author>Janis Pritzkau &lt;janispritzkau@gmail.com></author>
       <name>base-encode</name>
       <version>0.3.1</version>
       <description>Encode and decode data to any base.</description>
@@ -3390,7 +3390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base16@0.2.1">
-      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com&gt;</author>
+      <author>Thom Chiovoloni &lt;tchiovoloni@mozilla.com></author>
       <name>base16</name>
       <version>0.2.1</version>
       <description>base16 (hex) encoding and decoding</description>
@@ -3409,7 +3409,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base62@2.2.3">
-      <author>François Bernier &lt;frankbernier@gmail.com&gt;, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com&gt;</author>
+      <author>François Bernier &lt;frankbernier@gmail.com>, Chai T. Rex &lt;ChaiTRex@users.noreply.github.com></author>
       <name>base62</name>
       <version>2.2.3</version>
       <description>A Base62 encoding/decoding library</description>
@@ -3452,7 +3452,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -3499,7 +3499,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>basic-toml</name>
       <version>0.1.10</version>
       <description>Minimal TOML library with few dependencies</description>
@@ -3521,7 +3521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>better_io</name>
       <version>0.2.0</version>
       <description>Better traits and implementations for IO and buffering</description>
@@ -3565,7 +3565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
-      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com>, Emilio Cobos Álvarez &lt;emilio@crisal.io>, Nick Fitzgerald &lt;fitzgen@gmail.com>, The Servo project developers</author>
       <name>bindgen</name>
       <version>0.72.1</version>
       <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
@@ -3590,7 +3590,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-set</name>
       <version>0.8.0</version>
       <description>A set of bits</description>
@@ -3615,7 +3615,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.8.0</version>
       <description>A vector of bits</description>
@@ -3640,7 +3640,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
-      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com></author>
       <name>bit-vec</name>
       <version>0.9.1</version>
       <description>A vector of bits</description>
@@ -3690,7 +3690,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>bitpacking</name>
       <version>0.9.3</version>
       <description>Fast integer compression/decompression via SIMD bit-packing. Port of simdcomp to rust.</description>
@@ -3758,7 +3758,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3">
-      <author>Jack O'Connor &lt;oconnor663@gmail.com&gt;, Samuel Neves</author>
+      <author>Jack O'Connor &lt;oconnor663@gmail.com>, Samuel Neves</author>
       <name>blake3</name>
       <version>1.8.3</version>
       <description>the BLAKE3 hash function</description>
@@ -3846,7 +3846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>blocking</name>
       <version>1.6.2</version>
       <description>A thread pool for isolating blocking I/O in async programs</description>
@@ -3907,7 +3907,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borrow-or-share@0.2.4">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>borrow-or-share</name>
       <version>0.2.4</version>
       <description>Traits for either borrowing or sharing data.</description>
@@ -3929,7 +3929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh-derive@1.6.0">
-      <author>Near Inc &lt;hello@nearprotocol.com&gt;</author>
+      <author>Near Inc &lt;hello@nearprotocol.com></author>
       <name>borsh-derive</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3951,7 +3951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#borsh@1.6.0">
-      <author>Near Inc &lt;hello@near.org&gt;</author>
+      <author>Near Inc &lt;hello@near.org></author>
       <name>borsh</name>
       <version>1.6.0</version>
       <description>Binary Object Representation Serializer for Hashing </description>
@@ -3973,7 +3973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -3998,7 +3998,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -4023,7 +4023,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>bumpalo</name>
       <version>3.20.2</version>
       <description>A fast bump allocation arena for Rust.</description>
@@ -4045,7 +4045,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4067,7 +4067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecheck_derive@0.6.12">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>bytecheck_derive</name>
       <version>0.6.12</version>
       <description>Derive macro for bytecheck</description>
@@ -4089,7 +4089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytecount@0.6.9">
-      <author>Andre Bogus &lt;bogusandre@gmail.de&gt;, Joshua Landau &lt;joshua@landau.ws&gt;</author>
+      <author>Andre Bogus &lt;bogusandre@gmail.de>, Joshua Landau &lt;joshua@landau.ws></author>
       <name>bytecount</name>
       <version>0.6.9</version>
       <description>count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast</description>
@@ -4108,7 +4108,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>bytemuck</name>
       <version>1.25.0</version>
       <description>A crate for mucking around with piles of bytes.</description>
@@ -4127,7 +4127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -4152,7 +4152,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz></author>
       <name>bytes-utils</name>
       <version>0.1.4</version>
       <description>Additional utilities for working with the bytes crate</description>
@@ -4174,7 +4174,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -4217,7 +4217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
-      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <author>Without Boats &lt;saoirse@without.boats>, Ashley Williams &lt;ashley666ashley@gmail.com>, Steve Klabnik &lt;steve@steveklabnik.com>, Rain &lt;rain@sunshowers.io></author>
       <name>camino</name>
       <version>1.2.3</version>
       <description>UTF-8 paths</description>
@@ -4263,7 +4263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
-      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de></author>
       <name>cargo_metadata</name>
       <version>0.19.2</version>
       <description>structured access to the output of `cargo metadata`</description>
@@ -4304,7 +4304,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -4329,7 +4329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>census</name>
       <version>0.4.2</version>
       <description>Keeps an inventory of living objects</description>
@@ -4351,7 +4351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
-      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl></author>
       <name>cexpr</name>
       <version>0.6.0</version>
       <description>A C expression parser and evaluator</description>
@@ -4395,7 +4395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -4414,7 +4414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1">
-      <author>Zicklag &lt;zicklag@katharostech.com&gt;</author>
+      <author>Zicklag &lt;zicklag@katharostech.com></author>
       <name>cfg_aliases</name>
       <version>0.2.1</version>
       <description>A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.</description>
@@ -4505,7 +4505,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#charset@0.1.5">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>charset</name>
       <version>0.1.5</version>
       <description>Character encoding decoding for email</description>
@@ -4575,7 +4575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-io</name>
       <version>0.2.2</version>
       <description>Simplified Read/Write traits for no_std usage</description>
@@ -4597,7 +4597,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium-ll</name>
       <version>0.2.2</version>
       <description>Low-level CBOR codec primitives</description>
@@ -4619,7 +4619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium@0.2.2">
-      <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
+      <author>Nathaniel McCallum &lt;npmccallum@profian.com></author>
       <name>ciborium</name>
       <version>0.2.2</version>
       <description>serde implementation of CBOR using ciborium-basic</description>
@@ -4641,7 +4641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cidr@0.3.2">
-      <author>Stefan Bühler &lt;stbuehler@web.de&gt;</author>
+      <author>Stefan Bühler &lt;stbuehler@web.de></author>
       <name>cidr</name>
       <version>0.3.2</version>
       <description>IP network and IP host within network types</description>
@@ -4706,7 +4706,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
-      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <author>Kyle Mayes &lt;kyle@mayeses.com></author>
       <name>clang-sys</name>
       <version>1.8.1</version>
       <description>Rust bindings for libclang.</description>
@@ -4843,7 +4843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cmake@0.1.57">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cmake</name>
       <version>0.1.57</version>
       <description>A build dependency for running `cmake` to build a native library </description>
@@ -4868,7 +4868,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
-      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au&gt;</author>
+      <author>Brendan Zabarauskas &lt;bjzaba@yahoo.com.au></author>
       <name>codespan-reporting</name>
       <version>0.12.0</version>
       <description>Beautiful diagnostic reporting for text-based programming languages</description>
@@ -4911,7 +4911,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
-      <author>Arne Beer &lt;contact@arne.beer&gt;</author>
+      <author>Arne Beer &lt;contact@arne.beer></author>
       <name>comfy-table</name>
       <version>7.2.2</version>
       <description>An easy to use library for building beautiful tables with automatic content wrapping</description>
@@ -4936,7 +4936,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#community-id@0.2.4">
-      <author>Julian Wang &lt;traceflight@outlook.com&gt;</author>
+      <author>Julian Wang &lt;traceflight@outlook.com></author>
       <name>community-id</name>
       <version>0.2.4</version>
       <description>This package provides a Rust implementation of the open Community ID flow hashing standard.</description>
@@ -4955,7 +4955,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-codecs</name>
       <version>0.4.37</version>
       <description>Adaptors for various compression algorithms. </description>
@@ -4974,7 +4974,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Allen Bui &lt;fairingrey@gmail.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Allen Bui &lt;fairingrey@gmail.com></author>
       <name>compression-core</name>
       <version>0.4.31</version>
       <description>Abstractions for compression algorithms. </description>
@@ -4993,7 +4993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Taiki Endo &lt;te316e89@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Taiki Endo &lt;te316e89@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>concurrent-queue</name>
       <version>2.5.0</version>
       <description>Concurrent multi-producer multi-consumer queue</description>
@@ -5059,7 +5059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random-macro</name>
       <version>0.1.16</version>
       <description>Provides the procedural macro used by const-random</description>
@@ -5081,7 +5081,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
-      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com&gt;</author>
+      <author>Tom Kaitchuck &lt;Tom.Kaitchuck@gmail.com></author>
       <name>const-random</name>
       <version>0.1.18</version>
       <description>Provides compile time random number generation.</description>
@@ -5122,7 +5122,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2">
-      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br&gt;</author>
+      <author>Cesar Eduardo Barros &lt;cesarb@cesarb.eti.br></author>
       <name>constant_time_eq</name>
       <version>0.4.2</version>
       <description>Compares two equal-sized byte strings in constant time.</description>
@@ -5144,7 +5144,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.10.0</version>
       <description>Convert strings into any case</description>
@@ -5163,7 +5163,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.11.0</version>
       <description>Convert strings into any case</description>
@@ -5182,7 +5182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.7.1">
-      <author>rutrum &lt;dave@rutrum.net&gt;</author>
+      <author>rutrum &lt;dave@rutrum.net></author>
       <name>convert_case</name>
       <version>0.7.1</version>
       <description>Convert strings into any case</description>
@@ -5264,7 +5264,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
-      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com></author>
       <name>core_detect</name>
       <version>1.0.0</version>
       <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
@@ -5333,7 +5333,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0">
-      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com&gt;</author>
+      <author>Akhil Velagapudi &lt;akhilvelagapudi@gmail.com></author>
       <name>crc-catalog</name>
       <version>2.4.0</version>
       <description>Catalog of CRC algorithms (generated from http://reveng.sourceforge.net/crc-catalogue) expressed as simple Rust structs.</description>
@@ -5352,7 +5352,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -5371,7 +5371,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc@3.4.0">
-      <author>Rui Hu &lt;code@mrhooray.com&gt;, Akhil Velagapudi &lt;4@4khil.com&gt;</author>
+      <author>Rui Hu &lt;code@mrhooray.com>, Akhil Velagapudi &lt;4@4khil.com></author>
       <name>crc</name>
       <version>3.4.0</version>
       <description>Rust implementation of CRC with support of various standards</description>
@@ -5393,7 +5393,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0">
-      <author>Zack Slayton &lt;zack.slayton@gmail.com&gt;</author>
+      <author>Zack Slayton &lt;zack.slayton@gmail.com></author>
       <name>cron</name>
       <version>0.15.0</version>
       <description>A cron expression parser and schedule explorer.</description>
@@ -5520,7 +5520,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crunchy@0.2.4">
-      <author>Eira Fransham &lt;jackefransham@gmail.com&gt;</author>
+      <author>Eira Fransham &lt;jackefransham@gmail.com></author>
       <name>crunchy</name>
       <version>0.2.4</version>
       <description>Crunchy unroller: deterministically unroll constant loops</description>
@@ -5608,7 +5608,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv-core</name>
       <version>0.1.13</version>
       <description>Bare bones CSV parsing with no_std support.</description>
@@ -5633,7 +5633,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>csv</name>
       <version>1.4.0</version>
       <description>Fast CSV parsing with support for serde.</description>
@@ -5701,7 +5701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.20.11</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5723,7 +5723,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling</name>
       <version>0.23.0</version>
       <description>A proc-macro library for reading attributes into structs when implementing custom derives. </description>
@@ -5745,7 +5745,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.20.11</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5764,7 +5764,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_core</name>
       <version>0.23.0</version>
       <description>Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5783,7 +5783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.20.11</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5802,7 +5802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>darling_macro</name>
       <version>0.23.0</version>
       <description>Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. </description>
@@ -5821,7 +5821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0">
-      <author>Acrimon &lt;joel.wejdenstal@gmail.com&gt;</author>
+      <author>Acrimon &lt;joel.wejdenstal@gmail.com></author>
       <name>dashmap</name>
       <version>6.1.0</version>
       <description>Blazing fast concurrent HashMap for Rust.</description>
@@ -5846,7 +5846,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0">
-      <author>Julien Cretin &lt;git@ia0.eu&gt;</author>
+      <author>Julien Cretin &lt;git@ia0.eu></author>
       <name>data-encoding</name>
       <version>2.10.0</version>
       <description>Efficient and customizable data-encoding functions like base64, base32, and hex</description>
@@ -5930,7 +5930,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>deranged</name>
       <version>0.5.8</version>
       <description>Ranged integers</description>
@@ -5949,7 +5949,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2">
-      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;, Corey Farwell &lt;coreyf@rwell.org&gt;</author>
+      <author>The Rust-Fuzz Project Developers, Nick Fitzgerald &lt;fitzgen@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com>, Andre Bogus &lt;bogusandre@gmail.com>, Corey Farwell &lt;coreyf@rwell.org></author>
       <name>derive_arbitrary</name>
       <version>1.4.2</version>
       <description>Derives arbitrary traits</description>
@@ -5971,7 +5971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more-impl</name>
       <version>2.1.1</version>
       <description>Internal implementation of `derive_more` crate</description>
@@ -5993,7 +5993,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1">
-      <author>Jelte Fennema &lt;github-tech@jeltef.nl&gt;</author>
+      <author>Jelte Fennema &lt;github-tech@jeltef.nl></author>
       <name>derive_more</name>
       <version>2.1.1</version>
       <description>Adds #[derive(x)] macros for more traits</description>
@@ -6059,7 +6059,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>directories</name>
       <version>5.0.1</version>
       <description>A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -6116,7 +6116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.4.1</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -6135,7 +6135,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
-      <author>Jane Lusby &lt;jlusby@yaah.dev&gt;</author>
+      <author>Jane Lusby &lt;jlusby@yaah.dev></author>
       <name>displaydoc</name>
       <version>0.2.5</version>
       <description>A derive macro for implementing the display Trait via a doc comment and string interpolation </description>
@@ -6160,7 +6160,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
-      <author>Josh Driver &lt;keeperofdakeys@gmail.com&gt;</author>
+      <author>Josh Driver &lt;keeperofdakeys@gmail.com></author>
       <name>dns-lookup</name>
       <version>3.0.1</version>
       <description>A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants.</description>
@@ -6182,7 +6182,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>doc-comment</name>
       <version>0.3.4</version>
       <description>Macro to generate doc comments</description>
@@ -6204,7 +6204,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain-macros</name>
       <version>0.11.1</version>
       <description>Procedural macros for the `domain` crate.</description>
@@ -6229,7 +6229,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#domain@0.11.1">
-      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;dns-team@nlnetlabs.nl></author>
       <name>domain</name>
       <version>0.11.1</version>
       <description>A DNS library for Rust.</description>
@@ -6254,7 +6254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <author>Hengfei Yang &lt;hengfei.yang@gmail.com&gt;</author>
+      <author>Hengfei Yang &lt;hengfei.yang@gmail.com></author>
       <name>dotenv_config</name>
       <version>0.2.3</version>
       <description>parse `env` to config struct for Rust</description>
@@ -6279,7 +6279,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7">
-      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com&gt;, Craig Hills &lt;chills@gmail.com&gt;, Mike Piccolo &lt;mfpiccolo@gmail.com&gt;, Alice Maz &lt;alice@alicemaz.com&gt;, Sean Griffin &lt;sean@seantheprogrammer.com&gt;, Adam Sharp &lt;adam@sharplet.me&gt;, Arpad Borsos &lt;arpad.borsos@googlemail.com&gt;, Allan Zhang &lt;al@ayz.ai&gt;</author>
+      <author>Noemi Lapresta &lt;noemi.lapresta@gmail.com>, Craig Hills &lt;chills@gmail.com>, Mike Piccolo &lt;mfpiccolo@gmail.com>, Alice Maz &lt;alice@alicemaz.com>, Sean Griffin &lt;sean@seantheprogrammer.com>, Adam Sharp &lt;adam@sharplet.me>, Arpad Borsos &lt;arpad.borsos@googlemail.com>, Allan Zhang &lt;al@ayz.ai></author>
       <name>dotenvy</name>
       <version>0.15.7</version>
       <description>A well-maintained fork of the dotenv crate</description>
@@ -6319,7 +6319,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>dtype_dispatch</name>
       <version>0.2.1</version>
       <description>Macro builder for working with data types</description>
@@ -6338,7 +6338,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
-      <author>Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net></author>
       <name>dunce</name>
       <version>1.0.5</version>
       <description>Normalize Windows paths to the most compatible format, avoiding UNC where possible</description>
@@ -6363,7 +6363,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>dyn-clone</name>
       <version>1.0.20</version>
       <description>Clone trait that is dyn-compatible</description>
@@ -6425,7 +6425,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9">
-      <author>Simon Johnston &lt;johnstonskj@gmail.com&gt;</author>
+      <author>Simon Johnston &lt;johnstonskj@gmail.com></author>
       <name>email_address</name>
       <version>0.2.9</version>
       <description>A Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype. </description>
@@ -6447,7 +6447,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ena@0.14.4">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>ena</name>
       <version>0.14.4</version>
       <description>Union-find, congruence closure, and other unification code. Based on code from rustc.</description>
@@ -6469,7 +6469,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0">
-      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net&gt;</author>
+      <author>Torbjørn Birch Moltu &lt;t.b.moltu@lyse.net></author>
       <name>encode_unicode</name>
       <version>1.0.0</version>
       <description>UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. </description>
@@ -6491,7 +6491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -6516,7 +6516,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator-derive</name>
       <version>1.5.0</version>
       <description>Procedural macro to derive Sequence</description>
@@ -6541,7 +6541,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
-      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com></author>
       <name>enum-iterator</name>
       <version>2.3.0</version>
       <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
@@ -6620,7 +6620,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>erased-serde</name>
       <version>0.4.10</version>
       <description>Type-erased Serialize and Serializer traits</description>
@@ -6642,7 +6642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -6664,7 +6664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
-      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>John Nunley &lt;dev@notgull.net></author>
       <name>event-listener-strategy</name>
       <version>0.5.4</version>
       <description>Block or poll on event_listener easily</description>
@@ -6683,7 +6683,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>event-listener</name>
       <version>5.4.1</version>
       <description>Notify async tasks or threads</description>
@@ -6702,7 +6702,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2">
-      <author>Ben Wilber &lt;benwilber@gmail.com&gt;</author>
+      <author>Ben Wilber &lt;benwilber@gmail.com></author>
       <name>exitcode</name>
       <version>1.1.2</version>
       <description>Preferred system exit codes as defined by sysexits.h</description>
@@ -6727,7 +6727,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait-proc_macros</name>
       <version>1.0.1</version>
       <description>Internal: proc-macro backend of ::ext_trait.</description>
@@ -6749,7 +6749,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>ext-trait</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6771,7 +6771,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>extension-traits</name>
       <version>1.0.1</version>
       <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
@@ -6793,7 +6793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
-      <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
+      <author>Raph Levien &lt;raph@google.com>, Robin Stocker &lt;robin@nibor.org>, Keith Hall &lt;keith.hall@available.systems></author>
       <name>fancy-regex</name>
       <version>0.17.0</version>
       <description>An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.</description>
@@ -6815,7 +6815,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>fastdivide</name>
       <version>0.4.2</version>
       <description>Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions.</description>
@@ -6834,7 +6834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
-      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB &lt;hello@spiraldb.com></author>
       <name>fastlanes</name>
       <version>0.5.2</version>
       <description>Rust implementation of the FastLanes compression layout</description>
@@ -6856,7 +6856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>fastrand</name>
       <version>2.3.0</version>
       <description>A simple and fast random number generator</description>
@@ -6875,7 +6875,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
-      <author>Volo Team &lt;volo@cloudwego.io&gt;</author>
+      <author>Volo Team &lt;volo@cloudwego.io></author>
       <name>faststr</name>
       <version>0.2.34</version>
       <description>Faststr is a string library that reduces the cost of clone.</description>
@@ -6937,7 +6937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19">
-      <author>Robert Winslow &lt;hello@rwinslow.com&gt;, FlatBuffers Maintainers</author>
+      <author>Robert Winslow &lt;hello@rwinslow.com>, FlatBuffers Maintainers</author>
       <name>flatbuffers</name>
       <version>25.12.19</version>
       <description>Official FlatBuffers Rust runtime library.</description>
@@ -6959,7 +6959,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -6984,7 +6984,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fluent-uri@0.4.1">
-      <author>Scallop Ye &lt;yescallop@gmail.com&gt;</author>
+      <author>Scallop Ye &lt;yescallop@gmail.com></author>
       <name>fluent-uri</name>
       <version>0.4.1</version>
       <description>A generic URI/IRI handling library compliant with RFC 3986/3987.</description>
@@ -7006,7 +7006,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>flume</name>
       <version>0.11.1</version>
       <description>A blazingly fast multi-producer channel</description>
@@ -7028,7 +7028,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -7050,7 +7050,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.1.5</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7069,7 +7069,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -7107,7 +7107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fraction@0.15.3">
-      <author>dnsl48 &lt;dnsl48@gmail.com&gt;</author>
+      <author>dnsl48 &lt;dnsl48@gmail.com></author>
       <name>fraction</name>
       <version>0.15.3</version>
       <description>Lossless fractions and decimals; drop-in float replacement</description>
@@ -7132,7 +7132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Al Liu &lt;scygliu1@gmail.com&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Al Liu &lt;scygliu1@gmail.com></author>
       <name>fs4</name>
       <version>0.13.1</version>
       <description>No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.</description>
@@ -7154,7 +7154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0">
-      <author>Denis Kurilenko &lt;webdesus@gmail.com&gt;</author>
+      <author>Denis Kurilenko &lt;webdesus@gmail.com></author>
       <name>fs_extra</name>
       <version>1.3.0</version>
       <description>Expanding std::fs and std::io. Recursively copy folders with information about process and much more.</description>
@@ -7179,7 +7179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
-      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <author>SpiralDB Developers &lt;hello@spiraldb.com></author>
       <name>fsst-rs</name>
       <version>0.5.11</version>
       <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
@@ -7198,7 +7198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>funty</name>
       <version>2.0.0</version>
       <description>Trait generalization over the primitive types</description>
@@ -7283,7 +7283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0">
-      <author>Matthias Einwag &lt;matthias.einwag@live.com&gt;</author>
+      <author>Matthias Einwag &lt;matthias.einwag@live.com></author>
       <name>futures-intrusive</name>
       <version>0.5.0</version>
       <description>Futures based on intrusive data structures - for std and no-std environments. </description>
@@ -7326,7 +7326,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>futures-lite</name>
       <version>2.6.1</version>
       <description>Futures, streams, and async I/O combinators</description>
@@ -7414,7 +7414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>futures-timer</name>
       <version>3.0.3</version>
       <description>Timeouts for futures. </description>
@@ -7481,7 +7481,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com&gt;, Aaron Trent &lt;novacrazy@gmail.com&gt;</author>
+      <author>Bartłomiej Kamiński &lt;fizyk20@gmail.com>, Aaron Trent &lt;novacrazy@gmail.com></author>
       <name>generic-array</name>
       <version>0.14.7</version>
       <description>Generic types implementing functionality of arrays</description>
@@ -7594,7 +7594,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#grok@2.4.0">
-      <author>Matt Mastracci &lt;matthew@mastracci.com&gt;, Michael Nitschinger &lt;michael@nitschinger.at&gt;</author>
+      <author>Matt Mastracci &lt;matthew@mastracci.com>, Michael Nitschinger &lt;michael@nitschinger.at></author>
       <name>grok</name>
       <version>2.4.0</version>
       <description>A Rust implementation of the popular Java &amp; Ruby grok library which allows easy text and log file processing with composable  patterns. </description>
@@ -7641,7 +7641,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -7663,7 +7663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1">
-      <author>Kathryn Long &lt;squeeself@gmail.com&gt;</author>
+      <author>Kathryn Long &lt;squeeself@gmail.com></author>
       <name>half</name>
       <version>2.7.1</version>
       <description>Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.</description>
@@ -7682,7 +7682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.12.3</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7701,7 +7701,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.14.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7720,7 +7720,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.15.5</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7739,7 +7739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>hashbrown</name>
       <version>0.16.1</version>
       <description>A Rust port of Google's SwissTable hash map</description>
@@ -7776,7 +7776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
-      <author>kyren &lt;kerriganw@gmail.com&gt;</author>
+      <author>kyren &lt;kerriganw@gmail.com></author>
       <name>hashlink</name>
       <version>0.10.0</version>
       <description>HashMap-like containers that hold their key-value pairs in a user controllable order</description>
@@ -7798,7 +7798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -7823,7 +7823,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1">
-      <author>Without Boats &lt;woboats@gmail.com&gt;</author>
+      <author>Without Boats &lt;woboats@gmail.com></author>
       <name>heck</name>
       <version>0.4.1</version>
       <description>heck is a case conversion library.</description>
@@ -7866,7 +7866,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3">
-      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net&gt;</author>
+      <author>KokaKiwi &lt;kokakiwi@kokakiwi.net></author>
       <name>hex</name>
       <version>0.4.3</version>
       <description>Encoding and decoding data into/from hexadecimal representation.</description>
@@ -7932,7 +7932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12">
-      <author>Brian Anderson &lt;andersrb@gmail.com&gt;</author>
+      <author>Brian Anderson &lt;andersrb@gmail.com></author>
       <name>home</name>
       <version>0.5.12</version>
       <description>Shared definitions of home directories.</description>
@@ -7975,7 +7975,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1">
-      <author>Viktor Dahl &lt;pazaconyoman@gmail.com&gt;</author>
+      <author>Viktor Dahl &lt;pazaconyoman@gmail.com></author>
       <name>htmlescape</name>
       <version>0.3.1</version>
       <description>A library for HTML entity encoding and decoding</description>
@@ -7994,7 +7994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -8016,7 +8016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>0.4.6</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8038,7 +8038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -8060,7 +8060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>0.2.12</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8082,7 +8082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -8104,7 +8104,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -8126,7 +8126,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -8145,7 +8145,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
-      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com></author>
       <name>humansize</name>
       <version>2.1.3</version>
       <description>A configurable crate to easily represent sizes in a human-readable format.</description>
@@ -8240,7 +8240,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-timeout@0.5.2">
-      <author>Herman J. Radtke III &lt;herman@hermanradtke.com&gt;</author>
+      <author>Herman J. Radtke III &lt;herman@hermanradtke.com></author>
       <name>hyper-timeout</name>
       <version>0.5.2</version>
       <description>A connect, read and write timeout aware connector to be used with hyper Client.</description>
@@ -8265,7 +8265,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -8290,7 +8290,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -8315,7 +8315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -8488,7 +8488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1">
-      <author>Ted Driggs &lt;ted.driggs@outlook.com&gt;</author>
+      <author>Ted Driggs &lt;ted.driggs@outlook.com></author>
       <name>ident_case</name>
       <version>1.0.1</version>
       <description>Utility for applying case rules to Rust identifiers.</description>
@@ -8575,7 +8575,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>indoc</name>
       <version>2.0.7</version>
       <description>Indented document literals</description>
@@ -8619,7 +8619,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inherent@1.0.13">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inherent</name>
       <version>1.0.13</version>
       <description>Make trait methods callable without the trait in scope</description>
@@ -8663,7 +8663,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#integer-encoding@3.0.4">
-      <author>Lewin Bormann &lt;lbo@spheniscida.de&gt;</author>
+      <author>Lewin Bormann &lt;lbo@spheniscida.de></author>
       <name>integer-encoding</name>
       <version>3.0.4</version>
       <description>varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)</description>
@@ -8685,7 +8685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>inventory</name>
       <version>0.3.22</version>
       <description>Typed distributed plugin registration</description>
@@ -8707,7 +8707,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>ipcrypt-rs</name>
       <version>0.9.4</version>
       <description>IP address encryption and obfuscation methods in pure Rust</description>
@@ -8729,7 +8729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -8751,7 +8751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10">
-      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red&gt;</author>
+      <author>YOSHIOKA Takuma &lt;nop_thread@nops.red></author>
       <name>iri-string</name>
       <version>0.7.10</version>
       <description>IRI as string types</description>
@@ -8770,7 +8770,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <author>softprops &lt;d.tangren@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>softprops &lt;d.tangren@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>is-terminal</name>
       <version>0.4.17</version>
       <description>Test whether a given stream is a terminal</description>
@@ -8876,7 +8876,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -8898,7 +8898,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff-static</name>
       <version>0.2.23</version>
       <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
@@ -8923,7 +8923,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>jiff</name>
       <version>0.2.23</version>
       <description>A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. </description>
@@ -8945,7 +8945,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -8970,7 +8970,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>jsonschema</name>
       <version>0.38.1</version>
       <description>JSON schema validaton library</description>
@@ -9033,7 +9033,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop-util@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop-util</name>
       <version>0.22.2</version>
       <description>Runtime library for parsers generated by LALRPOP</description>
@@ -9052,7 +9052,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lalrpop@0.22.2">
-      <author>Niko Matsakis &lt;niko@alum.mit.edu&gt;</author>
+      <author>Niko Matsakis &lt;niko@alum.mit.edu></author>
       <name>lalrpop</name>
       <version>0.22.2</version>
       <description>convenient LR(1) parser generator</description>
@@ -9071,7 +9071,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
-      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <author>Chase Wilson &lt;contact@chasewilson.dev></author>
       <name>lasso</name>
       <version>0.7.3</version>
       <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
@@ -9093,7 +9093,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
+      <author>Marvin Löbel &lt;loebel.marvin@gmail.com></author>
       <name>lazy_static</name>
       <version>1.5.0</version>
       <description>A macro for declaring lazily evaluated statics in Rust.</description>
@@ -9115,7 +9115,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator-proc_macros</name>
       <version>0.1.7</version>
       <description>Internal: proc-macro backend of ::lending_iterator.</description>
@@ -9137,7 +9137,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>lending-iterator</name>
       <version>0.1.7</version>
       <description>Fully general lending iterators in stable rust: windows_mut!</description>
@@ -9159,7 +9159,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
-      <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
+      <author>Alexis Mousset &lt;contact@amousset.me>, Paolo Barbolini &lt;paolo@paolo565.org></author>
       <name>lettre</name>
       <version>0.11.22</version>
       <description>Email client</description>
@@ -9181,7 +9181,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>levenshtein_automata</name>
       <version>0.2.1</version>
       <description>Creates Levenshtein Automata in an efficient manner.</description>
@@ -9206,7 +9206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-core</name>
       <version>1.0.6</version>
       <description>Lexical, to- and from-string conversion routines.</description>
@@ -9225,7 +9225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-float</name>
       <version>1.0.6</version>
       <description>Efficient parsing of floats from strings.</description>
@@ -9244,7 +9244,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-parse-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-parse-integer</name>
       <version>1.0.6</version>
       <description>Efficient parsing of integers from strings.</description>
@@ -9263,7 +9263,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-util</name>
       <version>1.0.7</version>
       <description>Shared utilities for lexical creates.</description>
@@ -9282,7 +9282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-float@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-float</name>
       <version>1.0.6</version>
       <description>Efficient formatting of floats to strings.</description>
@@ -9301,7 +9301,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lexical-write-integer@1.0.6">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>lexical-write-integer</name>
       <version>1.0.6</version>
       <description>Efficient formatting of integers to strings.</description>
@@ -9360,7 +9360,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
-      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me></author>
       <name>libloading</name>
       <version>0.8.9</version>
       <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
@@ -9382,7 +9382,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma-sys</name>
       <version>0.4.5</version>
       <description>Raw bindings to liblzma which contains an implementation of LZMA and xz stream encoding/decoding.  High level Rust bindings are available in the `liblzma` crate. </description>
@@ -9407,7 +9407,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Portable-Network-Archive Developers</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Portable-Network-Archive Developers</author>
       <name>liblzma</name>
       <version>0.4.6</version>
       <description>Rust bindings to liblzma providing Read/Write streams as well as low-level in-memory encoding/decoding. forked from xz2. </description>
@@ -9429,7 +9429,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -9470,7 +9470,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -9514,7 +9514,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <author>Leo Borai &lt;estebanborai@gmail.com&gt;</author>
+      <author>Leo Borai &lt;estebanborai@gmail.com></author>
       <name>local-ip-address</name>
       <version>0.6.10</version>
       <description>Retrieve system's local IP address and Network Interfaces/Adapters on Linux, macOS and Windows.</description>
@@ -9536,7 +9536,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -9577,7 +9577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2">
-      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com&gt;</author>
+      <author>Benjamin Saunders &lt;ben.e.saunders@gmail.com></author>
       <name>lru-slab</name>
       <version>0.1.2</version>
       <description>Pre-allocated storage with constant-time LRU tracking</description>
@@ -9596,7 +9596,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
-      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
+      <author>Jerome Froelich &lt;jeromefroelic@hotmail.com></author>
       <name>lru</name>
       <version>0.16.4</version>
       <description>A LRU cache implementation</description>
@@ -9621,7 +9621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.11.6</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9643,7 +9643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com>, Arthur Silva &lt;arthurprs@gmail.com>, ticki &lt;Ticki@users.noreply.github.com></author>
       <name>lz4_flex</name>
       <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
@@ -9665,7 +9665,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
-      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <author>rep-nop &lt;repnop@outlook.com></author>
       <name>mac_address</name>
       <version>1.1.8</version>
       <description>Cross-platform retrieval of a network interface MAC address.</description>
@@ -9684,7 +9684,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute-proc_macro</name>
       <version>0.1.3</version>
       <description>Use declarative macros as proc_macro attributes or derives</description>
@@ -9703,7 +9703,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>macro_rules_attribute</name>
       <version>0.1.3</version>
       <description>Use declarative macros in attribute or derive position</description>
@@ -9728,7 +9728,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>matchers</name>
       <version>0.2.0</version>
       <description>Regex matching on character and byte streams. </description>
@@ -9753,7 +9753,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -9816,7 +9816,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0">
-      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com&gt;, Kamal Ahmad &lt;shibe@openmailbox.org&gt;, Konstantin Stepanov &lt;milezv@gmail.com&gt;, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com&gt;, Nathan Musoke &lt;nathan.musoke@gmail.com&gt;, Scott Mabin &lt;scott@mabez.dev&gt;, Tony Arcieri &lt;bascule@gmail.com&gt;, Wim de With &lt;register@dewith.io&gt;, Yosef Dinerstein &lt;yosefdi@gmail.com&gt;</author>
+      <author>Ivan Ukhov &lt;ivan.ukhov@gmail.com>, Kamal Ahmad &lt;shibe@openmailbox.org>, Konstantin Stepanov &lt;milezv@gmail.com>, Lukas Kalbertodt &lt;lukas.kalbertodt@gmail.com>, Nathan Musoke &lt;nathan.musoke@gmail.com>, Scott Mabin &lt;scott@mabez.dev>, Tony Arcieri &lt;bascule@gmail.com>, Wim de With &lt;register@dewith.io>, Yosef Dinerstein &lt;yosefdi@gmail.com></author>
       <name>md5</name>
       <version>0.8.0</version>
       <description>The package provides the MD5 hash function.</description>
@@ -9841,7 +9841,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
-      <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;</author>
+      <author>Pascal Seitz &lt;pascal.seitz@gmail.com></author>
       <name>measure_time</name>
       <version>0.9.0</version>
       <description>Provices macros to measure the time until end of scope. </description>
@@ -9863,7 +9863,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -9888,7 +9888,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;, The Contributors</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Yevhenii Reizner &lt;razrfalcon@gmail.com>, The Contributors</author>
       <name>memmap2</name>
       <version>0.9.10</version>
       <description>Cross-platform Rust API for memory-mapped file IO</description>
@@ -9910,7 +9910,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
-      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com></author>
       <name>memoffset</name>
       <version>0.9.1</version>
       <description>offset_of functionality for Rust structs.</description>
@@ -9929,7 +9929,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -9951,7 +9951,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -9973,7 +9973,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1">
-      <author>Alex Huszagh &lt;ahuszagh@gmail.com&gt;</author>
+      <author>Alex Huszagh &lt;ahuszagh@gmail.com></author>
       <name>minimal-lexical</name>
       <version>0.2.1</version>
       <description>Fast float parsing conversion routines.</description>
@@ -9995,7 +9995,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -10020,7 +10020,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -10063,7 +10063,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -10085,7 +10085,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1">
-      <author>Håvar Nøvik &lt;havar.novik@gmail.com&gt;</author>
+      <author>Håvar Nøvik &lt;havar.novik@gmail.com></author>
       <name>multimap</name>
       <version>0.10.1</version>
       <description>A multimap implementation.</description>
@@ -10107,7 +10107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10129,7 +10129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#munge_macro@0.4.7">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>munge_macro</name>
       <version>0.4.7</version>
       <description>Macro for custom destructuring</description>
@@ -10151,7 +10151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2">
-      <author>Stu Small &lt;stuart.alan.small@gmail.com&gt;</author>
+      <author>Stu Small &lt;stuart.alan.small@gmail.com></author>
       <name>murmur3</name>
       <version>0.5.2</version>
       <description>A rust implementation of Murmur3 hash</description>
@@ -10170,7 +10170,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <author>Paul Masurel &lt;paul.masurel@gmail.com></author>
       <name>murmurhash32</name>
       <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
@@ -10189,7 +10189,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>never-say-never</name>
       <version>6.6.666</version>
       <description>The never type (the true one!) in stable Rust.</description>
@@ -10211,7 +10211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6">
-      <author>Matt Brubeck &lt;mbrubeck@limpet.net&gt;, Jonathan Reem &lt;jonathan.reem@gmail.com&gt;</author>
+      <author>Matt Brubeck &lt;mbrubeck@limpet.net>, Jonathan Reem &lt;jonathan.reem@gmail.com></author>
       <name>new_debug_unreachable</name>
       <version>1.0.6</version>
       <description>panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)</description>
@@ -10271,7 +10271,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0">
-      <author>Parity Technologies &lt;admin@parity.io&gt;</author>
+      <author>Parity Technologies &lt;admin@parity.io></author>
       <name>nohash</name>
       <version>0.2.0</version>
       <description>An implementation of `std::hash::Hasher` which does not hash at all.</description>
@@ -10359,7 +10359,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat-proc_macros</name>
       <version>0.2.4</version>
       <description>Internal: proc-macro backend of ::nougat.</description>
@@ -10381,7 +10381,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>nougat</name>
       <version>0.2.4</version>
       <description>(lifetime) GATs on stable Rust</description>
@@ -10403,7 +10403,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3">
-      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, The Nushell Project Developers</author>
+      <author>ogham@bsago.me, Ryan Scheel (Havvy) &lt;ryan.havvy@gmail.com>, Josh Triplett &lt;josh@joshtriplett.org>, The Nushell Project Developers</author>
       <name>nu-ansi-term</name>
       <version>0.50.3</version>
       <description>Library for ANSI terminal colors and styles (bold, underline)</description>
@@ -10422,7 +10422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
-      <author>dignifiedquire &lt;dignifiedquire@gmail.com&gt;, The Rust Project Developers</author>
+      <author>dignifiedquire &lt;dignifiedquire@gmail.com>, The Rust Project Developers</author>
       <name>num-bigint-dig</name>
       <version>0.8.6</version>
       <description>Big integer implementation for Rust</description>
@@ -10472,7 +10472,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0">
-      <author>Kang Seonghoon &lt;public+git@mearie.org&gt;</author>
+      <author>Kang Seonghoon &lt;public+git@mearie.org></author>
       <name>num-cmp</name>
       <version>0.1.0</version>
       <description>Comparison between differently typed numbers</description>
@@ -10522,7 +10522,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>num-conv</name>
       <version>0.2.0</version>
       <description>`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. </description>
@@ -10666,7 +10666,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum</name>
       <version>0.7.6</version>
       <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
@@ -10685,7 +10685,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
-      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com>, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com>, Vincent Esche &lt;regexident@gmail.com></author>
       <name>num_enum_derive</name>
       <version>0.7.6</version>
       <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
@@ -10704,7 +10704,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev></author>
       <name>num_threads</name>
       <version>0.1.7</version>
       <description>A minimal library that determines the number of running threads for the current process.</description>
@@ -10777,7 +10777,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
-      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl&gt;</author>
+      <author>NLnet Labs &lt;rust-team@nlnetlabs.nl></author>
       <name>octseq</name>
       <version>0.5.2</version>
       <description>Abstractions for types representing octet sequences.</description>
@@ -10821,7 +10821,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -10843,7 +10843,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.1.13</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10862,7 +10862,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
-      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <author>Linus Färnstrand &lt;faern@faern.net></author>
       <name>oneshot</name>
       <version>0.2.1</version>
       <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
@@ -10881,7 +10881,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig</name>
       <version>6.5.1</version>
       <description>Rust-Onig is a set of Rust bindings for the Oniguruma regular expression library. Oniguruma is a modern regex library with support for multiple character encodings and regex syntaxes. </description>
@@ -10903,7 +10903,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig_sys@69.9.1">
-      <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
+      <author>Will Speak &lt;will@willspeak.me>, Ivan Ivashchenko &lt;defuz@me.com></author>
       <name>onig_sys</name>
       <version>69.9.1</version>
       <description>The `onig_sys` crate contains raw rust bindings to the oniguruma library. This crate exposes a set of unsafe functions which can then be used by other crates to create safe wrappers around Oniguruma.  You probably don't want to link to this crate directly; instead check out the `onig` crate. </description>
@@ -10971,7 +10971,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -10996,7 +10996,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>2.10.1</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11015,7 +11015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@4.6.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>4.6.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11034,7 +11034,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0">
-      <author>Jonathan Reem &lt;jonathan.reem@gmail.com&gt;, Matt Brubeck &lt;mbrubeck@limpet.net&gt;</author>
+      <author>Jonathan Reem &lt;jonathan.reem@gmail.com>, Matt Brubeck &lt;mbrubeck@limpet.net></author>
       <name>ordered-float</name>
       <version>5.1.0</version>
       <description>Wrappers for total ordering on floats</description>
@@ -11053,7 +11053,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0">
-      <author>Jan Schulte &lt;hello@unexpected-co.de&gt;, Stanislav Tkach &lt;stanislav.tkach@gmail.com&gt;</author>
+      <author>Jan Schulte &lt;hello@unexpected-co.de>, Stanislav Tkach &lt;stanislav.tkach@gmail.com></author>
       <name>os_info</name>
       <version>3.12.0</version>
       <description>Detect the operating system type and version.</description>
@@ -11078,7 +11078,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros</name>
       <version>0.18.5</version>
       <description>Easy, safe self-referential struct generation.</description>
@@ -11100,7 +11100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros_macro@0.18.5">
-      <author>Josh &lt;someguynamedjosh@github.com&gt;</author>
+      <author>Josh &lt;someguynamedjosh@github.com></author>
       <name>ouroboros_macro</name>
       <version>0.18.5</version>
       <description>Proc macro for ouroboros crate.</description>
@@ -11140,7 +11140,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
-      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
+      <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com></author>
       <name>owo-colors</name>
       <version>4.3.0</version>
       <description>Zero-allocation terminal colors that'll make people go owo</description>
@@ -11162,7 +11162,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, The Rust Project Developers</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, The Rust Project Developers</author>
       <name>parking</name>
       <version>2.2.1</version>
       <description>Thread parking and unparking</description>
@@ -11187,7 +11187,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -11206,7 +11206,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -11225,7 +11225,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
-      <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
+      <author>Apache Arrow &lt;dev@arrow.apache.org></author>
       <name>parquet</name>
       <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
@@ -11247,7 +11247,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parse-size@1.1.0">
-      <author>kennytm &lt;kennytm@gmail.com&gt;</author>
+      <author>kennytm &lt;kennytm@gmail.com></author>
       <name>parse-size</name>
       <version>1.1.0</version>
       <description>Parse byte size into integer accurately.</description>
@@ -11288,7 +11288,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>paste</name>
       <version>1.0.15</version>
       <description>Macros for all your token pasting needs</description>
@@ -11310,7 +11310,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
-      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <author>mwlon &lt;m.w.loncaric@gmail.com></author>
       <name>pco</name>
       <version>1.0.2</version>
       <description>Good compression for numerical sequences</description>
@@ -11329,7 +11329,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0">
-      <author>Nick Fitzgerald &lt;fitzgen@gmail.com&gt;</author>
+      <author>Nick Fitzgerald &lt;fitzgen@gmail.com></author>
       <name>peeking_take_while</name>
       <version>1.0.0</version>
       <description>Like `Iterator::take_while`, but calls the predicate on a peeked value. This allows you to use `Iterator::by_ref` and `Iterator::take_while` together, and still get the first value for which the `take_while` predicate returned false after dropping the `by_ref`.</description>
@@ -11386,7 +11386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest</name>
       <version>2.8.6</version>
       <description>The Elegant Parser</description>
@@ -11411,7 +11411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_derive@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_derive</name>
       <version>2.8.6</version>
       <description>pest's derive macro</description>
@@ -11436,7 +11436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_generator@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_generator</name>
       <version>2.8.6</version>
       <description>pest code generator</description>
@@ -11461,7 +11461,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pest_meta@2.8.6">
-      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com&gt;</author>
+      <author>Dragoș Tiselice &lt;dragostiselice@gmail.com></author>
       <name>pest_meta</name>
       <version>2.8.6</version>
       <description>pest meta language parser and validator</description>
@@ -11530,7 +11530,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
-      <author>Andrew Kane &lt;andrew@ankane.org&gt;</author>
+      <author>Andrew Kane &lt;andrew@ankane.org></author>
       <name>pgvector</name>
       <version>0.4.1</version>
       <description>pgvector support for Rust</description>
@@ -11549,7 +11549,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf</name>
       <version>0.12.1</version>
       <description>Runtime support for perfect hash function data structures</description>
@@ -11568,7 +11568,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.11.3</version>
       <description>Support code shared by PHF libraries</description>
@@ -11587,7 +11587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>phf_shared</name>
       <version>0.12.1</version>
       <description>Support code shared by PHF libraries</description>
@@ -11660,7 +11660,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -11682,7 +11682,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#piper@0.2.5">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>piper</name>
       <version>0.2.5</version>
       <description>An asynchronous single-consumer single-producer pipe for bytes.</description>
@@ -11739,7 +11739,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -11761,7 +11761,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
-      <author>Ed Barnard &lt;eabarnard@gmail.com&gt;</author>
+      <author>Ed Barnard &lt;eabarnard@gmail.com></author>
       <name>plist</name>
       <version>1.8.0</version>
       <description>A rusty plist parser. Supports Serde serialization.</description>
@@ -11783,7 +11783,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, John Nunley &lt;dev@notgull.net></author>
       <name>polling</name>
       <version>3.11.0</version>
       <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
@@ -11802,7 +11802,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
-      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com></author>
       <name>polonius-the-crab</name>
       <version>0.2.1</version>
       <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
@@ -11886,7 +11886,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0">
-      <author>Jacob Pratt &lt;jacob@jhpratt.dev&gt;</author>
+      <author>Jacob Pratt &lt;jacob@jhpratt.dev></author>
       <name>powerfmt</name>
       <version>0.2.0</version>
       <description>    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. </description>
@@ -11924,7 +11924,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1">
-      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;</author>
+      <author>Emilio Cobos Álvarez &lt;emilio@crisal.io></author>
       <name>precomputed-hash</name>
       <version>0.1.1</version>
       <description>A library intending to be a base dependency to expose a precomputed hash</description>
@@ -11943,7 +11943,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettydiff@0.8.1">
-      <author>Roman Koblov &lt;penpen938@me.com&gt;</author>
+      <author>Roman Koblov &lt;penpen938@me.com></author>
       <name>prettydiff</name>
       <version>0.8.1</version>
       <description>Side-by-side diff for two files</description>
@@ -11965,7 +11965,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>prettyplease</name>
       <version>0.2.37</version>
       <description>A minimal `syn` syntax tree pretty-printer</description>
@@ -12015,7 +12015,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
-      <author>Bastian Köcher &lt;git@kchr.de&gt;</author>
+      <author>Bastian Köcher &lt;git@kchr.de></author>
       <name>proc-macro-crate</name>
       <version>3.5.0</version>
       <description>Replacement for crate (macro_rules keyword) in proc-macros </description>
@@ -12037,7 +12037,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>proc-macro2-diagnostics</name>
       <version>0.10.1</version>
       <description>Diagnostics for proc-macro2.</description>
@@ -12062,7 +12062,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -12109,7 +12109,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-build</name>
       <version>0.14.3</version>
       <description>Generate Prost annotated Rust types from Protocol Buffers files.</description>
@@ -12128,7 +12128,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.13.5</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12147,7 +12147,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-derive</name>
       <version>0.14.3</version>
       <description>Generate encoding and decoding implementations for Prost annotated types.</description>
@@ -12166,7 +12166,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-reflect@0.14.7">
-      <author>Andrew Hickman &lt;andrew.hickman1@sky.com&gt;</author>
+      <author>Andrew Hickman &lt;andrew.hickman1@sky.com></author>
       <name>prost-reflect</name>
       <version>0.14.7</version>
       <description>A protobuf library extending prost with reflection support and dynamic messages.</description>
@@ -12188,7 +12188,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.13.5</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12207,7 +12207,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
@@ -12226,7 +12226,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-build@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-build</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12248,7 +12248,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt-types</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12270,7 +12270,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt@0.7.1">
-      <author>fdeantoni &lt;fdeantoni@gmail.com&gt;</author>
+      <author>fdeantoni &lt;fdeantoni@gmail.com></author>
       <name>prost-wkt</name>
       <version>0.7.1</version>
       <description>Helper crate for prost to allow JSON serialization and deserialization of Well Known Types.</description>
@@ -12292,7 +12292,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.13.5">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.13.5</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12311,7 +12311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3">
-      <author>Dan Burkert &lt;dan@danburkert.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Casper Meijn &lt;casper@meijn.net&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Dan Burkert &lt;dan@danburkert.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Casper Meijn &lt;casper@meijn.net>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>prost</name>
       <version>0.14.3</version>
       <description>A Protocol Buffers implementation for the Rust Language.</description>
@@ -12330,7 +12330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf-support@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf-support</name>
       <version>3.7.2</version>
       <description>Code supporting protobuf implementation. None of code in this crate is public API. </description>
@@ -12355,7 +12355,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2">
-      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com&gt;</author>
+      <author>Stepan Koltsov &lt;stepan.koltsov@gmail.com></author>
       <name>protobuf</name>
       <version>3.7.2</version>
       <description>Rust implementation of Google protocol buffers </description>
@@ -12380,7 +12380,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl-types@2.0.11">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl-types</name>
       <version>2.0.11</version>
       <description>Common types for the public suffix implementation crates</description>
@@ -12402,7 +12402,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psl@2.1.196">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>psl</name>
       <version>2.1.196</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12424,7 +12424,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30">
-      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me&gt;</author>
+      <author>Simonas Kazlauskas &lt;psm@kazlauskas.me></author>
       <name>psm</name>
       <version>0.1.30</version>
       <description>Portable Stack Manipulation: stack manipulation and introspection routines</description>
@@ -12446,7 +12446,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.1.4</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12468,7 +12468,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta</name>
       <version>0.3.1</version>
       <description>A radioactive stabilization of the ptr_meta rfc</description>
@@ -12490,7 +12490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.1.4">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.1.4</version>
       <description>Macros for ptr_meta</description>
@@ -12512,7 +12512,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta_derive@0.3.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>ptr_meta_derive</name>
       <version>0.3.1</version>
       <description>Proc macros for ptr_meta</description>
@@ -12534,7 +12534,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#publicsuffix@2.3.0">
-      <author>rushmorem &lt;rushmore@webenchanter.com&gt;</author>
+      <author>rushmorem &lt;rushmore@webenchanter.com></author>
       <name>publicsuffix</name>
       <version>2.3.0</version>
       <description>Extract root domain and suffix from a domain name</description>
@@ -12556,7 +12556,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark-to-cmark@22.0.0">
-      <author>Sebastian Thiel &lt;byronimo@gmail.com&gt;, Dylan Owen &lt;dyltotheo@gmail.com&gt;, Alessandro Ogier &lt;alessandro.ogier@gmail.com&gt;, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com&gt;, Andrew Lyjak &lt;andrew.lyjak@gmail.com&gt;</author>
+      <author>Sebastian Thiel &lt;byronimo@gmail.com>, Dylan Owen &lt;dyltotheo@gmail.com>, Alessandro Ogier &lt;alessandro.ogier@gmail.com>, Zixian Cai &lt;2891235+caizixian@users.noreply.github.com>, Andrew Lyjak &lt;andrew.lyjak@gmail.com></author>
       <name>pulldown-cmark-to-cmark</name>
       <version>22.0.0</version>
       <description>Convert pulldown-cmark Events back to the string they were parsed from</description>
@@ -12581,7 +12581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pulldown-cmark@0.13.1">
-      <author>Raph Levien &lt;raph.levien@gmail.com&gt;, Marcus Klaas de Vries &lt;mail@marcusklaas.nl&gt;</author>
+      <author>Raph Levien &lt;raph.levien@gmail.com>, Marcus Klaas de Vries &lt;mail@marcusklaas.nl></author>
       <name>pulldown-cmark</name>
       <version>0.13.1</version>
       <description>A pull parser for CommonMark</description>
@@ -12642,7 +12642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>quickcheck</name>
       <version>1.1.0</version>
       <description>Automatic property based testing with shrinking.</description>
@@ -12721,7 +12721,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -12743,7 +12743,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1">
-      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com&gt;</author>
+      <author>Kartikaya Gupta &lt;kats@seldon.staktrace.com></author>
       <name>quoted_printable</name>
       <version>0.5.1</version>
       <description>A simple encoder/decoder for quoted-printable data</description>
@@ -12765,7 +12765,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#radium@0.7.0">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>radium</name>
       <version>0.7.0</version>
       <description>Portable interfaces for maybe-atomic types</description>
@@ -12790,7 +12790,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rancor</name>
       <version>0.1.1</version>
       <description>Scalable and efficient error handling without type composition</description>
@@ -13082,7 +13082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive-proc-macro-impl@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive-proc-macro-impl</name>
       <version>0.1.1</version>
       <description>Procedural macros for the recursive crate.</description>
@@ -13101,7 +13101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>recursive</name>
       <version>0.1.1</version>
       <description>Easy recursion without stack overflows.</description>
@@ -13120,7 +13120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast-impl</name>
       <version>1.0.25</version>
       <description>Derive implementation for ref_cast::RefCast.</description>
@@ -13142,7 +13142,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ref-cast</name>
       <version>1.0.25</version>
       <description>Safely cast &amp;T to &amp;U where the struct U contains a single field of type T.</description>
@@ -13164,7 +13164,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1">
-      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev&gt;</author>
+      <author>Dmitry Dygalo &lt;dmitry@dygalo.dev></author>
       <name>referencing</name>
       <version>0.38.1</version>
       <description>An implementation-agnostic JSON reference resolution library for Rust.</description>
@@ -13183,7 +13183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -13232,7 +13232,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-lite</name>
       <version>0.1.9</version>
       <description>A lightweight regex engine that optimizes for binary size and compilation time. </description>
@@ -13257,7 +13257,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -13282,7 +13282,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex</name>
       <version>1.12.3</version>
       <description>An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. </description>
@@ -13307,7 +13307,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#relative-path@2.0.1">
-      <author>John-John Tedro &lt;udoprog@tedro.se&gt;</author>
+      <author>John-John Tedro &lt;udoprog@tedro.se></author>
       <name>relative-path</name>
       <version>2.0.1</version>
       <description>Portable, relative paths for Rust.</description>
@@ -13332,7 +13332,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.4.2">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.4.2</version>
       <description>Endian-aware primitives for Rust</description>
@@ -13354,7 +13354,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rend</name>
       <version>0.5.3</version>
       <description>Cross-platform, endian-aware primitives for Rust</description>
@@ -13376,7 +13376,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-middleware</name>
       <version>0.4.2</version>
       <description>Wrapper around reqwest to allow for client middleware chains.</description>
@@ -13395,7 +13395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com&gt;</author>
+      <author>Rodrigo Gryzinski &lt;rodrigo.gryzinski@truelayer.com></author>
       <name>reqwest-retry</name>
       <version>0.7.0</version>
       <description>Retry middleware for reqwest.</description>
@@ -13414,7 +13414,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.12.28</version>
       <description>higher level HTTP client library</description>
@@ -13436,7 +13436,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>reqwest</name>
       <version>0.13.2</version>
       <description>higher level HTTP client library</description>
@@ -13458,7 +13458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
-      <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
+      <author>Luca Palmieri &lt;lpalmieri@truelayer.com></author>
       <name>retry-policies</name>
       <version>0.4.0</version>
       <description>A collection of plug-and-play retry policies for Rust projects.</description>
@@ -13498,7 +13498,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.7.46</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13517,7 +13517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv</name>
       <version>0.8.15</version>
       <description>Zero-copy deserialization framework for Rust</description>
@@ -13539,7 +13539,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.7.46</version>
       <description>Derive macro for rkyv</description>
@@ -13558,7 +13558,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15">
-      <author>David Koloski &lt;djkoloski@gmail.com&gt;</author>
+      <author>David Koloski &lt;djkoloski@gmail.com></author>
       <name>rkyv_derive</name>
       <version>0.8.15</version>
       <description>Derive macro for rkyv</description>
@@ -13577,7 +13577,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
-      <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
+      <author>Wim Looman &lt;wim@nemo157.com>, Kerollmops &lt;kero@meilisearch.com></author>
       <name>roaring</name>
       <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
@@ -13599,7 +13599,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roxmltree@0.21.1">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>roxmltree</name>
       <version>0.21.1</version>
       <description>Represent an XML as a read-only tree.</description>
@@ -13621,7 +13621,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rsa@0.9.10">
-      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com&gt;</author>
+      <author>RustCrypto Developers, dignifiedquire &lt;dignifiedquire@gmail.com></author>
       <name>rsa</name>
       <version>0.9.10</version>
       <description>Pure Rust RSA implementation</description>
@@ -13643,7 +13643,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0">
-      <author>Jakob Demler &lt;jdemler@curry-software.com&gt;, CurrySoftware &lt;info@curry-software.com&gt;</author>
+      <author>Jakob Demler &lt;jdemler@curry-software.com>, CurrySoftware &lt;info@curry-software.com></author>
       <name>rust-stemmers</name>
       <version>1.2.0</version>
       <description>A rust implementation of some popular snowball stemming algorithms</description>
@@ -13662,7 +13662,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0">
-      <author>Paul Mason &lt;paul@form1.co.nz&gt;</author>
+      <author>Paul Mason &lt;paul@form1.co.nz></author>
       <name>rust_decimal</name>
       <version>1.40.0</version>
       <description>Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations.</description>
@@ -13724,7 +13724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>0.38.44</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13746,7 +13746,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
-      <author>Dan Gohman &lt;dev@sunfishcode.online&gt;, Jakub Konka &lt;kubkon@jakubkonka.com&gt;</author>
+      <author>Dan Gohman &lt;dev@sunfishcode.online>, Jakub Konka &lt;kubkon@jakubkonka.com></author>
       <name>rustix</name>
       <version>1.1.4</version>
       <description>Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls</description>
@@ -13870,7 +13870,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>rustversion</name>
       <version>1.0.22</version>
       <description>Conditional compilation according to rustc compiler version</description>
@@ -13892,7 +13892,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
-      <author>Katsu Kawakami &lt;kkawa1570@gmail.com&gt;</author>
+      <author>Katsu Kawakami &lt;kkawa1570@gmail.com></author>
       <name>rustyline</name>
       <version>17.0.2</version>
       <description>Rustyline, a readline implementation based on Antirez's Linenoise</description>
@@ -13914,7 +13914,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -13958,7 +13958,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -14005,7 +14005,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
-      <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
+      <author>David Pedersen &lt;david.pdrsn@gmail.com></author>
       <name>sea-bae</name>
       <version>0.2.1</version>
       <description>A Rust proc-macro attribute parser</description>
@@ -14030,7 +14030,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
-      <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
+      <author>Billy Chan &lt;ccw.billy.123@gmail.com></author>
       <name>sea-orm-macros</name>
       <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
@@ -14055,7 +14055,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com></author>
       <name>sea-orm</name>
       <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
@@ -14080,7 +14080,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
-      <author>Valentin Tolmer &lt;valentin@tolmer.fr&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Valentin Tolmer &lt;valentin@tolmer.fr>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query-binder</name>
       <version>0.7.0</version>
       <description>Driver library for using SeaQuery with SQLx</description>
@@ -14102,7 +14102,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
-      <author>Follpvosten &lt;wolfi@karpador.xyz&gt;, Rene Leveille &lt;rene@nestingsafe.com&gt;</author>
+      <author>Follpvosten &lt;wolfi@karpador.xyz>, Rene Leveille &lt;rene@nestingsafe.com></author>
       <name>sea-query-derive</name>
       <version>0.4.3</version>
       <description>Derive macro for sea-query's Iden trait</description>
@@ -14124,7 +14124,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7">
-      <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;, Billy Chan &lt;ccw.billy.123@gmail.com&gt;, Ivan Krivosheev &lt;py.krivosheev@gmail.com&gt;</author>
+      <author>Chris Tsang &lt;chris.2y3@outlook.com>, Billy Chan &lt;ccw.billy.123@gmail.com>, Ivan Krivosheev &lt;py.krivosheev@gmail.com></author>
       <name>sea-query</name>
       <version>0.32.7</version>
       <description>🔱 A dynamic query builder for MySQL, Postgres and SQLite</description>
@@ -14146,7 +14146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0">
-      <author>ticki &lt;ticki@users.noreply.github.com&gt;, Tom Almeida &lt;tom@tommoa.me&gt;</author>
+      <author>ticki &lt;ticki@users.noreply.github.com>, Tom Almeida &lt;tom@tommoa.me></author>
       <name>seahash</name>
       <version>4.1.0</version>
       <description>A blazingly fast, portable hash function with proven statistical guarantees.</description>
@@ -14168,7 +14168,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework-sys</name>
       <version>2.17.0</version>
       <description>Apple `Security.framework` low-level FFI bindings</description>
@@ -14190,7 +14190,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;, Kornel &lt;kornel@geekhood.net&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com>, Kornel &lt;kornel@geekhood.net></author>
       <name>security-framework</name>
       <version>3.7.0</version>
       <description>Security.framework bindings for macOS and iOS</description>
@@ -14215,7 +14215,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>semver</name>
       <version>1.0.27</version>
       <description>Parser and evaluator for Cargo's flavor of Semantic Versioning</description>
@@ -14237,7 +14237,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>seq-macro</name>
       <version>0.3.6</version>
       <description>Macro to repeat sequentially indexed copies of a fragment of code.</description>
@@ -14259,7 +14259,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -14284,7 +14284,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -14309,7 +14309,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -14334,7 +14334,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -14356,7 +14356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -14378,7 +14378,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -14400,7 +14400,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_yaml</name>
       <version>0.9.34+deprecated</version>
       <description>YAML data format for Serde</description>
@@ -14422,7 +14422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <author>Antoine Catton &lt;devel@antoine.catton.fr&gt;</author>
+      <author>Antoine Catton &lt;devel@antoine.catton.fr></author>
       <name>serde_yaml_ng</name>
       <version>0.10.0</version>
       <description>YAML data format for Serde</description>
@@ -14488,7 +14488,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0">
-      <author>baoyachi &lt;liaoymxsdl@gmail.com&gt;</author>
+      <author>baoyachi &lt;liaoymxsdl@gmail.com></author>
       <name>sha256</name>
       <version>1.6.0</version>
       <description>sha256 crypto digest</description>
@@ -14573,7 +14573,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io></author>
       <name>sharded-slab</name>
       <version>0.1.7</version>
       <description>A lock-free concurrent slab. </description>
@@ -14598,7 +14598,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -14617,7 +14617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -14661,7 +14661,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -14680,7 +14680,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5">
-      <author>Hans Kratz &lt;hans@appfour.com&gt;</author>
+      <author>Hans Kratz &lt;hans@appfour.com></author>
       <name>simdutf8</name>
       <version>0.1.5</version>
       <description>SIMD-accelerated UTF-8 validation.</description>
@@ -14705,7 +14705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2">
-      <author>Frank Denis &lt;github@pureftpd.org&gt;</author>
+      <author>Frank Denis &lt;github@pureftpd.org></author>
       <name>siphasher</name>
       <version>1.0.2</version>
       <description>SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust</description>
@@ -14730,7 +14730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
-      <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
+      <author>Mike Heffner &lt;mikeh@fesnel.com></author>
       <name>sketches-ddsketch</name>
       <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
@@ -14752,7 +14752,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -14793,7 +14793,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com></author>
       <name>smol</name>
       <version>2.0.2</version>
       <description>A small and fast async runtime</description>
@@ -14812,7 +14812,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14834,7 +14834,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14856,7 +14856,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu-derive</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -14878,7 +14878,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.7.5">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.7.5</version>
       <description>An ergonomic error handling library</description>
@@ -14900,7 +14900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.8.9">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.8.9</version>
       <description>An ergonomic error handling library</description>
@@ -14922,7 +14922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>snafu</name>
       <version>0.9.0</version>
       <description>An ergonomic error handling library</description>
@@ -14944,7 +14944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>snap</name>
       <version>1.1.1</version>
       <description>A pure Rust implementation of the Snappy compression algorithm. Includes streaming compression and decompression. </description>
@@ -14969,7 +14969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -14994,7 +14994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -15032,7 +15032,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org></author>
       <name>sqlparser</name>
       <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
@@ -15082,7 +15082,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-core</name>
       <version>0.8.6</version>
       <description>Core of SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15101,7 +15101,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros-core</name>
       <version>0.8.6</version>
       <description>Macro support core for SQLx, the Rust SQL toolkit. Not intended to be used directly.</description>
@@ -15120,7 +15120,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-macros</name>
       <version>0.8.6</version>
       <description>Macros for SQLx, the rust SQL toolkit. Not intended to be used directly.</description>
@@ -15139,7 +15139,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-mysql</name>
       <version>0.8.6</version>
       <description>MySQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15161,7 +15161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-postgres</name>
       <version>0.8.6</version>
       <description>PostgreSQL driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15183,7 +15183,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx-sqlite</name>
       <version>0.8.6</version>
       <description>SQLite driver implementation for SQLx. Not for direct use; see the `sqlx` crate for details.</description>
@@ -15205,7 +15205,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
-      <author>Ryan Leckey &lt;leckey.ryan@gmail.com&gt;, Austin Bonander &lt;austin.bonander@gmail.com&gt;, Chloe Ross &lt;orangesnowfox@gmail.com&gt;, Daniel Akhterov &lt;akhterovd@gmail.com&gt;</author>
+      <author>Ryan Leckey &lt;leckey.ryan@gmail.com>, Austin Bonander &lt;austin.bonander@gmail.com>, Chloe Ross &lt;orangesnowfox@gmail.com>, Daniel Akhterov &lt;akhterovd@gmail.com></author>
       <name>sqlx</name>
       <version>0.8.6</version>
       <description>🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, and SQLite.</description>
@@ -15227,7 +15227,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1">
-      <author>Robert Grosse &lt;n210241048576@gmail.com&gt;</author>
+      <author>Robert Grosse &lt;n210241048576@gmail.com></author>
       <name>stable_deref_trait</name>
       <version>1.2.1</version>
       <description>An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. </description>
@@ -15249,7 +15249,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Simonas Kazlauskas &lt;stacker@kazlauskas.me&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Simonas Kazlauskas &lt;stacker@kazlauskas.me></author>
       <name>stacker</name>
       <version>0.1.23</version>
       <description>A stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack. </description>
@@ -15321,7 +15321,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#stringprep@0.1.5">
-      <author>Steven Fackler &lt;sfackler@gmail.com&gt;</author>
+      <author>Steven Fackler &lt;sfackler@gmail.com></author>
       <name>stringprep</name>
       <version>0.1.5</version>
       <description>An implementation of the stringprep algorithm</description>
@@ -15340,7 +15340,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strip-ansi-escapes@0.2.1">
-      <author>Ted Mielczarek &lt;ted@mielczarek.org&gt;</author>
+      <author>Ted Mielczarek &lt;ted@mielczarek.org></author>
       <name>strip-ansi-escapes</name>
       <version>0.2.1</version>
       <description>Strip ANSI escape sequences from byte streams.</description>
@@ -15365,7 +15365,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1">
-      <author>Danny Guo &lt;danny@dannyguo.com&gt;, maxbachmann &lt;oss@maxbachmann.de&gt;</author>
+      <author>Danny Guo &lt;danny@dannyguo.com>, maxbachmann &lt;oss@maxbachmann.de></author>
       <name>strsim</name>
       <version>0.11.1</version>
       <description>Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice. </description>
@@ -15390,7 +15390,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.26.3">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.26.3</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15415,7 +15415,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15440,7 +15440,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.26.4">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.26.4</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15465,7 +15465,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0">
-      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com&gt;</author>
+      <author>Peter Glotfelty &lt;peter.glotfelty@microsoft.com></author>
       <name>strum_macros</name>
       <version>0.28.0</version>
       <description>Helpful macros for working with enums and strings</description>
@@ -15490,7 +15490,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1">
-      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net&gt;, Henry de Valence &lt;hdevalence@hdevalence.ca&gt;</author>
+      <author>Isis Lovecruft &lt;isis@patternsinthevoid.net>, Henry de Valence &lt;hdevalence@hdevalence.ca></author>
       <name>subtle</name>
       <version>2.6.1</version>
       <description>Pure-Rust traits and utilities for constant-time cryptographic implementations.</description>
@@ -15515,7 +15515,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0">
-      <author>Svix Inc. &lt;oss@svix.com&gt;</author>
+      <author>Svix Inc. &lt;oss@svix.com></author>
       <name>svix-ksuid</name>
       <version>0.8.0</version>
       <description>A pure Rust and fully tested KSUID implementation</description>
@@ -15537,7 +15537,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>1.0.109</version>
       <description>Parser for Rust source code</description>
@@ -15559,7 +15559,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -15581,7 +15581,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -15606,7 +15606,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2">
-      <author>Nika Layzell &lt;nika@thelayzells.com&gt;</author>
+      <author>Nika Layzell &lt;nika@thelayzells.com></author>
       <name>synstructure</name>
       <version>0.13.2</version>
       <description>Helper methods and macros for custom derives</description>
@@ -15628,7 +15628,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com&gt;</author>
+      <author>Guillaume Gomez &lt;guillaume1.gomez@gmail.com></author>
       <name>sysinfo</name>
       <version>0.38.3</version>
       <description>Library to get system information such as processes, CPUs, disks, components and networks</description>
@@ -15647,7 +15647,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0">
-      <author>Stephen Wakely &lt;fungus.humungus@gmail.com&gt;</author>
+      <author>Stephen Wakely &lt;fungus.humungus@gmail.com></author>
       <name>syslog_loose</name>
       <version>0.22.0</version>
       <description>A loose parser for syslog messages.</description>
@@ -15729,7 +15729,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>tantivy-fst</name>
       <version>0.5.0</version>
       <description>This is a tantivy-specific fork from the fst crate from Burntsushi. (Please use the fst crate instead.) </description>
@@ -15751,7 +15751,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1">
-      <author>Elliott Linder &lt;elliott.darfink@gmail.com&gt;, myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>Elliott Linder &lt;elliott.darfink@gmail.com>, myrrlyn &lt;self@myrrlyn.dev></author>
       <name>tap</name>
       <version>1.0.1</version>
       <description>Generic extensions for tapping values in Rust</description>
@@ -15776,7 +15776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
-      <author>Steven Allen &lt;steven@stebalien.com&gt;, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au&gt;, Jason White &lt;me@jasonwhite.io&gt;</author>
+      <author>Steven Allen &lt;steven@stebalien.com>, The Rust Project Developers, Ashley Mannix &lt;ashleymannix@live.com.au>, Jason White &lt;me@jasonwhite.io></author>
       <name>tempfile</name>
       <version>3.26.0</version>
       <description>A library for managing temporary files and directories.</description>
@@ -15851,7 +15851,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>termcolor</name>
       <version>1.4.1</version>
       <description>A simple cross platform library for writing colored text to a terminal. </description>
@@ -15900,7 +15900,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>1.0.69</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15919,7 +15919,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror-impl</name>
       <version>2.0.18</version>
       <description>Implementation detail of the `thiserror` crate</description>
@@ -15938,7 +15938,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>1.0.69</version>
       <description>derive(Error)</description>
@@ -15960,7 +15960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>thiserror</name>
       <version>2.0.18</version>
       <description>derive(Error)</description>
@@ -15982,7 +15982,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>thread_local</name>
       <version>1.1.9</version>
       <description>Per-object thread-local storage</description>
@@ -16004,7 +16004,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0">
-      <author>Apache Thrift Developers &lt;dev@thrift.apache.org&gt;</author>
+      <author>Apache Thrift Developers &lt;dev@thrift.apache.org></author>
       <name>thrift</name>
       <version>0.17.0</version>
       <description>Rust bindings for the Apache Thrift RPC system</description>
@@ -16029,7 +16029,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-core</name>
       <version>0.1.8</version>
       <description>This crate is an implementation detail and should not be relied upon directly.</description>
@@ -16048,7 +16048,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time-macros</name>
       <version>0.2.27</version>
       <description>    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. </description>
@@ -16067,7 +16067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
-      <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;, Time contributors</author>
+      <author>Jacob Pratt &lt;open-source@jhpratt.dev>, Time contributors</author>
       <name>time</name>
       <version>0.3.47</version>
       <description>Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].</description>
@@ -16089,7 +16089,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tiny-keccak@2.0.2">
-      <author>debris &lt;marek.kotewicz@gmail.com&gt;</author>
+      <author>debris &lt;marek.kotewicz@gmail.com></author>
       <name>tiny-keccak</name>
       <version>2.0.2</version>
       <description>An implementation of Keccak derived functions.</description>
@@ -16127,7 +16127,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0">
-      <author>Lokathor &lt;zefria@gmail.com&gt;</author>
+      <author>Lokathor &lt;zefria@gmail.com></author>
       <name>tinyvec</name>
       <version>1.10.0</version>
       <description>`tinyvec` provides 100% safe vec-like data structures.</description>
@@ -16146,7 +16146,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1">
-      <author>Soveu &lt;marx.tomasz@gmail.com&gt;</author>
+      <author>Soveu &lt;marx.tomasz@gmail.com></author>
       <name>tinyvec_macros</name>
       <version>0.1.1</version>
       <description>Some macros for tiny containers</description>
@@ -16165,7 +16165,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -16211,7 +16211,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-stream</name>
       <version>0.1.18</version>
       <description>Utilities to work with `Stream` and `tokio`. </description>
@@ -16233,7 +16233,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -16255,7 +16255,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -16331,7 +16331,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-build</name>
       <version>0.14.5</version>
       <description>Codegen module of `tonic` gRPC implementation. </description>
@@ -16353,7 +16353,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost-build</name>
       <version>0.14.5</version>
       <description>Prost build integration for tonic</description>
@@ -16375,7 +16375,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic-prost</name>
       <version>0.14.5</version>
       <description>Prost codec implementation for tonic</description>
@@ -16397,7 +16397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5">
-      <author>Lucio Franco &lt;luciofranco14@gmail.com&gt;</author>
+      <author>Lucio Franco &lt;luciofranco14@gmail.com></author>
       <name>tonic</name>
       <version>0.14.5</version>
       <description>A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. </description>
@@ -16419,7 +16419,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-http</name>
       <version>0.6.8</version>
       <description>Tower middleware and utilities for HTTP clients and servers</description>
@@ -16441,7 +16441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -16466,7 +16466,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -16491,7 +16491,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -16513,7 +16513,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -16535,7 +16535,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -16557,7 +16557,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-log</name>
       <version>0.2.0</version>
       <description>Provides compatibility between `tracing` and the `log` crate. </description>
@@ -16579,7 +16579,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-serde</name>
       <version>0.2.0</version>
       <description>A compatibility layer for serializing trace data with `serde` </description>
@@ -16601,7 +16601,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;me@davidbarsky.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;me@davidbarsky.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-subscriber</name>
       <version>0.3.22</version>
       <description>Utilities for implementing and composing `tracing` subscribers. </description>
@@ -16623,7 +16623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -16645,7 +16645,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -16695,7 +16695,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2">
-      <author>Jake Goulding &lt;jake.goulding@gmail.com&gt;</author>
+      <author>Jake Goulding &lt;jake.goulding@gmail.com></author>
       <name>twox-hash</name>
       <version>2.1.2</version>
       <description>A Rust implementation of the XXHash and XXH3 algorithms</description>
@@ -16717,7 +16717,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typeid</name>
       <version>1.0.3</version>
       <description>Const TypeId and non-'static TypeId</description>
@@ -16760,7 +16760,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag-impl</name>
       <version>0.2.21</version>
       <description>Implementation detail of the typetag crate</description>
@@ -16782,7 +16782,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>typetag</name>
       <version>0.2.21</version>
       <description>Serde serializable and deserializable trait objects</description>
@@ -16828,7 +16828,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>ucd-trie</name>
       <version>0.1.7</version>
       <description>A trie for storing Unicode codepoint sets and maps. </description>
@@ -16853,7 +16853,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -16897,7 +16897,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0">
-      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com&gt;</author>
+      <author>YesLogic Pty. Ltd. &lt;info@yeslogic.com></author>
       <name>unicode-general-category</name>
       <version>1.1.0</version>
       <description>Fast lookup of the Unicode General Category property for char</description>
@@ -16922,7 +16922,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -16944,7 +16944,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-normalization</name>
       <version>0.1.25</version>
       <description>This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. </description>
@@ -16969,7 +16969,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.4">
-      <author>Charles Lew &lt;crlf0710@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Charles Lew &lt;crlf0710@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-properties</name>
       <version>0.1.4</version>
       <description>Query character Unicode properties according to UAX #44 and UTR #51. </description>
@@ -16994,7 +16994,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-segmentation</name>
       <version>1.12.0</version>
       <description>This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. </description>
@@ -17016,7 +17016,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.1.14</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17038,7 +17038,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2">
-      <author>kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-width</name>
       <version>0.2.2</version>
       <description>Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. </description>
@@ -17060,7 +17060,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6">
-      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, kwantam &lt;kwantam@gmail.com&gt;, Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>erick.tryzelaar &lt;erick.tryzelaar@gmail.com>, kwantam &lt;kwantam@gmail.com>, Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>unicode-xid</name>
       <version>0.2.6</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. </description>
@@ -17107,7 +17107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unsafe-libyaml</name>
       <version>0.2.11</version>
       <description>libyaml transpiled to rust by c2rust</description>
@@ -17129,7 +17129,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.7.1">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.7.1</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17151,7 +17151,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0">
-      <author>Brian Smith &lt;brian@briansmith.org&gt;</author>
+      <author>Brian Smith &lt;brian@briansmith.org></author>
       <name>untrusted</name>
       <version>0.9.0</version>
       <description>Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.</description>
@@ -17195,7 +17195,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3">
-      <author>Kornel &lt;kornel@geekhood.net&gt;, Bertram Truong &lt;b@bertramtruong.com&gt;</author>
+      <author>Kornel &lt;kornel@geekhood.net>, Bertram Truong &lt;b@bertramtruong.com></author>
       <name>urlencoding</name>
       <version>2.1.3</version>
       <description>A Rust library for doing URL percentage encoding.</description>
@@ -17217,7 +17217,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6">
-      <author>Simon Sapin &lt;simon.sapin@exyr.org&gt;</author>
+      <author>Simon Sapin &lt;simon.sapin@exyr.org></author>
       <name>utf-8</name>
       <version>0.7.6</version>
       <description>Incremental, zero-copy UTF-8 decoding with error handling</description>
@@ -17236,7 +17236,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>utf8-ranges</name>
       <version>1.0.5</version>
       <description>DEPRECATED. Use regex-syntax::utf8 submodule instead.</description>
@@ -17261,7 +17261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8">
-      <author>Magic Len &lt;len@magiclen.org&gt;</author>
+      <author>Magic Len &lt;len@magiclen.org></author>
       <name>utf8-width</name>
       <version>0.1.8</version>
       <description>To determine the width of a UTF-8 character by providing its first byte.</description>
@@ -17283,7 +17283,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>utf8_iter</name>
       <version>1.0.4</version>
       <description>Iterator by char over potentially-invalid UTF-8 in &amp;[u8]</description>
@@ -17308,7 +17308,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>utf8parse</name>
       <version>0.2.2</version>
       <description>Table-driven UTF-8 parser</description>
@@ -17330,7 +17330,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa-gen</name>
       <version>5.4.0</version>
       <description>Code generation implementation for utoipa</description>
@@ -17349,7 +17349,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com&gt;</author>
+      <author>Juha Kukkonen &lt;juha7kukkonen@gmail.com></author>
       <name>utoipa</name>
       <version>5.4.0</version>
       <description>Compile time generated OpenAPI documentation for Rust</description>
@@ -17386,7 +17386,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
-      <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
+      <author>Ashley Mannix&lt;ashleymannix@live.com.au>, Dylan DPC&lt;dylan.dpc@gmail.com>, Hunar Roop Kahlon&lt;hunar.roop@gmail.com></author>
       <name>uuid</name>
       <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
@@ -17411,7 +17411,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -17433,7 +17433,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -17455,7 +17455,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0">
-      <author>Vector Contributors &lt;vector@datadoghq.com&gt;</author>
+      <author>Vector Contributors &lt;vector@datadoghq.com></author>
       <name>vrl</name>
       <version>0.31.0</version>
       <description>Vector Remap Language</description>
@@ -17495,7 +17495,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vte@0.14.1">
-      <author>Joe Wilm &lt;joe@jwilm.com&gt;, Christian Duerr &lt;contact@christianduerr.com&gt;</author>
+      <author>Joe Wilm &lt;joe@jwilm.com>, Christian Duerr &lt;contact@christianduerr.com></author>
       <name>vte</name>
       <version>0.14.1</version>
       <description>Parser for implementing terminal emulators</description>
@@ -17517,7 +17517,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -17542,7 +17542,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -17631,7 +17631,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3">
-      <author>Harry Fei &lt;tiziyuanfang@gmail.com&gt;</author>
+      <author>Harry Fei &lt;tiziyuanfang@gmail.com></author>
       <name>which</name>
       <version>6.0.3</version>
       <description>A Rust equivalent of Unix command "which". Locate installed executable in cross platforms.</description>
@@ -17713,7 +17713,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0">
-      <author>hhatto &lt;hhatto.jp@gmail.com&gt;</author>
+      <author>hhatto &lt;hhatto.jp@gmail.com></author>
       <name>woothee</name>
       <version>0.13.0</version>
       <description>user-agent strings parser</description>
@@ -17754,7 +17754,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#wyz@0.5.1">
-      <author>myrrlyn &lt;self@myrrlyn.dev&gt;</author>
+      <author>myrrlyn &lt;self@myrrlyn.dev></author>
       <name>wyz</name>
       <version>0.5.1</version>
       <description>myrrlyn’s utility collection</description>
@@ -17779,7 +17779,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xmlparser@0.13.6">
-      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com&gt;</author>
+      <author>Yevhenii Reizner &lt;razrfalcon@gmail.com></author>
       <name>xmlparser</name>
       <version>0.13.6</version>
       <description>Pull-based, zero-allocation XML parser.</description>
@@ -17801,7 +17801,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15">
-      <author>Douman &lt;douman@gmx.se&gt;</author>
+      <author>Douman &lt;douman@gmx.se></author>
       <name>xxhash-rust</name>
       <version>0.8.15</version>
       <description>Implementation of xxhash</description>
@@ -17820,7 +17820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>yansi</name>
       <version>1.0.1</version>
       <description>A dead simple ANSI terminal color painting library.</description>
@@ -17842,7 +17842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke-derive</name>
       <version>0.8.1</version>
       <description>Custom derive for the yoke crate</description>
@@ -17861,7 +17861,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>yoke</name>
       <version>0.8.1</version>
       <description>Abstraction allowing borrowed data to be carried along with the backing data it borrows from</description>
@@ -17880,7 +17880,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy-derive</name>
       <version>0.8.40</version>
       <description>Custom derive for traits from the zerocopy crate</description>
@@ -17899,7 +17899,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.40">
-      <author>Joshua Liebow-Feeser &lt;joshlf@google.com&gt;, Jack Wrenn &lt;jswrenn@amazon.com&gt;</author>
+      <author>Joshua Liebow-Feeser &lt;joshlf@google.com>, Jack Wrenn &lt;jswrenn@amazon.com></author>
       <name>zerocopy</name>
       <version>0.8.40</version>
       <description>Zerocopy makes zero-cost memory manipulation effortless. We write "unsafe" so you don't have to.</description>
@@ -17918,7 +17918,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom-derive</name>
       <version>0.1.6</version>
       <description>Custom derive for the zerofrom crate</description>
@@ -17937,7 +17937,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerofrom</name>
       <version>0.1.6</version>
       <description>ZeroFrom trait for constructing</description>
@@ -18019,7 +18019,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2">
-      <author>Manish Goregaokar &lt;manishsmail@gmail.com&gt;</author>
+      <author>Manish Goregaokar &lt;manishsmail@gmail.com></author>
       <name>zerovec-derive</name>
       <version>0.11.2</version>
       <description>Custom derive for the zerovec crate</description>
@@ -18057,7 +18057,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
-      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <author>Zac Burns &lt;That3Percent@gmail.com></author>
       <name>zigzag</name>
       <version>0.1.0</version>
       <description>ZigZag encoding and decoding</description>
@@ -18076,7 +18076,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, Marli Frost &lt;marli@frost.red>, Ryan Levick &lt;ryan.levick@gmail.com></author>
       <name>zip</name>
       <version>0.6.6</version>
       <description>Library to support the reading and writing of zip files. </description>
@@ -18116,7 +18116,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -18138,7 +18138,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-safe</name>
       <version>7.2.4</version>
       <description>Safe low-level bindings for the zstd compression library.</description>
@@ -18157,7 +18157,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd-sys</name>
       <version>2.0.16+zstd.1.5.7</version>
       <description>Low-level bindings for the zstd compression library.</description>
@@ -18179,7 +18179,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3">
-      <author>Alexandre Bury &lt;alexandre.bury@gmail.com&gt;</author>
+      <author>Alexandre Bury &lt;alexandre.bury@gmail.com></author>
       <name>zstd</name>
       <version>0.13.3</version>
       <description>Binding for the zstd compression library.</description>
@@ -19287,7 +19287,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
@@ -19333,7 +19333,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
@@ -19364,7 +19364,7 @@
       <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/proto#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
       <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
@@ -19375,9 +19375,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />

--- a/src/wal/wal.cdx.xml
+++ b/src/wal/wal.cdx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:fa009ea7-4f87-497e-b450-d3cea7c12772" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:7e0253b1-c714-449c-bb77-07912771d585" version="1">
   <metadata>
-    <timestamp>2026-04-06T08:46:46.277680000Z</timestamp>
+    <timestamp>2026-07-29T08:21:36.737330000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
@@ -9,7 +9,7 @@
         <version>0.5.7</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
       <name>wal</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/wal@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0 bin-target-0">
           <name>wal</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/wal@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -30,6 +30,38 @@
     </properties>
   </metadata>
   <components>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error-attr2</name>
+      <version>2.0.0</version>
+      <description>Attribute macro for the proc-macro-error2 crate</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
+      <name>proc-macro-error2</name>
+      <version>2.0.1</version>
+      <description>Almost drop-in replacement to panics in proc-macros</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro-error2@2.0.1?vcs_url=git%2Bhttps://github.com/hengfeiyang/proc-macro-error-2%3Fbranch=main%403aec7aa1c9c4c9de7019f1b9f919e19380342bbf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <author>Matthias Seitz &lt;matthias.seitz@outlook.de&gt;</author>
       <name>chromiumoxide</name>
@@ -125,7 +157,1398 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <component type="library" bom-ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <name>object_store</name>
+      <version>0.13.2</version>
+      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/object_store@0.13.2?vcs_url=git%2Bhttps://github.com/openobserve/arrow-rs-object-store%3Fbranch=openobserve-v0.13.2%4001c97b4d3f7857a1af87f0b66b68d329d3ccd9fd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/apache/arrow-rs-object-store</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion</name>
+      <version>54.0.0</version>
+      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog-listing</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog-listing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog-listing@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-catalog</name>
+      <version>54.0.0</version>
+      <description>datafusion-catalog</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-catalog@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common-runtime</name>
+      <version>54.0.0</version>
+      <description>Common Runtime functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common-runtime@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-arrow</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-arrow</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-arrow@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-csv</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-csv</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-csv@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-json</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-json</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-json@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource-parquet</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource-parquet</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource-parquet@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-datasource</name>
+      <version>54.0.0</version>
+      <description>datafusion-datasource</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-datasource@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-doc</name>
+      <version>54.0.0</version>
+      <description>Documentation module for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-doc@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-execution</name>
+      <version>54.0.0</version>
+      <description>Execution configuration support for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-execution@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr-common</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-expr</name>
+      <version>54.0.0</version>
+      <description>Logical plan and expression representation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate-common</name>
+      <version>54.0.0</version>
+      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-aggregate</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-aggregate@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-nested</name>
+      <version>54.0.0</version>
+      <description>Nested Type Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-nested@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-table</name>
+      <version>54.0.0</version>
+      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-table@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window-common</name>
+      <version>54.0.0</version>
+      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions-window</name>
+      <version>54.0.0</version>
+      <description>Window function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions-window@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-functions</name>
+      <version>54.0.0</version>
+      <description>Function packages for the DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-functions@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-macros</name>
+      <version>54.0.0</version>
+      <description>Procedural macros for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-macros@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Query Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-adapter</name>
+      <version>54.0.0</version>
+      <description>Physical expression schema adaptation utilities for DataFusion</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-adapter@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr-common</name>
+      <version>54.0.0</version>
+      <description>Common functionality of physical expression for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-expr</name>
+      <version>54.0.0</version>
+      <description>Physical expression implementation for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-expr@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-optimizer</name>
+      <version>54.0.0</version>
+      <description>DataFusion Physical Optimizer</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-optimizer@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-physical-plan</name>
+      <version>54.0.0</version>
+      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-physical-plan@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto-common</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion common types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto-common@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-proto</name>
+      <version>54.0.0</version>
+      <description>Protobuf serialization of DataFusion logical plan expressions</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-proto@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-pruning</name>
+      <version>54.0.0</version>
+      <description>DataFusion Pruning Logic</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-pruning@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-session</name>
+      <version>54.0.0</version>
+      <description>datafusion-session</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-session@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
+      <name>datafusion-sql</name>
+      <version>54.0.0</version>
+      <description>DataFusion SQL Query Planner</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/datafusion-sql@54.0.0?vcs_url=git%2Bhttps://github.com/openobserve/datafusion%3Frev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b%40869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://datafusion.apache.org</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/apache/datafusion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy</name>
+      <version>0.26.1</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy@0.26.1?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>ownedbytes</name>
+      <version>0.9.0</version>
+      <description>Expose data as static slice</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/ownedbytes@0.9.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ownedbytes/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-bitpacker</name>
+      <version>0.10.0</version>
+      <description>Tantivy-sub crate: bitpacking</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-bitpacker@0.10.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <name>tantivy-columnar</name>
+      <version>0.7.0</version>
+      <description>column oriented storage for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-columnar@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
+      <name>tantivy-common</name>
+      <version>0.11.0</version>
+      <description>common traits and utility functions used by multiple tantivy subcrates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-common@0.11.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tantivy_common/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
+      <name>tantivy-query-grammar</name>
+      <version>0.26.0</version>
+      <description>Search engine library</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-query-grammar@0.26.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <name>tantivy-sstable</name>
+      <version>0.7.0</version>
+      <description>sstables for tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-sstable@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <name>tantivy-stacker</name>
+      <version>0.7.0</version>
+      <description>term hashmap used for indexing</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-stacker@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <name>tantivy-tokenizer-api</name>
+      <version>0.7.0</version>
+      <description>Tokenizer API of tantivy</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tantivy-tokenizer-api@0.7.0?vcs_url=git%2Bhttps://github.com/openobserve/tantivy%3Fbranch=perf/openobserve%40679ab092944c4a73ae2f40c09d6d06f3ec39c409</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/quickwit-oss/tantivy</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex</name>
+      <version>0.1.0</version>
+      <description>Vortex file format with all builtin codecs and a sampling compressor.</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-alp</name>
+      <version>0.1.0</version>
+      <description>Vortex ALP array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-alp@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array-macros</name>
+      <version>0.1.0</version>
+      <description>Proc macros for slot-oriented Vortex array helpers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array-macros@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-array</name>
+      <version>0.1.0</version>
+      <description>Vortex in memory columnar data format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-array@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-btrblocks</name>
+      <version>0.1.0</version>
+      <description>BtrBlocks style compressor</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-btrblocks@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-buffer</name>
+      <version>0.1.0</version>
+      <description>A byte buffer implementation for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-buffer@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-bytebool</name>
+      <version>0.1.0</version>
+      <description>Vortex byte-boolean array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-bytebool@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-compressor</name>
+      <version>0.1.0</version>
+      <description>Encoding-agnostic compression framework for Vortex arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-compressor@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-datetime-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex physical encoding that compresses temporal components individually</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-datetime-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-decimal-byte-parts</name>
+      <version>0.1.0</version>
+      <description>Vortex decimal array (non-canonical) encodings</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-decimal-byte-parts@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-error</name>
+      <version>0.1.0</version>
+      <description>Vortex errors</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-error@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fastlanes</name>
+      <version>0.1.0</version>
+      <description>Vortex fastlanes arrays</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fastlanes@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-file</name>
+      <version>0.1.0</version>
+      <description>Vortex file readers and writers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-file@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-flatbuffers</name>
+      <version>0.1.0</version>
+      <description>Flatbuffers definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-flatbuffers@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-fsst</name>
+      <version>0.1.0</version>
+      <description>Vortex FSST string array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-fsst@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-io</name>
+      <version>0.1.0</version>
+      <description>Core async and blocking IO traits and implementations, used by IPC and file format</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-io@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-ipc</name>
+      <version>0.1.0</version>
+      <description>IPC message format to exchange Vortex arrays across processes</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-ipc@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-layout</name>
+      <version>0.1.0</version>
+      <description>Vortex layouts provide a way to perform lazy push-down scans over abstract storage</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-layout@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-mask</name>
+      <version>0.1.0</version>
+      <description>Vortex Mask - sorted, unique, non-negative integers</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-mask@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-metrics</name>
+      <version>0.1.0</version>
+      <description>Vortex Metrics</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-metrics@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-pco</name>
+      <version>0.1.0</version>
+      <description>Vortex Pco array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-pco@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-proto</name>
+      <version>0.1.0</version>
+      <description>Protocol buffer definitions for Vortex types</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-proto@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-runend</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-runend@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-scan</name>
+      <version>0.1.0</version>
+      <description>Scanning operations for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-scan@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sequence</name>
+      <version>0.1.0</version>
+      <description>Vortex run end encoded array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sequence@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-session</name>
+      <version>0.1.0</version>
+      <description>Session object for Vortex</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-session@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-sparse</name>
+      <version>0.1.0</version>
+      <description>Vortex Sparse array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-sparse@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-utils</name>
+      <version>0.1.0</version>
+      <description>Common definitions across crates</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-utils@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zigzag</name>
+      <version>0.1.0</version>
+      <description>Vortex zig zag array</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zigzag@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <author>Vortex Authors &lt;hello@vortex.dev&gt;</author>
+      <name>vortex-zstd</name>
+      <version>0.1.0</version>
+      <description>Vortex zstd compression array encoding</description>
+      <scope>required</scope>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vortex-zstd@0.1.0?vcs_url=git%2Bhttps://github.com/openobserve/vortex%3Frev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0%4057ffbf2b2dde0d63df03ff1f4788cd85206388a0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/vortex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <name>config</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -134,7 +1557,7 @@
       </licenses>
       <purl>pkg:cargo/config@0.1.0?download_url=file://../config</purl>
     </component>
-    <component type="library" bom-ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
       <name>proto</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -494,19 +1917,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103">
       <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
       <name>anyhow</name>
-      <version>1.0.102</version>
+      <version>1.0.103</version>
       <description>Flexible concrete Error type built on std::error::Error</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c</hash>
+        <hash alg="SHA-256">2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/anyhow@1.0.102</purl>
+      <purl>pkg:cargo/anyhow@1.0.103</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/anyhow</url>
@@ -556,25 +1979,47 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;</author>
       <name>arc-swap</name>
-      <version>1.8.2</version>
+      <version>1.9.1</version>
       <description>Atomically swappable Arc</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5</hash>
+        <hash alg="SHA-256">6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arc-swap@1.8.2</purl>
+      <purl>pkg:cargo/arc-swap@1.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/arc-swap</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/vorner/arc-swap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0">
+      <author>SpiralDB Authors &lt;hello@spiraldb.com&gt;</author>
+      <name>arcref</name>
+      <version>0.2.0</version>
+      <description>For when you need a pointer and don't care if it's &amp;'static T or Arc&lt;T&gt;</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/arcref@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/arcref</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/arcref</url>
         </reference>
       </externalReferences>
     </component>
@@ -644,19 +2089,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-arith</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow arithmetic kernels</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f</hash>
+        <hash alg="SHA-256">a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-arith@58.0.0</purl>
+      <purl>pkg:cargo/arrow-arith@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -666,19 +2111,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-array</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e</hash>
+        <hash alg="SHA-256">cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0</expression>
+        <expression>Apache-2.0 AND MIT</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-array@58.0.0</purl>
+      <purl>pkg:cargo/arrow-array@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -688,19 +2133,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-buffer</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Buffer abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20</hash>
+        <hash alg="SHA-256">0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-buffer@58.0.0</purl>
+      <purl>pkg:cargo/arrow-buffer@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -710,19 +2155,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-cast</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Cast kernel and utilities for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26</hash>
+        <hash alg="SHA-256">4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-cast@58.0.0</purl>
+      <purl>pkg:cargo/arrow-cast@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -732,19 +2177,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-csv</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing CSV format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7</hash>
+        <hash alg="SHA-256">e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-csv@58.0.0</purl>
+      <purl>pkg:cargo/arrow-csv@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -754,19 +2199,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-data</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Array data abstractions for Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33</hash>
+        <hash alg="SHA-256">3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-data@58.0.0</purl>
+      <purl>pkg:cargo/arrow-data@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -776,19 +2221,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ipc</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for the Arrow IPC format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c</hash>
+        <hash alg="SHA-256">238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ipc@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ipc@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -798,19 +2243,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-json</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Support for parsing JSON format to and from the Arrow format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22</hash>
+        <hash alg="SHA-256">205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-json@58.0.0</purl>
+      <purl>pkg:cargo/arrow-json@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -820,19 +2265,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-ord</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Ordering kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495</hash>
+        <hash alg="SHA-256">1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-ord@58.0.0</purl>
+      <purl>pkg:cargo/arrow-ord@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -842,19 +2287,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-row</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Arrow row format</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663</hash>
+        <hash alg="SHA-256">bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-row@58.0.0</purl>
+      <purl>pkg:cargo/arrow-row@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -864,19 +2309,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-schema</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Defines the logical types for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb</hash>
+        <hash alg="SHA-256">f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-schema@58.0.0</purl>
+      <purl>pkg:cargo/arrow-schema@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -886,19 +2331,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-select</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Selection kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325</hash>
+        <hash alg="SHA-256">8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-select@58.0.0</purl>
+      <purl>pkg:cargo/arrow-select@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -908,19 +2353,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow-string</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>String kernels for arrow arrays</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c</hash>
+        <hash alg="SHA-256">29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow-string@58.0.0</purl>
+      <purl>pkg:cargo/arrow-string@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -930,19 +2375,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>arrow</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Rust implementation of Apache Arrow</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da</hash>
+        <hash alg="SHA-256">378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/arrow@58.0.0</purl>
+      <purl>pkg:cargo/arrow@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -1096,6 +2541,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-executor</name>
+      <version>1.14.0</version>
+      <description>Async executor</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-executor@1.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-executor</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-fs</name>
@@ -1121,6 +2585,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-io</name>
+      <version>2.6.0</version>
+      <description>Async I/O and timers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-io@2.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-io</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
       <name>async-lock</name>
@@ -1137,6 +2620,50 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smol-rs/async-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-net</name>
+      <version>2.0.0</version>
+      <description>Async networking primitives for TCP/UDP/Unix communication</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-net@2.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/async-net</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>async-process</name>
+      <version>2.5.0</version>
+      <description>Async interface for working with processes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-process@2.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-process</url>
         </reference>
       </externalReferences>
     </component>
@@ -1159,6 +2686,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dcchut/async-recursion</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <author>John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>async-signal</name>
+      <version>0.2.14</version>
+      <description>Async signal handling</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/async-signal@0.2.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/async-signal</url>
         </reference>
       </externalReferences>
     </component>
@@ -1436,19 +2982,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-sdk-sns</name>
-      <version>1.97.0</version>
+      <version>1.98.0</version>
       <description>AWS SDK for Amazon Simple Notification Service</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9f88a10a02e1783e748c74067ec93f8da50ad95e264bbb0cdfb0a7cf191cbecf</hash>
+        <hash alg="SHA-256">caa03e65dbad2dd07b57bcd44f48dbd65283b71ee33ea7e6efe8dcc26b82e98e</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-sdk-sns@1.97.0</purl>
+      <purl>pkg:cargo/aws-sdk-sns@1.98.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/awslabs/aws-sdk-rust</url>
@@ -1683,19 +3229,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <author>AWS Rust SDK Team &lt;aws-sdk-rust@amazon.com&gt;, Russell Cohen &lt;rcoh@amazon.com&gt;</author>
       <name>aws-smithy-types</name>
-      <version>1.4.6</version>
+      <version>1.4.7</version>
       <description>Types for smithy-rs codegen.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75</hash>
+        <hash alg="SHA-256">9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/aws-smithy-types@1.4.6</purl>
+      <purl>pkg:cargo/aws-smithy-types@1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
@@ -1737,6 +3283,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/smithy-lang/smithy-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <name>axum-client-ip</name>
+      <version>1.3.1</version>
+      <description>Client IP address extractors for Axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-client-ip@1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/axum-client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -1956,6 +3520,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>better_io</name>
+      <version>0.2.0</version>
+      <description>Better traits and implementations for IO and buffering</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/better_io@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <author>Andrew Kubera</author>
       <name>bigdecimal</name>
@@ -1978,6 +3561,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/akubera/bigdecimal-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <author>Jyun-Yan You &lt;jyyou.tw@gmail.com&gt;, Emilio Cobos Álvarez &lt;emilio@crisal.io&gt;, Nick Fitzgerald &lt;fitzgen@gmail.com&gt;, The Servo project developers</author>
+      <name>bindgen</name>
+      <version>0.72.1</version>
+      <description>Automatically generates Rust FFI bindings to C and C++ libraries.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/bindgen@0.72.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bindgen</url>
+        </reference>
+        <reference type="website">
+          <url>https://rust-lang.github.io/rust-bindgen/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/rust-bindgen</url>
         </reference>
       </externalReferences>
     </component>
@@ -2019,6 +3627,31 @@
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
       <purl>pkg:cargo/bit-vec@0.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bit-vec/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/contain-rs/bit-vec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <author>Alexis Beingessner &lt;a.beingessner@gmail.com&gt;</author>
+      <name>bit-vec</name>
+      <version>0.9.1</version>
+      <description>A vector of bits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bit-vec@0.9.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/bit-vec/</url>
@@ -2159,6 +3792,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/block-buffer@0.10.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/block-buffer</url>
@@ -2561,6 +4216,71 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <author>Without Boats &lt;saoirse@without.boats&gt;, Ashley Williams &lt;ashley666ashley@gmail.com&gt;, Steve Klabnik &lt;steve@steveklabnik.com&gt;, Rain &lt;rain@sunshowers.io&gt;</author>
+      <name>camino</name>
+      <version>1.2.3</version>
+      <description>UTF-8 paths</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/camino@1.2.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/camino</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/camino-rs/camino</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <name>cargo-platform</name>
+      <version>0.1.9</version>
+      <description>Cargo's representation of a target platform.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo-platform@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cargo-platform</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cargo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <author>Oliver Schneider &lt;git-spam-no-reply9815368754983@oli-obk.de&gt;</author>
+      <name>cargo_metadata</name>
+      <version>0.19.2</version>
+      <description>structured access to the output of `cargo metadata`</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cargo_metadata@0.19.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/oli-obk/cargo_metadata</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <author>RustCrypto Developers</author>
       <name>cbc</name>
@@ -2627,6 +4347,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/census</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <author>Jethro Beekman &lt;jethro@jbeekman.nl&gt;</author>
+      <name>cexpr</name>
+      <version>0.6.0</version>
+      <description>A C expression parser and evaluator</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/cexpr@0.6.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cexpr/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/jethrogb/rust-cexpr</url>
         </reference>
       </externalReferences>
     </component>
@@ -2832,25 +4574,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <author>Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
-      <name>chumsky</name>
-      <version>0.9.3</version>
-      <description>A parser library for humans with powerful error recovery</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/chumsky@0.9.3</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/zesterer/chumsky</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2">
       <author>Nathaniel McCallum &lt;npmccallum@profian.com&gt;</author>
       <name>ciborium-io</name>
@@ -2982,6 +4705,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <author>Kyle Mayes &lt;kyle@mayeses.com&gt;</author>
+      <name>clang-sys</name>
+      <version>1.8.1</version>
+      <description>Rust bindings for libclang.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/clang-sys@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/clang-sys</url>
+        </reference>
+        <reference type="other">
+          <url>clang</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/KyleMayes/clang-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <name>clap</name>
       <version>4.5.60</version>
@@ -3051,6 +4799,24 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/clap-rs/clap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <name>client-ip</name>
+      <version>0.2.1</version>
+      <description>HTTP client IP address extractors</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/client-ip@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imbolc/client-ip</url>
         </reference>
       </externalReferences>
     </component>
@@ -3245,6 +5011,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6">
       <author>RustCrypto Developers</author>
       <name>const-oid</name>
@@ -3308,6 +5099,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/tkaitchuck/constrandom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6">
+      <author>Joachim Enggård Nebel</author>
+      <name>const_for</name>
+      <version>0.1.6</version>
+      <description>Ergonomic for loop macro for const and no_std contexts</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const_for@0.1.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/JENebel/const_for</url>
         </reference>
       </externalReferences>
     </component>
@@ -3431,6 +5241,53 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation</name>
+      <version>0.9.4</version>
+      <description>Bindings to Core Foundation for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core-foundation@0.9.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0">
+      <author>Thom Chiovoloni &lt;chiovolonit@gmail.com&gt;</author>
+      <name>core_detect</name>
+      <version>1.0.0</version>
+      <description>A `no_std` version of the `std::is_x86_feature_detected!` macro.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core_detect@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/core_detect</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/thomcc/core_detect</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
       <author>RustCrypto Developers</author>
       <name>cpufeatures</name>
@@ -3444,6 +5301,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/cpufeatures@0.2.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/cpufeatures</url>
@@ -3577,18 +5456,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <name>crossbeam-epoch</name>
-      <version>0.9.18</version>
+      <version>0.9.20</version>
       <description>Epoch-based garbage collection</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e</hash>
+        <hash alg="SHA-256">2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/crossbeam-epoch@0.9.18</purl>
+      <purl>pkg:cargo/crossbeam-epoch@0.9.20</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch</url>
@@ -3675,6 +5554,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/crypto-common@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/crypto-common</url>
@@ -3775,6 +5676,27 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/RustCrypto/block-modes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <name>custom-labels</name>
+      <version>0.4.6</version>
+      <description>Custom labels for profilers</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/custom-labels@0.4.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://polarsignals.com</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/polarsignals/custom-labels</url>
         </reference>
       </externalReferences>
     </component>
@@ -3945,729 +5867,24 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog-listing</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog-listing</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0">
+      <name>datasketches</name>
+      <version>0.3.0</version>
+      <description>A software library of stochastic streaming algorithms (a.k.a. sketches)</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6</hash>
+        <hash alg="SHA-256">46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/datafusion-catalog-listing@53.0.0</purl>
+      <purl>pkg:cargo/datasketches@0.3.0</purl>
       <externalReferences>
         <reference type="website">
-          <url>https://datafusion.apache.org</url>
+          <url>https://datasketches.apache.org</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-catalog</name>
-      <version>53.0.0</version>
-      <description>datafusion-catalog</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-catalog@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common-runtime</name>
-      <version>53.0.0</version>
-      <description>Common Runtime functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common-runtime@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-arrow</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-arrow</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-arrow@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-csv</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-csv</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-csv@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-json</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-json</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-json@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource-parquet</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource-parquet</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource-parquet@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-datasource</name>
-      <version>53.0.0</version>
-      <description>datafusion-datasource</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-datasource@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-doc</name>
-      <version>53.0.0</version>
-      <description>Documentation module for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-doc@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-execution</name>
-      <version>53.0.0</version>
-      <description>Execution configuration support for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-execution@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr-common</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-expr</name>
-      <version>53.0.0</version>
-      <description>Logical plan and expression representation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate-common</name>
-      <version>53.0.0</version>
-      <description>Utility functions for implementing aggregate functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-aggregate</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-aggregate@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-nested</name>
-      <version>53.0.0</version>
-      <description>Nested Type Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-nested@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-table</name>
-      <version>53.0.0</version>
-      <description>Traits and types for logical plans and expressions for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-table@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window-common</name>
-      <version>53.0.0</version>
-      <description>Common functions for implementing user-defined window functions for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions-window</name>
-      <version>53.0.0</version>
-      <description>Window function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions-window@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-functions</name>
-      <version>53.0.0</version>
-      <description>Function packages for the DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-functions@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-macros</name>
-      <version>53.0.0</version>
-      <description>Procedural macros for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-macros@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Query Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-adapter</name>
-      <version>53.0.0</version>
-      <description>Physical expression schema adaptation utilities for DataFusion</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-adapter@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr-common</name>
-      <version>53.0.0</version>
-      <description>Common functionality of physical expression for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-expr</name>
-      <version>53.0.0</version>
-      <description>Physical expression implementation for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-expr@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-optimizer</name>
-      <version>53.0.0</version>
-      <description>DataFusion Physical Optimizer</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-optimizer@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-physical-plan</name>
-      <version>53.0.0</version>
-      <description>Physical (ExecutionPlan) implementations for DataFusion query engine</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-physical-plan@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto-common</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion common types</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">965eca01edc8259edbbd95883a00b6d81e329fd44a019cfac3a03b026a83eade</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto-common@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-proto</name>
-      <version>53.0.0</version>
-      <description>Protobuf serialization of DataFusion logical plan expressions</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-proto@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-pruning</name>
-      <version>53.0.0</version>
-      <description>DataFusion Pruning Logic</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-pruning@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-session</name>
-      <version>53.0.0</version>
-      <description>datafusion-session</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-session@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion-sql</name>
-      <version>53.0.0</version>
-      <description>DataFusion SQL Query Planner</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion-sql@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
-      <name>datafusion</name>
-      <version>53.0.0</version>
-      <description>DataFusion is an in-memory query engine that uses Apache Arrow as the memory model</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/datafusion@53.0.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://datafusion.apache.org</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/apache/datafusion</url>
+          <url>https://github.com/apache/datasketches-rust</url>
         </reference>
       </externalReferences>
     </component>
@@ -4810,6 +6027,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/digest@0.10.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/digest</url>
@@ -5079,6 +6318,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>dtype_dispatch</name>
+      <version>0.2.1</version>
+      <description>Macro builder for working with data types</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dtype_dispatch@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5">
       <author>Kornel &lt;kornel@geekhood.net&gt;</author>
       <name>dunce</name>
@@ -5257,6 +6515,56 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator-derive</name>
+      <version>1.5.0</version>
+      <description>Procedural macro to derive Sequence</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator-derive@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator-derive</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <author>Stephane Raux &lt;stephaneyfx@gmail.com&gt;</author>
+      <name>enum-iterator</name>
+      <version>2.3.0</version>
+      <description>Tools to iterate over all values of a type (e.g. all variants of an enumeration)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD</expression>
+      </licenses>
+      <purl>pkg:cargo/enum-iterator@2.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/enum-iterator</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/stephaneyfx/enum-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/stephaneyfx/enum-iterator.git</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <name>env_filter</name>
       <version>1.0.0</version>
@@ -5418,6 +6726,72 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait-proc_macros</name>
+      <version>1.0.1</version>
+      <description>Internal: proc-macro backend of ::ext_trait.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait-proc_macros@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>ext-trait</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ext-trait@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>extension-traits</name>
+      <version>1.0.1</version>
+      <description>Annotation to easily define ad-hoc / one-shot extension traits</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/extension-traits@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ext-trait</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/ext-trait.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <author>Raph Levien &lt;raph@google.com&gt;, Robin Stocker &lt;robin@nibor.org&gt;, Keith Hall &lt;keith.hall@available.systems&gt;</author>
       <name>fancy-regex</name>
@@ -5456,6 +6830,28 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/fulmicoton/fastdivide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <author>SpiralDB &lt;hello@spiraldb.com&gt;</author>
+      <name>fastlanes</name>
+      <version>0.5.2</version>
+      <description>Rust implementation of the FastLanes compression layout</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fastlanes@0.5.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spiraldb/fastlanes</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fastlanes</url>
         </reference>
       </externalReferences>
     </component>
@@ -5779,6 +7175,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/webdesus/fs_extra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <author>SpiralDB Developers &lt;hello@spiraldb.com&gt;</author>
+      <name>fsst-rs</name>
+      <version>0.5.11</version>
+      <description>Pure-Rust implementation of Fast Static Symbol Tables algorithm for string compression</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/fsst-rs@0.5.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spiraldb/fsst</url>
         </reference>
       </externalReferences>
     </component>
@@ -6225,28 +7640,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>h2</name>
-      <version>0.3.27</version>
-      <description>An HTTP/2 client and server</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/h2@0.3.27</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/h2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/h2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>h2</name>
@@ -6358,6 +7751,24 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/hashbrown@0.16.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/hashbrown</url>
@@ -6733,6 +8144,31 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <author>Leopold Arkham &lt;leopold.arkham@gmail.com&gt;</author>
+      <name>humansize</name>
+      <version>2.1.3</version>
+      <description>A configurable crate to easily represent sizes in a human-readable format.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/humansize@2.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/humansize</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/LeopoldArkham/humansize</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0">
       <name>humantime</name>
       <version>2.3.0</version>
@@ -6757,27 +8193,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <name>hyper-rustls</name>
-      <version>0.24.2</version>
-      <description>Rustls+hyper integration for pure rust HTTPS</description>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590</hash>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
       </hashes>
       <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
+        <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/hyper-rustls@0.24.2</purl>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/hyper-rustls/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://docs.rs/hybrid-array</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rustls/hyper-rustls</url>
+          <url>https://github.com/RustCrypto/hybrid-array</url>
         </reference>
       </externalReferences>
     </component>
@@ -6855,31 +8289,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
-      <name>hyper</name>
-      <version>0.14.32</version>
-      <description>A fast and correct HTTP library.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyper@0.14.32</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyper</url>
-        </reference>
-        <reference type="website">
-          <url>https://hyper.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>hyper</name>
@@ -6902,31 +8311,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/hyper</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <author>Tasos Bakogiannis &lt;t.bakogiannis@gmail.com&gt;</author>
-      <name>hyperloglogplus</name>
-      <version>0.4.1</version>
-      <description>HyperLogLog implementations.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/hyperloglogplus@0.4.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/hyperloglogplus</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tabac/hyperloglog.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -7169,18 +8553,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <name>indexmap</name>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <description>A hash table with consistent order and fast iteration.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017</hash>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/indexmap@2.13.0</purl>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/indexmap/</url>
@@ -7425,6 +8809,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <author>bluss</author>
+      <name>itertools</name>
+      <version>0.10.5</version>
+      <description>Extra iterator adaptors, iterator methods, free functions, and macros.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itertools@0.10.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itertools/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-itertools/itertools</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <author>bluss</author>
       <name>itertools</name>
@@ -7488,6 +8894,31 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>jiff-static</name>
+      <version>0.2.23</version>
+      <description>Create static TimeZone values for Jiff (useful in core-only environments).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/jiff-static@0.2.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jiff-tzdb</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/jiff</url>
         </reference>
       </externalReferences>
     </component>
@@ -7557,6 +8988,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <author>Khashayar Fereidani</author>
+      <name>kanal</name>
+      <version>0.1.1</version>
+      <description>The fast sync and async channel that Rust deserves</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/kanal@0.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/kanal</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/fereidani/kanal</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <author>RustCrypto Developers</author>
       <name>keccak</name>
@@ -7617,6 +9070,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <author>Chase Wilson &lt;contact@chasewilson.dev&gt;</author>
+      <name>lasso</name>
+      <version>0.7.3</version>
+      <description>A multithreaded and single threaded string interner that allows strings to be cached with a minimal memory footprint, associating them with a unique key that can be used to retrieve them at any time. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lasso@0.7.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lasso</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Kixiron/lasso</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
       <author>Marvin Löbel &lt;loebel.marvin@gmail.com&gt;</author>
       <name>lazy_static</name>
@@ -7639,19 +9114,63 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator-proc_macros</name>
+      <version>0.1.7</version>
+      <description>Internal: proc-macro backend of ::lending_iterator.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator-proc_macros@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>lending-iterator</name>
+      <version>0.1.7</version>
+      <description>Fully general lending iterators in stable rust: windows_mut!</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lending-iterator@0.1.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/lending-iterator</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/lending-iterator.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <author>Alexis Mousset &lt;contact@amousset.me&gt;, Paolo Barbolini &lt;paolo@paolo565.org&gt;</author>
       <name>lettre</name>
-      <version>0.11.19</version>
+      <version>0.11.22</version>
       <description>Email client</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f</hash>
+        <hash alg="SHA-256">0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lettre@0.11.19</purl>
+      <purl>pkg:cargo/lettre@0.11.22</purl>
       <externalReferences>
         <reference type="website">
           <url>https://lettre.rs</url>
@@ -7821,22 +9340,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
       <author>The Rust Project Developers</author>
       <name>libc</name>
-      <version>0.2.182</version>
+      <version>0.2.186</version>
       <description>Raw FFI bindings to platform libraries like libc.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112</hash>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/libc@0.2.182</purl>
+      <purl>pkg:cargo/libc@0.2.186</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <author>Simonas Kazlauskas &lt;libloading@kazlauskas.me&gt;</author>
+      <name>libloading</name>
+      <version>0.8.9</version>
+      <description>Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55</hash>
+      </hashes>
+      <licenses>
+        <expression>ISC</expression>
+      </licenses>
+      <purl>pkg:cargo/libloading@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/libloading/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nagisa/rust_libloading/</url>
         </reference>
       </externalReferences>
     </component>
@@ -8054,19 +9595,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
       <author>Jerome Froelich &lt;jeromefroelic@hotmail.com&gt;</author>
       <name>lru</name>
-      <version>0.12.5</version>
+      <version>0.16.4</version>
       <description>A LRU cache implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38</hash>
+        <hash alg="SHA-256">7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lru@0.12.5</purl>
+      <purl>pkg:cargo/lru@0.16.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/lru/</url>
@@ -8101,25 +9642,88 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <author>Pascal Seitz &lt;pascal.seitz@gmail.com&gt;, Arthur Silva &lt;arthurprs@gmail.com&gt;, ticki &lt;Ticki@users.noreply.github.com&gt;</author>
       <name>lz4_flex</name>
-      <version>0.12.1</version>
+      <version>0.13.1</version>
       <description>Fastest LZ4 implementation in Rust, no unsafe by default.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746</hash>
+        <hash alg="SHA-256">7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/lz4_flex@0.12.1</purl>
+      <purl>pkg:cargo/lz4_flex@0.13.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/pseitz/lz4_flex</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/pseitz/lz4_flex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <author>rep-nop &lt;repnop@outlook.com&gt;</author>
+      <name>mac_address</name>
+      <version>1.1.8</version>
+      <description>Cross-platform retrieval of a network interface MAC address.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mac_address@1.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rep-nop/mac_address</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute-proc_macro</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros as proc_macro attributes or derives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute-proc_macro@0.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>macro_rules_attribute</name>
+      <version>0.1.3</version>
+      <description>Use declarative macros in attribute or derive position</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/macro_rules_attribute@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/macro_rules_attribute</url>
+        </reference>
+        <reference type="website">
+          <url>https://crates.io/crates/macro_rules_attribute</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/macro_rules_attribute-rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8180,6 +9784,28 @@
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
       <purl>pkg:cargo/md-5@0.10.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/md-5</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>md-5</name>
+      <version>0.11.0</version>
+      <description>MD5 hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/md-5@0.11.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/md-5</url>
@@ -8283,6 +9909,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <author>Gilad Naaman &lt;gilad.naaman@gmail.com&gt;</author>
+      <name>memoffset</name>
+      <version>0.9.1</version>
+      <description>offset_of functionality for Rust structs.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memoffset@0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Gilnaa/memoffset</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
       <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
       <name>mime</name>
@@ -8302,6 +9947,28 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
         </reference>
       </externalReferences>
     </component>
@@ -8352,19 +10019,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
       <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>mio</name>
-      <version>1.1.1</version>
+      <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc</hash>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/mio@1.1.1</purl>
+      <purl>pkg:cargo/mio@1.2.1</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/tokio-rs/mio</url>
@@ -8502,22 +10169,44 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0">
       <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
       <name>murmurhash32</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A simple implementation of murmurhash32_2</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b</hash>
+        <hash alg="SHA-256">a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/murmurhash32@0.3.1</purl>
+      <purl>pkg:cargo/murmurhash32@0.4.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/murmurhash32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>never-say-never</name>
+      <version>6.6.666</version>
+      <description>The never type (the true one!) in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/never-say-never@6.6.666</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/never-say-never</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/never-say-never.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8540,6 +10229,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/mbrubeck/rust-debug-unreachable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <author>The nix-rust Project Developers</author>
+      <name>nix</name>
+      <version>0.29.0</version>
+      <description>Rust friendly bindings to *nix APIs</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/nix@0.29.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nix-rust/nix</url>
         </reference>
       </externalReferences>
     </component>
@@ -8647,6 +10355,50 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/rust-bakery/nom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat-proc_macros</name>
+      <version>0.2.4</version>
+      <description>Internal: proc-macro backend of ::nougat.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat-proc_macros@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>nougat</name>
+      <version>0.2.4</version>
+      <description>(lifetime) GATs on stable Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/nougat@0.2.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/nougat</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/nougat.rs</url>
         </reference>
       </externalReferences>
     </component>
@@ -8913,6 +10665,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum</name>
+      <version>0.7.6</version>
+      <description>Procedural macros to make inter-operation between primitives and enums easier.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <author>Daniel Wagner-Hall &lt;dawagner@gmail.com&gt;, Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;, Vincent Esche &lt;regexident@gmail.com&gt;</author>
+      <name>num_enum_derive</name>
+      <version>0.7.6</version>
+      <description>Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num_enum_derive@0.7.6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/illicitonion/num_enum</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
       <author>Jacob Pratt &lt;open-source@jhpratt.dev&gt;</author>
       <name>num_threads</name>
@@ -8983,24 +10773,6 @@
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/gimli-rs/object</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <name>object_store</name>
-      <version>0.13.1</version>
-      <description>A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/object_store@0.13.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/apache/arrow-rs-object-store</url>
         </reference>
       </externalReferences>
     </component>
@@ -9089,6 +10861,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1">
+      <author>Linus Färnstrand &lt;faern@faern.net&gt;</author>
+      <name>oneshot</name>
+      <version>0.2.1</version>
+      <description>Oneshot spsc channel with (potentially) lock-free non-blocking send, and a receiver supporting both thread blocking receive operations as well as Future based async polling. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/oneshot@0.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/faern/oneshot</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <author>Will Speak &lt;will@willspeak.me&gt;, Ivan Ivashchenko &lt;defuz@me.com&gt;</author>
       <name>onig</name>
@@ -9158,18 +10949,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <name>opentelemetry</name>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
       <description>OpenTelemetry API for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0</hash>
+        <hash alg="SHA-256">b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/opentelemetry@0.31.0</purl>
+      <purl>pkg:cargo/opentelemetry@0.32.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry</url>
@@ -9348,31 +11139,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>ownedbytes</name>
-      <version>0.9.0</version>
-      <description>Expose data as static slice</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/ownedbytes@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/ownedbytes/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0">
       <author>jam1garner &lt;8260240+jam1garner@users.noreply.github.com&gt;</author>
       <name>owo-colors</name>
@@ -9458,19 +11224,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <author>Apache Arrow &lt;dev@arrow.apache.org&gt;</author>
       <name>parquet</name>
-      <version>58.0.0</version>
+      <version>58.3.0</version>
       <description>Apache Parquet implementation in Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b</hash>
+        <hash alg="SHA-256">5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/parquet@58.0.0</purl>
+      <purl>pkg:cargo/parquet@58.3.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/apache/arrow-rs</url>
@@ -9540,6 +11306,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/dtolnay/paste</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <author>mwlon &lt;m.w.loncaric@gmail.com&gt;</author>
+      <name>pco</name>
+      <version>1.0.2</version>
+      <description>Good compression for numerical sequences</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pco@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pcodec/pcodec</url>
         </reference>
       </externalReferences>
     </component>
@@ -9997,6 +11782,47 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, John Nunley &lt;dev@notgull.net&gt;</author>
+      <name>polling</name>
+      <version>3.11.0</version>
+      <description>Portable interface to epoll, kqueue, event ports, and IOCP</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/polling@3.11.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/polling</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1">
+      <author>Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;</author>
+      <name>polonius-the-crab</name>
+      <version>0.2.1</version>
+      <description>Tools to feature more lenient Polonius-based borrow-checker patterns in stable Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/polonius-the-crab@0.2.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/polonius-the-crab</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/danielhenrymantilla/polonius-the-crab.rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <author>RustCrypto Developers</author>
       <name>poly1305</name>
@@ -10210,44 +12036,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error-attr2</name>
-      <version>2.0.0</version>
-      <description>Attribute macro for the proc-macro-error2 crate</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error-attr2@2.0.0</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <author>CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;, GnomedDev &lt;david2005thomas@gmail.com&gt;</author>
-      <name>proc-macro-error2</name>
-      <version>2.0.1</version>
-      <description>Almost drop-in replacement to panics in proc-macros</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/proc-macro-error2@2.0.1</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/GnomedDev/proc-macro-error-2</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
       <name>proc-macro2-diagnostics</name>
@@ -10423,7 +12211,7 @@
       <name>prost-types</name>
       <version>0.14.3</version>
       <description>Prost definitions of Protocol Buffers well known types.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7</hash>
       </hashes>
@@ -10832,6 +12620,27 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <name>quick-xml</name>
+      <version>0.39.2</version>
+      <description>High performance xml reader and writer</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/quick-xml@0.39.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quick-xml</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tafia/quick-xml</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>quickcheck</name>
@@ -10857,18 +12666,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
       <name>quinn-proto</name>
-      <version>0.11.14</version>
+      <version>0.11.15</version>
       <description>State machine for the QUIC transport protocol</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098</hash>
+        <hash alg="SHA-256">4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/quinn-proto@0.11.14</purl>
+      <purl>pkg:cargo/quinn-proto@0.11.15</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/quinn-rs/quinn</url>
@@ -11002,19 +12811,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <author>The Rand Project Developers, The Rust Project Developers</author>
       <name>rand</name>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <description>Random number generators and other randomness functionality. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8</hash>
+        <hash alg="SHA-256">d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand@0.10.0</purl>
+      <purl>pkg:cargo/rand@0.10.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/rand</url>
@@ -11202,28 +13011,28 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
       <author>The Rand Project Developers</author>
-      <name>rand_distr</name>
-      <version>0.4.3</version>
-      <description>Sampling from random number distributions </description>
+      <name>rand_xoshiro</name>
+      <version>0.6.0</version>
+      <description>Xoshiro, xoroshiro and splitmix64 random number generators</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31</hash>
+        <hash alg="SHA-256">6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/rand_distr@0.4.3</purl>
+      <purl>pkg:cargo/rand_xoshiro@0.6.0</purl>
       <externalReferences>
         <reference type="documentation">
-          <url>https://docs.rs/rand_distr</url>
+          <url>https://docs.rs/rand_xoshiro</url>
         </reference>
         <reference type="website">
           <url>https://rust-random.github.io/book</url>
         </reference>
         <reference type="vcs">
-          <url>https://github.com/rust-random/rand</url>
+          <url>https://github.com/rust-random/rngs</url>
         </reference>
       </externalReferences>
     </component>
@@ -11626,6 +13435,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>reqwest</name>
+      <version>0.13.2</version>
+      <description>higher level HTTP client library</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/reqwest@0.13.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/reqwest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/reqwest</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <author>Luca Palmieri &lt;lpalmieri@truelayer.com&gt;</author>
       <name>retry-policies</name>
@@ -11745,19 +13576,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <author>Wim Looman &lt;wim@nemo157.com&gt;, Kerollmops &lt;kero@meilisearch.com&gt;</author>
       <name>roaring</name>
-      <version>0.11.3</version>
+      <version>0.11.4</version>
       <description>A better compressed bitset - pure Rust implementation</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885</hash>
+        <hash alg="SHA-256">1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/roaring@0.11.3</purl>
+      <purl>pkg:cargo/roaring@0.11.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/roaring</url>
@@ -11981,60 +13812,39 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <name>rustls-platform-verifier</name>
+      <version>0.6.2</version>
+      <description>rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/rustls-platform-verifier@0.6.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rustls/rustls-platform-verifier</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <name>rustls-webpki</name>
-      <version>0.101.7</version>
+      <version>0.103.13</version>
       <description>Web PKI X.509 Certificate Verification.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765</hash>
+        <hash alg="SHA-256">61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e</hash>
       </hashes>
       <licenses>
         <expression>ISC</expression>
       </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.101.7</purl>
+      <purl>pkg:cargo/rustls-webpki@0.103.13</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
-      <name>rustls-webpki</name>
-      <version>0.103.9</version>
-      <description>Web PKI X.509 Certificate Verification.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53</hash>
-      </hashes>
-      <licenses>
-        <expression>ISC</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls-webpki@0.103.9</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/rustls/webpki</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <name>rustls</name>
-      <version>0.21.12</version>
-      <description>Rustls is a modern TLS library written in Rust.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/rustls@0.21.12</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -12194,28 +14004,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <author>Joseph Birr-Pixton &lt;jpixton@gmail.com&gt;</author>
-      <name>sct</name>
-      <version>0.7.1</version>
-      <description>Certificate transparency SCT verification library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414</hash>
-      </hashes>
-      <licenses>
-        <expression>Apache-2.0 OR ISC OR MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/sct@0.7.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/sct.rs</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <author>David Pedersen &lt;david.pdrsn@gmail.com&gt;</author>
       <name>sea-bae</name>
@@ -12241,19 +14029,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <author>Billy Chan &lt;ccw.billy.123@gmail.com&gt;</author>
       <name>sea-orm-macros</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>Derive macros for SeaORM</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832</hash>
+        <hash alg="SHA-256">9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm-macros@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm-macros@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12266,19 +14054,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <author>Chris Tsang &lt;chris.2y3@outlook.com&gt;</author>
       <name>sea-orm</name>
-      <version>1.1.19</version>
+      <version>1.1.20</version>
       <description>🐚 An async &amp; dynamic ORM for Rust</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103</hash>
+        <hash alg="SHA-256">2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sea-orm@1.1.19</purl>
+      <purl>pkg:cargo/sea-orm@1.1.20</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sea-orm</url>
@@ -12423,25 +14211,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/kornelski/rust-security-framework</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <author>Tamo &lt;tamo@meilisearch.com, Dean Karn &lt;dean@segment.com&gt;, Ulysse Carion &lt;ulysse@segment.com&gt;</author>
-      <name>segment</name>
-      <version>0.2.6</version>
-      <description>Segment analytics client for Rust. Forked for Meilisearch: https://github.com/meilisearch</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">971369158e31ad10bd73b558625f99de39554a2f00c2ff886a6796d950e69664</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/segment@0.2.6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>https://github.com/irevoire/segment</url>
         </reference>
       </externalReferences>
     </component>
@@ -12759,6 +14528,28 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <author>RustCrypto Developers</author>
       <name>sha3</name>
@@ -12938,19 +14729,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <author>Mike Heffner &lt;mikeh@fesnel.com&gt;</author>
       <name>sketches-ddsketch</name>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <description>A direct port of the Golang DDSketch implementation. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b</hash>
+        <hash alg="SHA-256">05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sketches-ddsketch@0.3.1</purl>
+      <purl>pkg:cargo/sketches-ddsketch@0.4.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/mheffner/rust-sketches-ddsketch</url>
@@ -12998,6 +14789,25 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;</author>
+      <name>smol</name>
+      <version>2.0.2</version>
+      <description>A small and fast async runtime</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/smol@2.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/smol</url>
         </reference>
       </externalReferences>
     </component>
@@ -13158,19 +14968,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
       <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
       <name>socket2</name>
-      <version>0.5.10</version>
+      <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678</hash>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/socket2@0.5.10</purl>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/socket2</url>
@@ -13183,44 +14993,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
-      <name>socket2</name>
-      <version>0.6.2</version>
-      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/socket2@0.6.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/socket2</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rust-lang/socket2</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
       <name>spin</name>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67</hash>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/spin@0.9.8</purl>
+      <purl>pkg:cargo/spin@0.9.9</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/mvdnes/spin-rs.git</url>
@@ -13246,19 +15031,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <author>Apache DataFusion &lt;dev@datafusion.apache.org&gt;</author>
       <name>sqlparser</name>
-      <version>0.61.0</version>
+      <version>0.62.0</version>
       <description>Extensible SQL Lexer and Parser with support for ANSI SQL:2011</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7</hash>
+        <hash alg="SHA-256">13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/sqlparser@0.61.0</purl>
+      <purl>pkg:cargo/sqlparser@0.62.0</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/sqlparser/</url>
@@ -13883,6 +15668,44 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0">
       <author>Oliver Giersch</author>
       <name>tagptr</name>
@@ -13905,77 +15728,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-bitpacker</name>
-      <version>0.9.0</version>
-      <description>Tantivy-sub crate: bitpacking</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-bitpacker@0.9.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy-bitpacker/latest/tantivy_bitpacker</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <name>tantivy-columnar</name>
-      <version>0.6.0</version>
-      <description>column oriented storage for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-columnar@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <author>Paul Masurel &lt;paul@quickwit.io&gt;, Pascal Seitz &lt;pascal@quickwit.io&gt;</author>
-      <name>tantivy-common</name>
-      <version>0.10.0</version>
-      <description>common traits and utility functions used by multiple tantivy subcrates</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-common@0.10.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy_common/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
       <name>tantivy-fst</name>
@@ -13995,116 +15747,6 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/quickwit-inc/fst</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy-query-grammar</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-query-grammar@0.25.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <name>tantivy-sstable</name>
-      <version>0.6.0</version>
-      <description>sstables for tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-sstable@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <name>tantivy-stacker</name>
-      <version>0.6.0</version>
-      <description>term hashmap used for indexing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-stacker@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <name>tantivy-tokenizer-api</name>
-      <version>0.6.0</version>
-      <description>Tokenizer API of tantivy</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy-tokenizer-api@0.6.0</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <author>Paul Masurel &lt;paul.masurel@gmail.com&gt;</author>
-      <name>tantivy</name>
-      <version>0.25.0</version>
-      <description>Search engine library</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tantivy@0.25.0</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tantivy/</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/quickwit-oss/tantivy</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/quickwit-oss/tantivy</url>
         </reference>
       </externalReferences>
     </component>
@@ -14230,6 +15872,30 @@
         </reference>
         <reference type="vcs">
           <url>https://github.com/BurntSushi/termcolor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0">
+      <name>termtree</name>
+      <version>1.0.0</version>
+      <description>Visualize tree-like data on the command-line</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/termtree@1.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/termtree</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-cli/termtree</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-cli/termtree</url>
         </reference>
       </externalReferences>
     </component>
@@ -14498,49 +16164,25 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio-macros</name>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c</hash>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio-macros@2.6.1</purl>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
         </reference>
         <reference type="vcs">
           <url>https://github.com/tokio-rs/tokio</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <name>tokio-rustls</name>
-      <version>0.24.1</version>
-      <description>Asynchronous TLS/SSL streams for Tokio using Rustls.</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT OR Apache-2.0</expression>
-      </licenses>
-      <purl>pkg:cargo/tokio-rustls@0.24.1</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://docs.rs/tokio-rustls</url>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/rustls/tokio-rustls</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/rustls/tokio-rustls</url>
         </reference>
       </externalReferences>
     </component>
@@ -14612,19 +16254,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tokio</name>
-      <version>1.50.0</version>
+      <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d</hash>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
       </hashes>
       <licenses>
         <expression>MIT</expression>
       </licenses>
-      <purl>pkg:cargo/tokio@1.50.0</purl>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
       <externalReferences>
         <reference type="website">
           <url>https://tokio.rs</url>
@@ -14936,27 +16578,6 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <name>tracing-opentelemetry</name>
-      <version>0.32.1</version>
-      <description>OpenTelemetry integration for tracing</description>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="SHA-256">1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc</hash>
-      </hashes>
-      <licenses>
-        <expression>MIT</expression>
-      </licenses>
-      <purl>pkg:cargo/tracing-opentelemetry@0.32.1</purl>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://github.com/tokio-rs/tracing-opentelemetry</url>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
       <name>tracing-serde</name>
@@ -15117,19 +16738,18 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0">
-      <author>Paho Lurie-Gregg &lt;paho@paholg.com&gt;, Andre Bogus &lt;bogusandre@gmail.com&gt;</author>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
       <name>typenum</name>
-      <version>1.19.0</version>
+      <version>1.20.1</version>
       <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb</hash>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
       </hashes>
       <licenses>
         <expression>MIT OR Apache-2.0</expression>
       </licenses>
-      <purl>pkg:cargo/typenum@1.19.0</purl>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/typenum</url>
@@ -15237,7 +16857,7 @@
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
-      <scope>excluded</scope>
+      <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
       </hashes>
@@ -15765,19 +17385,19 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <author>Ashley Mannix&lt;ashleymannix@live.com.au&gt;, Dylan DPC&lt;dylan.dpc@gmail.com&gt;, Hunar Roop Kahlon&lt;hunar.roop@gmail.com&gt;</author>
       <name>uuid</name>
-      <version>1.21.0</version>
+      <version>1.23.3</version>
       <description>A library to generate and parse UUIDs.</description>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb</hash>
+        <hash alg="SHA-256">144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7</hash>
       </hashes>
       <licenses>
         <expression>Apache-2.0 OR MIT</expression>
       </licenses>
-      <purl>pkg:cargo/uuid@1.21.0</purl>
+      <purl>pkg:cargo/uuid@1.23.3</purl>
       <externalReferences>
         <reference type="documentation">
           <url>https://docs.rs/uuid</url>
@@ -16436,6 +18056,25 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <author>Zac Burns &lt;That3Percent@gmail.com&gt;</author>
+      <name>zigzag</name>
+      <version>0.1.0</version>
+      <description>ZigZag encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zigzag@0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/That3Percent/zigzag</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, Marli Frost &lt;marli@frost.red&gt;, Ryan Levick &lt;ryan.levick@gmail.com&gt;</author>
       <name>zip</name>
@@ -16563,6 +18202,16 @@
     </component>
   </components>
   <dependencies>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+    </dependency>
+    <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1">
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error-attr2@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-tungstenite@0.28.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -16579,7 +18228,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#which@6.0.3" />
@@ -16591,12 +18240,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_fetcher@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#os_info@3.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6" />
     </dependency>
     <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#chromiumoxide_pdl@0.7.0">
@@ -16614,23 +18263,1046 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0">
+    <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-macros@54.0.0">
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-doc@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-adapter@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-optimizer@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common-runtime@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-aggregate-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-window-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-catalog-listing@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-arrow@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-csv@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-json@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource-parquet@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-table@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-pruning@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-datasource@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-expr-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-session@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-execution@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-physical-plan@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-sql@54.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-common@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-expr@54.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-functions-nested@54.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-columnar@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#ownedbytes@0.9.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-query-grammar@0.26.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-sstable@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-bitpacker@0.10.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-stacker@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-common@0.11.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#tantivy-tokenizer-api@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#inventory@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array-macros@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-compressor@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-file@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-alp@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-bytebool@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-datetime-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-decimal-byte-parts@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fastlanes@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-fsst@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-ipc@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-layout@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-btrblocks@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-flatbuffers@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-io@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-metrics@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-pco@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-types@0.14.3" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-runend@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-scan@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sequence@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-proto@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-sparse@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-utils@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zigzag@0.1.0">
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0" />
+    </dependency>
+    <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-zstd@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-array@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-buffer@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-error@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-mask@0.1.0" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#vortex-session@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
+    </dependency>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aes-siv@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-config@1.8.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitvec@1.0.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16638,7 +19310,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cron@0.15.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34" />
@@ -16646,77 +19318,68 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ordered-float@5.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prometheus@0.14.0" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha256@1.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#svix-ksuid@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0" />
+      <dependency ref="git+https://github.com/openobserve/tantivy?branch=perf%2Fopenobserve#0.26.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
+      <dependency ref="git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vrl@0.31.0" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/proto#0.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0" />
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/proto#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2" />
+      <dependency ref="git+https://github.com/openobserve/datafusion?rev=869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b#datafusion-proto@54.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-build@0.14.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-wkt-types@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tonic-prost-build@0.14.5" />
     </dependency>
-    <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/wal#0.1.0">
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/wal#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="path+file:///Users/hengfeiyang/code/rust/github.com/openobserve/openobserve/src/config#0.1.0" />
+      <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/config#0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu@0.9.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
@@ -16778,16 +19441,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.13" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ar_archive_writer@0.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arbitrary@1.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_arbitrary@1.4.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.9.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arcref@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#argon2@0.5.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
@@ -16795,40 +19459,40 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayref@0.3.9" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.6" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-complex@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
@@ -16838,41 +19502,42 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#csv-core@0.1.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-core@1.0.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
@@ -16882,58 +19547,59 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-csv@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-json@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ascii-canvas@4.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
@@ -16976,22 +19642,63 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-task@4.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-signal@0.2.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream-impl@0.3.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -17017,7 +19724,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tungstenite@0.24.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0">
@@ -17036,7 +19743,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17044,7 +19751,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha1@0.10.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
@@ -17052,7 +19759,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2">
@@ -17073,7 +19780,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17083,9 +19790,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.97.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-sdk-sns@1.98.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-runtime@1.7.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
@@ -17095,7 +19802,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17113,7 +19820,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17131,7 +19838,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17150,7 +19857,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime@1.10.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-types@1.3.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -17163,7 +19870,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
@@ -17178,35 +19885,29 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http@0.63.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -17220,23 +19921,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-json@0.62.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-query@0.60.15">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -17246,7 +19947,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-http-client@1.1.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-observability@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
@@ -17256,10 +19957,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64-simd@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes-utils@0.1.4" />
@@ -17275,7 +19976,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-xml@0.60.15">
@@ -17285,9 +19986,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-credential-types@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-async@1.2.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-runtime-api@1.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-smithy-types@1.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-client-ip@1.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -17330,7 +20036,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -17348,6 +20054,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#basic-toml@0.1.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
@@ -17356,10 +20063,25 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -17381,10 +20103,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-padding@0.3.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
@@ -17454,16 +20178,33 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#camino@1.2.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cbc@0.1.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cexpr@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfb-mode@0.8.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
@@ -17497,10 +20238,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-ll@0.2.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ciborium-io@0.2.2" />
@@ -17518,6 +20255,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cityhasher@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clang-sys@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap@4.5.60">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.60" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.5.55" />
@@ -17535,6 +20277,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.0.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#client-ip@0.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cmac@0.7.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2" />
@@ -17546,7 +20291,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.12.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2">
@@ -17572,6 +20317,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
@@ -17581,6 +20327,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-random-macro@0.1.16" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
@@ -17594,10 +20341,18 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
@@ -17615,10 +20370,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12">
@@ -17629,7 +20384,10 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto_secretbox@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aead@0.5.2" />
@@ -17651,6 +20409,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ctr@0.9.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#custom-labels@0.4.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.11" />
@@ -17695,511 +20459,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#data-encoding@2.10.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blake3@1.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-macros@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-doc@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-proto-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-pruning@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion@53.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-catalog-listing@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-common-runtime@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-arrow@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-csv@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-json@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-datasource-parquet@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-execution@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-aggregate@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-nested@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-table@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-functions-window@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-adapter@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-expr-common@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-optimizer@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-physical-plan@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-session@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datafusion-sql@53.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#datasketches@0.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dbl@0.3.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7" />
     </dependency>
@@ -18234,6 +20494,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#directories@5.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1" />
     </dependency>
@@ -18242,10 +20507,10 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys-next@0.1.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5">
@@ -18255,8 +20520,8 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dns-lookup@3.0.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#doc-comment@0.3.4" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#domain-macros@0.11.1">
@@ -18277,16 +20542,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenv_config@0.2.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#askama@0.15.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#convert_case@0.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dunce@1.0.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0">
@@ -18306,6 +20572,14 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator@2.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#enum-iterator-derive@1.5.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_filter@1.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -18323,7 +20597,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18335,12 +20609,30 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#exitcode@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait-proc_macros@1.0.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ext-trait@1.0.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastlanes@0.5.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const_for@0.1.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core_detect@1.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#faststr@0.2.34">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18368,7 +20660,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flume@0.11.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5" />
@@ -18384,6 +20676,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs_extra@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fsst-rs@0.5.11">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#funty@2.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
@@ -18437,21 +20732,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3" />
@@ -18462,19 +20757,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#gxhash@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18482,9 +20764,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
@@ -18511,6 +20793,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
     </dependency>
@@ -18530,7 +20817,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#home@0.5.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
@@ -18560,15 +20847,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humansize@2.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.24.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -18577,7 +20861,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18586,7 +20870,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
@@ -18598,31 +20882,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@0.14.32">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.3.27" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@0.2.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@0.4.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
@@ -18638,11 +20905,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
@@ -18698,9 +20962,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7">
@@ -18733,9 +20997,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.10.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
@@ -18743,12 +21010,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#either@1.15.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.23">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jiff-static@0.2.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jsonschema@0.38.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
@@ -18765,10 +21038,15 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#referencing@0.38.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-general-category@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid-simd@0.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#kanal@0.1.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#keccak@0.1.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
@@ -18792,13 +21070,29 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lasso@0.7.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator@0.1.7">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#extension-traits@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lending-iterator-proc_macros@0.1.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lettre@0.11.22">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chumsky@0.9.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email-encoding@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#email_address@0.2.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0" />
@@ -18812,8 +21106,8 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quoted_printable@0.5.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
@@ -18842,10 +21136,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lexical-util@1.0.7" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libloading@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma-sys@0.4.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#liblzma@0.4.6">
@@ -18864,21 +21161,30 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#local-ip-address@0.6.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.16.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute-proc_macro@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
@@ -18888,27 +21194,39 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md5@0.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#moka@0.12.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#event-listener@5.4.1" />
@@ -18917,7 +21235,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -18927,7 +21245,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multimap@0.10.1" />
@@ -18940,13 +21258,21 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmur3@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.4.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#never-say-never@6.6.666" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0">
@@ -18958,6 +21284,15 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat@0.2.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#macro_rules_attribute@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nougat-proc_macros@0.2.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.6">
@@ -19004,48 +21339,27 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-rational@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object@0.37.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#octseq@0.5.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19055,8 +21369,11 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ofb@0.6.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cipher@0.4.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#onig@6.5.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -19067,7 +21384,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.32.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
@@ -19103,9 +21420,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
@@ -19114,17 +21428,17 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.0.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parquet@58.3.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
@@ -19132,18 +21446,18 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.13.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#object_store@0.13.1" />
+      <dependency ref="git+https://github.com/openobserve/arrow-rs-object-store?branch=openobserve-v0.13.2#object_store@0.13.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thrift@0.17.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
     </dependency>
@@ -19154,6 +21468,12 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#paste@1.0.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pco@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#better_io@0.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dtype_dispatch@0.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#half@2.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#peeking_take_while@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
@@ -19180,12 +21500,12 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.7.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#petgraph@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fixedbitset@0.5.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1">
@@ -19227,11 +21547,16 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polling@3.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#polonius-the-crab@0.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#poly1305@0.8.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opaque-debug@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#universal-hash@0.5.1" />
@@ -19263,16 +21588,6 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19287,7 +21602,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#protobuf@3.7.2" />
@@ -19309,14 +21624,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.13.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19415,14 +21730,18 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quickcheck@1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#env_logger@0.11.9" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru-slab@0.1.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2" />
@@ -19436,21 +21755,21 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-proto@0.11.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn-udp@0.5.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
@@ -19461,13 +21780,13 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19492,9 +21811,8 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_xoshiro@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6" />
@@ -19535,7 +21853,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-filtered@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nohash@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
@@ -19557,7 +21875,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
@@ -19566,7 +21884,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-retry@0.7.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.103" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
@@ -19575,7 +21893,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
@@ -19601,7 +21919,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -19610,6 +21928,41 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@1.0.6" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quinn@0.11.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5" />
     </dependency>
@@ -19617,7 +21970,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.7.46">
@@ -19630,19 +21983,19 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv@0.8.15">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#munge@0.4.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ptr_meta@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rancor@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rend@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.8.15" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rkyv_derive@0.7.46">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
@@ -19654,7 +22007,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.3">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#roaring@0.11.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytemuck@1.25.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
     </dependency>
@@ -19696,12 +22049,12 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@0.38.44">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
@@ -19710,21 +22063,19 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-platform-verifier@0.6.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.101.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aws-lc-rs@1.16.2" />
@@ -19732,7 +22083,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2" />
     </dependency>
@@ -19740,7 +22091,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustyline@17.0.2">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1" />
@@ -19754,18 +22105,14 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sct@0.7.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-bae@0.2.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1" />
+      <dependency ref="git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#proc-macro-error2@2.0.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -19773,7 +22120,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.19">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm@1.1.20">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-stream@0.3.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19781,10 +22128,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ouroboros@0.18.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pgvector@0.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust_decimal@1.40.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-orm-macros@1.1.20" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query@0.32.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19795,7 +22143,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-binder@0.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bigdecimal@0.4.10" />
@@ -19805,7 +22153,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#darling@0.20.11" />
@@ -19824,29 +22172,23 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sea-query-derive@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seahash@4.1.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#segment@0.2.6">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#semver@1.0.27" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#seq-macro@0.3.6" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19859,6 +22201,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
@@ -19875,14 +22218,14 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_yaml_ng@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -19903,12 +22246,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha3@0.10.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19920,7 +22268,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signature@2.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7" />
@@ -19929,12 +22277,23 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#siphasher@1.0.2" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.4.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smol@2.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-channel@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-executor@1.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-fs@2.2.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-io@2.6.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-lock@3.4.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-net@2.0.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-process@2.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#blocking@1.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.7.5">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1" />
@@ -19967,20 +22326,17 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snafu-derive@0.9.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#snap@1.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.8">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spki@0.7.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#der@0.7.10" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.61.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlparser@0.62.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#recursive@0.1.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20006,7 +22362,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashlink@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
@@ -20019,11 +22375,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webpki-roots@0.26.11" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6">
@@ -20042,7 +22398,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6">
@@ -20090,7 +22446,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6">
@@ -20126,7 +22482,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#whoami@1.6.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6">
@@ -20148,7 +22504,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx@0.8.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6" />
@@ -20161,7 +22517,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#stacker@0.1.23">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#psm@0.1.30" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0" />
@@ -20224,7 +22580,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.38.3">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#objc2-io-kit@0.3.1" />
@@ -20233,100 +22589,20 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0" />
     </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tagptr@0.2.0" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ownedbytes@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-ranges@1.0.5" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#nom@7.1.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#murmurhash32@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rand_distr@0.4.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy@0.25.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#arc-swap@1.8.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitpacking@0.9.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bon@3.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#census@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#downcast-rs@2.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fastdivide@0.4.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#htmlescape@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyperloglogplus@0.4.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#levenshtein_automata@0.2.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lru@0.12.5" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lz4_flex@0.11.6" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#measure_time@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#oneshot@0.1.13" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-stemmers@1.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sketches-ddsketch@0.3.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-bitpacker@0.9.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-columnar@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-common@0.10.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-fst@0.5.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-query-grammar@0.25.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-sstable@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-stacker@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tantivy-tokenizer-api@0.6.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tap@1.0.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tempfile@3.26.0">
@@ -20340,6 +22616,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#term@1.2.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termtree@1.0.0" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20372,7 +22649,7 @@
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#time@0.3.47">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num_threads@0.1.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0" />
@@ -20391,48 +22668,43 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.24.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.21.12" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
-    </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.182" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.1.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.6.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.4+spec-1.1.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.0.0+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.0.9+spec-1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.14" />
@@ -20477,9 +22749,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
@@ -20499,13 +22771,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.10" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20513,11 +22785,11 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
@@ -20535,14 +22807,6 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-    </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.22" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
@@ -20584,7 +22848,7 @@
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#twox-hash@2.1.2" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3" />
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typetag-impl@0.2.21">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
@@ -20627,6 +22891,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3" />
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf-8@0.7.6" />
@@ -20641,7 +22906,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa@5.4.0">
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utoipa-gen@5.4.0" />
@@ -20650,7 +22915,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#outref@0.5.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vsimd@0.8.0" />
     </dependency>
-    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0">
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
     </dependency>
@@ -20696,7 +22961,7 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#influxdb-line-protocol@2.0.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipcrypt-rs@0.9.4" />
@@ -20751,13 +23016,13 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syslog_loose@0.22.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#termcolor@1.4.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.50.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ua-parser@0.2.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#url@2.5.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#utf8-width@0.1.8" />
-      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.21.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.1.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#woothee@0.13.0" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15" />
@@ -20857,6 +23122,9 @@
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.1" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zigzag@0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
     </dependency>
     <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zip@0.6.6">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />

--- a/src/web/web.cdx.xml
+++ b/src/web/web.cdx.xml
@@ -1,0 +1,3462 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:a3dee618-5d23-41de-bea5-b02b29fbcbe2" version="1">
+  <metadata>
+    <timestamp>2026-07-29T08:21:37.299128000Z</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cargo-cyclonedx</name>
+        <version>0.5.7</version>
+      </tool>
+    </tools>
+    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+      <name>web</name>
+      <version>0.1.0</version>
+      <scope>required</scope>
+      <licenses>
+        <expression>AGPL-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/web@0.1.0?download_url=file://.</purl>
+      <components>
+        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0 bin-target-0">
+          <name>web</name>
+          <version>0.1.0</version>
+          <purl>pkg:cargo/web@0.1.0?download_url=file://.#src/lib.rs</purl>
+        </component>
+      </components>
+    </component>
+    <properties>
+      <property name="cdx:rustc:sbom:target:triple">aarch64-apple-darwin</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <name>adler2</name>
+      <version>2.0.1</version>
+      <description>A simple clean-room implementation of the Adler-32 checksum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa</hash>
+      </hashes>
+      <licenses>
+        <expression>0BSD OR MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/adler2@2.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/adler2/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/oyvindln/adler2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>aho-corasick</name>
+      <version>1.1.4</version>
+      <description>Fast multiple substring searching.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/aho-corasick@1.1.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/aho-corasick</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/aho-corasick</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <name>alloc-no-stdlib</name>
+      <version>2.0.4</version>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/alloc-no-stdlib@2.0.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://raw.githubusercontent.com/dropbox/rust-alloc-no-stdlib/master/tests/lib.rs</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dropbox/rust-alloc-no-stdlib</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dropbox/rust-alloc-no-stdlib</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <name>alloc-stdlib</name>
+      <version>0.2.2</version>
+      <description>A dynamic allocator example that may be used with the stdlib</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/alloc-stdlib@0.2.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://raw.githubusercontent.com/dropbox/rust-alloc-no-stdlib/master/alloc-stdlib/tests/lib.rs</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dropbox/rust-alloc-no-stdlib</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dropbox/rust-alloc-no-stdlib</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
+      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <name>allocator-api2</name>
+      <version>0.2.21</version>
+      <description>Mirror of Rust's allocator API</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/allocator-api2@0.2.21</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/allocator-api2</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/zakarumych/allocator-api2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/zakarumych/allocator-api2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
+      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <name>atomic-waker</name>
+      <version>1.1.2</version>
+      <description>A synchronization primitive for task wakeup</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/atomic-waker@1.1.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smol-rs/atomic-waker</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
+      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <name>autocfg</name>
+      <version>1.5.0</version>
+      <description>Automatic cfg for Rust compiler features</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/autocfg@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/autocfg/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/cuviper/autocfg</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
+      <name>axum-core</name>
+      <version>0.5.6</version>
+      <description>Core types and traits for axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-core@0.5.6</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum-macros@0.5.0">
+      <name>axum-macros</name>
+      <version>0.5.0</version>
+      <description>Macros for axum</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum-macros@0.5.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8">
+      <name>axum</name>
+      <version>0.8.8</version>
+      <description>Web framework that focuses on ergonomics and modularity</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/axum@0.8.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/axum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
+      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <name>base64</name>
+      <version>0.22.1</version>
+      <description>encodes and decodes base64 as bytes or utf8</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/base64@0.22.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/base64</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/marshallpierce/rust-base64</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3">
+      <author>YetiBarBar</author>
+      <name>base85rs</name>
+      <version>0.1.3</version>
+      <description>A base85 (RFC1924 variant) encoder / decoder</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">87678d33a2af71f019ed11f52db246ca6c5557edee2cccbe689676d1ad9c6b5a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/base85rs@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/base85rs/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/YetiBarBar/base85rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
+      <author>The Rust Project Developers</author>
+      <name>bitflags</name>
+      <version>2.11.0</version>
+      <description>A macro to generate structures which behave like bitflags. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bitflags@2.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bitflags</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/bitflags/bitflags</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bitflags/bitflags</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <author>RustCrypto Developers</author>
+      <name>block-buffer</name>
+      <version>0.12.1</version>
+      <description>Buffer types for block processing of data</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/block-buffer@0.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/block-buffer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <name>brotli-decompressor</name>
+      <version>5.0.0</version>
+      <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/brotli-decompressor@5.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://github.com/dropbox/rust-brotli-decompressor/blob/master/README.md</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dropbox/rust-brotli-decompressor</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dropbox/rust-brotli-decompressor</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <name>brotli</name>
+      <version>8.0.2</version>
+      <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560</hash>
+      </hashes>
+      <licenses>
+        <expression>BSD-3-Clause AND MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/brotli@8.0.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/brotli/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dropbox/rust-brotli</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dropbox/rust-brotli</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>bstr</name>
+      <version>1.12.1</version>
+      <description>A string type that is not required to be valid UTF-8.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/bstr@1.12.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/bstr</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/bstr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>byteorder</name>
+      <version>1.5.0</version>
+      <description>Library for reading/writing numbers in big-endian and little-endian.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/byteorder@1.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/byteorder</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/byteorder</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/byteorder</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>bytes</name>
+      <version>1.11.1</version>
+      <description>Types and traits for working with bytes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/bytes@1.11.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/bytes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>cc</name>
+      <version>1.2.56</version>
+      <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cc@1.2.56</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cc</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/cc-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cc-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>cfg-if</name>
+      <version>1.0.4</version>
+      <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cfg-if@1.0.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cfg-if</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44">
+      <name>chrono</name>
+      <version>0.4.44</version>
+      <description>Date and time library for Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/chrono@0.4.44</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/chrono/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/chronotope/chrono</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/chronotope/chrono</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2">
+      <author>RustCrypto Developers</author>
+      <name>const-oid</name>
+      <version>0.10.2</version>
+      <description>Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/const-oid@0.10.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/const-oid</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/RustCrypto/formats/tree/master/const-oid</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/formats</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation-sys</name>
+      <version>0.8.7</version>
+      <description>Bindings to Core Foundation for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core-foundation-sys@0.8.7</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <author>The Servo Project Developers</author>
+      <name>core-foundation</name>
+      <version>0.9.4</version>
+      <description>Bindings to Core Foundation for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/core-foundation@0.9.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/core-foundation-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <author>RustCrypto Developers</author>
+      <name>cpufeatures</name>
+      <version>0.3.0</version>
+      <description>Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/cpufeatures@0.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/cpufeatures</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
+      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>crc32fast</name>
+      <version>1.5.0</version>
+      <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crc32fast@1.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/srijs/rust-crc32fast</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <author>RustCrypto Developers</author>
+      <name>crypto-common</name>
+      <version>0.2.2</version>
+      <description>Common traits used by cryptographic algorithms</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/crypto-common@0.2.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/crypto-common</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <author>RustCrypto Developers</author>
+      <name>digest</name>
+      <version>0.11.3</version>
+      <description>Traits for cryptographic hash functions and message authentication codes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/digest@0.11.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/digest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <name>dirs-sys</name>
+      <version>0.5.0</version>
+      <description>System-level helper functions for the dirs and directories crates.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dirs-sys@0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/dirs-dev/dirs-sys-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <name>dirs</name>
+      <version>6.0.0</version>
+      <description>A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/dirs@6.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/soc/dirs-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <name>encoding_rs</name>
+      <version>0.8.35</version>
+      <description>A Gecko-oriented implementation of the Encoding Standard</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3</hash>
+      </hashes>
+      <licenses>
+        <expression>(Apache-2.0 OR MIT) AND BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/encoding_rs@0.8.35</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/encoding_rs/</url>
+        </reference>
+        <reference type="website">
+          <url>https://docs.rs/encoding_rs/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hsivonen/encoding_rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2">
+      <name>equivalent</name>
+      <version>1.0.2</version>
+      <description>Traits for key comparison in maps.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/equivalent@1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/indexmap-rs/equivalent</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
+      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <name>errno</name>
+      <version>0.3.14</version>
+      <description>Cross-platform interface to the `errno` variable.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/errno@0.3.14</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/errno</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/lambda-fairy/rust-errno</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9">
+      <name>find-msvc-tools</name>
+      <version>0.1.9</version>
+      <description>Find windows-specific tools, read MSVC versions from the registry and from COM interfaces</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/find-msvc-tools@0.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/find-msvc-tools</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/cc-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <name>flate2</name>
+      <version>1.1.9</version>
+      <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/flate2@1.1.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/flate2</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/flate2-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/flate2-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>fnv</name>
+      <version>1.0.7</version>
+      <description>Fowler–Noll–Vo hash function</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0  OR  MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/fnv@1.0.7</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://doc.servo.org/fnv/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/rust-fnv</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
+      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <name>foldhash</name>
+      <version>0.2.0</version>
+      <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib</expression>
+      </licenses>
+      <purl>pkg:cargo/foldhash@0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/orlp/foldhash</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2">
+      <author>The rust-url developers</author>
+      <name>form_urlencoded</name>
+      <version>1.2.2</version>
+      <description>Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/form_urlencoded@1.2.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/servo/rust-url</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
+      <name>futures-channel</name>
+      <version>0.3.32</version>
+      <description>Channels for asynchronous communication using futures-rs. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-channel@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32">
+      <name>futures-core</name>
+      <version>0.3.32</version>
+      <description>The core traits and types in for the `futures` library. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-core@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32">
+      <name>futures-io</name>
+      <version>0.3.32</version>
+      <description>The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-io@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32">
+      <name>futures-macro</name>
+      <version>0.3.32</version>
+      <description>The futures-rs procedural macro implementations. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-macro@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32">
+      <name>futures-sink</name>
+      <version>0.3.32</version>
+      <description>The asynchronous `Sink` trait for the futures-rs library. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-sink@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32">
+      <name>futures-task</name>
+      <version>0.3.32</version>
+      <description>Tools for working with tasks. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-task@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32">
+      <name>futures-util</name>
+      <version>0.3.32</version>
+      <description>Common utilities and extension traits for the futures-rs library. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/futures-util@0.3.32</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://rust-lang.github.io/futures-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/futures-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>globset</name>
+      <version>0.4.18</version>
+      <description>Cross platform single glob and glob set matching. Glob set matching is the process of matching one or more glob patterns against a single candidate path simultaneously, and returning all of the globs that matched. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/globset@0.4.18</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/globset</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/ripgrep/tree/master/crates/globset</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/ripgrep/tree/master/crates/globset</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>h2</name>
+      <version>0.4.13</version>
+      <description>An HTTP/2 client and server</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/h2@0.4.13</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/h2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/h2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <name>hashbrown</name>
+      <version>0.17.1</version>
+      <description>A Rust port of Google's SwissTable hash map</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hashbrown@0.17.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/hashbrown</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <name>hdrhistogram</name>
+      <version>7.5.4</version>
+      <description>A port of HdrHistogram to Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hdrhistogram@7.5.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hdrhistogram</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/HdrHistogram/HdrHistogram_rust</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/HdrHistogram/HdrHistogram_rust.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>http-body-util</name>
+      <version>0.1.3</version>
+      <description>Combinators and adapters for HTTP request or response bodies. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/http-body-util@0.1.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/http-body-util</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/http-body</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>http-body</name>
+      <version>1.0.1</version>
+      <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/http-body@1.0.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/http-body</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/http-body</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>http</name>
+      <version>1.4.0</version>
+      <description>A set of types for representing HTTP requests and responses. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/http@1.4.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/http</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/http</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>httparse</name>
+      <version>1.10.1</version>
+      <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/httparse@1.10.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/httparse</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/httparse</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
+      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <name>httpdate</name>
+      <version>1.0.3</version>
+      <description>HTTP date parsing and formatting</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/httpdate@1.0.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pyfisch/httpdate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <author>RustCrypto Developers</author>
+      <name>hybrid-array</name>
+      <version>0.4.12</version>
+      <description>Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/hybrid-array@0.4.12</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hybrid-array</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hybrid-array</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>hyper-util</name>
+      <version>0.1.20</version>
+      <description>hyper utilities</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/hyper-util@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hyper-util</url>
+        </reference>
+        <reference type="website">
+          <url>https://hyper.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/hyper-util</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>hyper</name>
+      <version>1.8.1</version>
+      <description>A protective and efficient HTTP library for all.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/hyper@1.8.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/hyper</url>
+        </reference>
+        <reference type="website">
+          <url>https://hyper.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/hyper</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
+      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <name>iana-time-zone</name>
+      <version>0.1.65</version>
+      <description>get the IANA time zone for the current system</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/iana-time-zone@0.1.65</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/strawlab/iana-time-zone</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
+      <name>indexmap</name>
+      <version>2.14.0</version>
+      <description>A hash table with consistent order and fast iteration.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/indexmap@2.14.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/indexmap/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/indexmap-rs/indexmap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
+      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <name>ipnet</name>
+      <version>2.12.0</version>
+      <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ipnet@2.12.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ipnet</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/krisprice/ipnet</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>itoa</name>
+      <version>1.0.17</version>
+      <description>Fast integer primitive to string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/itoa@1.0.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/itoa</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/itoa</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>jobserver</name>
+      <version>0.1.34</version>
+      <description>An implementation of the GNU Make jobserver for Rust. </description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/jobserver@0.1.34</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/jobserver</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/jobserver-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/jobserver-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186">
+      <author>The Rust Project Developers</author>
+      <name>libc</name>
+      <version>0.2.186</version>
+      <description>Raw FFI bindings to platform libraries like libc.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/libc@0.2.186</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/libc</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <name>libm</name>
+      <version>0.2.16</version>
+      <description>libm in pure Rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/libm@0.2.16</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/compiler-builtins</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <name>libz-sys</name>
+      <version>1.1.24</version>
+      <description>Low-level bindings to the system libz library (also known as zlib).</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/libz-sys@1.1.24</purl>
+      <externalReferences>
+        <reference type="other">
+          <url>z</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/libz-sys</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>lock_api</name>
+      <version>0.4.14</version>
+      <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/lock_api@0.4.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29">
+      <author>The Rust Project Developers</author>
+      <name>log</name>
+      <version>0.4.29</version>
+      <description>A lightweight logging facade for Rust </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/log@0.4.29</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/log</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/log</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <name>matchit</name>
+      <version>0.8.4</version>
+      <description>A high performance, zero-copy URL router.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT AND BSD-3-Clause</expression>
+      </licenses>
+      <purl>pkg:cargo/matchit@0.8.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ibraheemdev/matchit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <name>memchr</name>
+      <version>2.8.0</version>
+      <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/memchr@2.8.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/memchr/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/memchr</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/memchr</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>mime</name>
+      <version>0.3.17</version>
+      <description>Strongly Typed Mimes</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/mime@0.3.17</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/hyperium/mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <name>mime_guess</name>
+      <version>2.0.5</version>
+      <description>A simple crate for detection of a file's MIME type by its extension.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mime_guess@2.0.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/abonander/mime_guess</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
+      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <name>miniz_oxide</name>
+      <version>0.8.9</version>
+      <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Zlib OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/miniz_oxide@0.8.9</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/miniz_oxide</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>mio</name>
+      <version>1.2.1</version>
+      <description>Lightweight non-blocking I/O.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/mio@1.2.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tokio-rs/mio</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/mio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
+      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <name>multer</name>
+      <version>3.1.0</version>
+      <description>An async parser for `multipart/form-data` content-type in Rust.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/multer@3.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/rwf2/multer</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rwf2/multer</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
+      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;, Lynnesbian &lt;lynne@bune.city&gt;</author>
+      <name>new_mime_guess</name>
+      <version>4.0.4</version>
+      <description>A simple crate for associating MIME types to file extensions.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">02a2dfb3559d53e90b709376af1c379462f7fb3085a0177deb73e6ea0d99eff4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/new_mime_guess@4.0.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/new_mime_guess/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Lynnesbian/mime_guess</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19">
+      <author>The Rust Project Developers</author>
+      <name>num-traits</name>
+      <version>0.2.19</version>
+      <description>Numeric traits for generic mathematics</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/num-traits@0.2.19</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/num-traits</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-num/num-traits</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-num/num-traits</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <name>once_cell</name>
+      <version>1.21.3</version>
+      <description>Single assignment cells and lazy values.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/once_cell@1.21.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/once_cell</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/matklad/once_cell</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <name>option-ext</name>
+      <version>0.2.0</version>
+      <description>Extends `Option` with additional operations</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d</hash>
+      </hashes>
+      <licenses>
+        <expression>MPL-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/option-ext@0.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/option-ext/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/soc/option-ext</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/soc/option-ext.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>parking_lot</name>
+      <version>0.12.5</version>
+      <description>More compact and efficient implementations of the standard synchronization primitives.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/parking_lot@0.12.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <name>parking_lot_core</name>
+      <version>0.9.12</version>
+      <description>An advanced API for creating custom synchronization primitives.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/parking_lot_core@0.9.12</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Amanieu/parking_lot</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2">
+      <author>The rust-url developers</author>
+      <name>percent-encoding</name>
+      <version>2.3.2</version>
+      <description>Percent encoding and decoding</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/percent-encoding@2.3.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/servo/rust-url/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17">
+      <name>pin-project-lite</name>
+      <version>0.2.17</version>
+      <description>A lightweight version of pin-project written with declarative macros. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/pin-project-lite@0.2.17</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/taiki-e/pin-project-lite</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
+      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <name>pin-utils</name>
+      <version>0.1.0</version>
+      <description>Utilities for pinning </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pin-utils@0.1.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pin-utils</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang-nursery/pin-utils</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>pkg-config</name>
+      <version>0.3.32</version>
+      <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/pkg-config@0.3.32</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/pkg-config</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/pkg-config-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <name>proc-macro2</name>
+      <version>1.0.106</version>
+      <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/proc-macro2@1.0.106</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/proc-macro2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/proc-macro2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>quote</name>
+      <version>1.0.45</version>
+      <description>Quasi-quoting macro quote!(...)</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/quote@1.0.45</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/quote/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/quote</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>regex-automata</name>
+      <version>0.4.14</version>
+      <description>Automata construction and matching using regular expressions.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/regex-automata@0.4.14</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/regex-automata</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/regex/tree/master/regex-automata</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>regex-syntax</name>
+      <version>0.8.10</version>
+      <description>A regular expression parser.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/regex-syntax@0.8.10</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/regex-syntax</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/regex/tree/master/regex-syntax</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/regex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1">
+      <name>rust-embed-for-web-impl</name>
+      <version>11.4.1</version>
+      <description>The proc-macro implementation of rust-embed-for-web.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8527f04d3f734ff9ebab526fcc3e03d61d66386975b2cf898d6b2a221f7dee29</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rust-embed-for-web-impl@11.4.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1">
+      <name>rust-embed-for-web-utils</name>
+      <version>11.4.1</version>
+      <description>Utilities for rust-embed-for-web</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d05939009fc97b73cd5ccee07f5af565b2e3f676a60de30fe8c29419dd33b2c2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rust-embed-for-web-utils@11.4.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1">
+      <name>rust-embed-for-web</name>
+      <version>11.4.1</version>
+      <description>Rust Macro which embeds files into your executable. A fork of `rust-embed` with a focus on usage on web servers.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cc9de9fc1c7cb74c76c770e9ae5454c050aead66420ad59cdad7544e1a5d85fc</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/rust-embed-for-web@11.4.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/rust-embed-for-web</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SeriousBug/rust-embed-for-web</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>ryu</name>
+      <version>1.0.23</version>
+      <description>Fast floating point to string conversion</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0 OR BSL-1.0</expression>
+      </licenses>
+      <purl>pkg:cargo/ryu@1.0.23</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/ryu</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/ryu</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>same-file</name>
+      <version>1.0.6</version>
+      <description>A simple crate for determining whether two file paths point to the same file. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/same-file@1.0.6</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/same-file</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/same-file</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/same-file</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0">
+      <author>bluss</author>
+      <name>scopeguard</name>
+      <version>1.2.0</version>
+      <description>A RAII scope guard that will run a given closure when it goes out of scope, even if the code between panics (assuming unwinding panic).  Defines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as shorthands for guards with one of the implemented strategies. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/scopeguard@1.2.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/scopeguard/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bluss/scopeguard</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde</name>
+      <version>1.0.228</version>
+      <description>A generic serialization/deserialization framework</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_core</name>
+      <version>1.0.228</version>
+      <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_core@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_core</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_derive</name>
+      <version>1.0.228</version>
+      <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_derive@1.0.228</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://serde.rs/derive.html</url>
+        </reference>
+        <reference type="website">
+          <url>https://serde.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/serde</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_json</name>
+      <version>1.0.149</version>
+      <description>A JSON serialization file format</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_json@1.0.149</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_json</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/serde-rs/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>serde_path_to_error</name>
+      <version>0.1.20</version>
+      <description>Path to the element that failed to deserialize</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_path_to_error@0.1.20</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_path_to_error</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/path-to-error</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <name>serde_urlencoded</name>
+      <version>0.7.1</version>
+      <description>`x-www-form-urlencoded` meets Serde</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/serde_urlencoded@0.7.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/serde_urlencoded/0.7.1/serde_urlencoded/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nox/serde_urlencoded</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <author>RustCrypto Developers</author>
+      <name>sha2</name>
+      <version>0.11.0</version>
+      <description>Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sha2@0.11.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sha2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/RustCrypto/hashes</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
+      <author>Vladimir Matveev &lt;vmatveev@citrine.cc&gt;, Ian Jackson &lt;iwj@torproject.org&gt;</author>
+      <name>shellexpand</name>
+      <version>3.1.2</version>
+      <description>Shell-like expansions in strings</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/shellexpand@3.1.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>http://docs.rs/shellexpand/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://gitlab.com/ijackson/rust-shellexpand</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
+      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <name>shlex</name>
+      <version>1.3.0</version>
+      <description>Split a string into shell words, like Python's shlex.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/shlex@1.3.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/comex/rust-shlex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <name>signal-hook-registry</name>
+      <version>1.4.8</version>
+      <description>Backend crate for signal-hook</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/signal-hook-registry@1.4.8</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/signal-hook-registry</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/vorner/signal-hook</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
+      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <name>simd-adler32</name>
+      <version>0.3.8</version>
+      <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/simd-adler32@0.3.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mcountryman/simd-adler32</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
+      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <name>slab</name>
+      <version>0.4.12</version>
+      <description>Pre-allocated storage for a uniform data type</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/slab@0.4.12</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/slab</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
+      <author>The Servo Project Developers</author>
+      <name>smallvec</name>
+      <version>1.15.1</version>
+      <description>'Small vector' optimization: store up to a small number of items on the stack</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/smallvec@1.15.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/smallvec/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/servo/rust-smallvec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <name>socket2</name>
+      <version>0.6.4</version>
+      <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/socket2@0.6.4</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/socket2</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/rust-lang/socket2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <name>spin</name>
+      <version>0.9.9</version>
+      <description>Spin-based synchronization primitives</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/spin@0.9.9</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mvdnes/spin-rs.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>syn</name>
+      <version>2.0.117</version>
+      <description>Parser for Rust source code</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/syn@2.0.117</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/syn</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/syn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
+      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <name>sync_wrapper</name>
+      <version>1.0.2</version>
+      <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263</hash>
+      </hashes>
+      <licenses>
+        <expression>Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/sync_wrapper@1.0.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/sync_wrapper</url>
+        </reference>
+        <reference type="website">
+          <url>https://docs.rs/sync_wrapper</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/Actyx/sync_wrapper</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration-sys</name>
+      <version>0.6.0</version>
+      <description>Low level bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration-sys@0.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <author>Mullvad VPN</author>
+      <name>system-configuration</name>
+      <version>0.7.0</version>
+      <description>Bindings to SystemConfiguration framework for macOS</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/system-configuration@0.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mullvad/system-configuration-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
+      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>tokio-macros</name>
+      <version>2.7.0</version>
+      <description>Tokio's proc macros. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-macros@2.7.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
+      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>tokio-util</name>
+      <version>0.7.18</version>
+      <description>Additional utilities for working with Tokio. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio-util@0.7.18</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
+      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>tokio</name>
+      <version>1.52.3</version>
+      <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tokio@1.52.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tokio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
+      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <name>tower-layer</name>
+      <version>0.3.3</version>
+      <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tower-layer@0.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tower-layer/0.3.3</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
+      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <name>tower-service</name>
+      <version>0.3.3</version>
+      <description>Trait representing an asynchronous, request / response based, client or server. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tower-service@0.3.3</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/tower-service/0.3.3</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
+      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <name>tower</name>
+      <version>0.5.3</version>
+      <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tower@0.5.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tower-rs/tower</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
+      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <name>tracing-attributes</name>
+      <version>0.1.31</version>
+      <description>Procedural macro attributes for automatically instrumenting functions. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-attributes@0.1.31</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
+      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>tracing-core</name>
+      <version>0.1.36</version>
+      <description>Core primitives for application-level tracing. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing-core@0.1.36</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
+      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <name>tracing</name>
+      <version>0.1.44</version>
+      <description>Application-level tracing for Rust. </description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/tracing@0.1.44</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://tokio.rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/tokio-rs/tracing</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>try-lock</name>
+      <version>0.2.5</version>
+      <description>A lightweight atomic lock.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/try-lock@0.2.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/try-lock</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/try-lock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1">
+      <name>typenum</name>
+      <version>1.20.1</version>
+      <description>Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/typenum@1.20.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/typenum</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/paholg/typenum</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>unicase</name>
+      <version>2.9.0</version>
+      <description>A case-insensitive wrapper around strings.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unicase@2.9.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/unicase</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/unicase</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>unicode-ident</name>
+      <version>1.0.24</version>
+      <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75</hash>
+      </hashes>
+      <licenses>
+        <expression>(MIT OR Apache-2.0) AND Unicode-3.0</expression>
+      </licenses>
+      <purl>pkg:cargo/unicode-ident@1.0.24</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/unicode-ident</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/unicode-ident</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
+      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <name>vcpkg</name>
+      <version>0.2.15</version>
+      <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/vcpkg@0.2.15</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/vcpkg</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/mcgoo/vcpkg-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
+      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <name>version_check</name>
+      <version>0.9.5</version>
+      <description>Tiny crate to check the version of the installed/running rustc.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-256">0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT OR Apache-2.0</expression>
+      </licenses>
+      <purl>pkg:cargo/version_check@0.9.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/version_check/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/SergioBenitez/version_check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
+      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <name>walkdir</name>
+      <version>2.5.0</version>
+      <description>Recursively walk a directory.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b</hash>
+      </hashes>
+      <licenses>
+        <expression>Unlicense OR MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/walkdir@2.5.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/walkdir/</url>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/BurntSushi/walkdir</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/walkdir</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
+      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <name>want</name>
+      <version>0.3.1</version>
+      <description>Detect when another Future wants a result.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/want@0.3.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/want</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/seanmonstar/want</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3">
+      <name>zlib-rs</name>
+      <version>0.6.3</version>
+      <description>A memory-safe zlib implementation written in rust</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513</hash>
+      </hashes>
+      <licenses>
+        <expression>Zlib</expression>
+      </licenses>
+      <purl>pkg:cargo/zlib-rs@0.6.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/trifectatechfoundation/zlib-rs</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/trifectatechfoundation/zlib-rs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
+      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <name>zmij</name>
+      <version>1.0.21</version>
+      <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa</hash>
+      </hashes>
+      <licenses>
+        <expression>MIT</expression>
+      </licenses>
+      <purl>pkg:cargo/zmij@1.0.21</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://docs.rs/zmij</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dtolnay/zmij</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-macros@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-core@0.5.6" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum-macros@0.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#base85rs@0.1.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-impl@11.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web-utils@11.4.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#log@0.4.29" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31" />
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
+      <dependency ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5" />
+    </dependency>
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3" />
+    <dependency ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21" />
+  </dependencies>
+</bom>

--- a/src/web/web.cdx.xml
+++ b/src/web/web.cdx.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:a3dee618-5d23-41de-bea5-b02b29fbcbe2" version="1">
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:96402d60-64f0-48b2-95f2-68e447c9af43" version="1">
   <metadata>
-    <timestamp>2026-07-29T08:21:37.299128000Z</timestamp>
+    <timestamp>2026-07-29T08:37:07.844940000Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cargo-cyclonedx</name>
-        <version>0.5.7</version>
+        <version>0.5.9</version>
       </tool>
     </tools>
-    <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+    <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0">
       <name>web</name>
       <version>0.1.0</version>
       <scope>required</scope>
@@ -18,7 +18,7 @@
       </licenses>
       <purl>pkg:cargo/web@0.1.0?download_url=file://.</purl>
       <components>
-        <component type="library" bom-ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0 bin-target-0">
+        <component type="library" bom-ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0 bin-target-0">
           <name>web</name>
           <version>0.1.0</version>
           <purl>pkg:cargo/web@0.1.0?download_url=file://.#src/lib.rs</purl>
@@ -31,7 +31,7 @@
   </metadata>
   <components>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1">
-      <author>Jonas Schievink &lt;jonasschievink@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;</author>
+      <author>Jonas Schievink &lt;jonasschievink@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com></author>
       <name>adler2</name>
       <version>2.0.1</version>
       <description>A simple clean-room implementation of the Adler-32 checksum</description>
@@ -53,7 +53,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>aho-corasick</name>
       <version>1.1.4</version>
       <description>Fast multiple substring searching.</description>
@@ -75,10 +75,10 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-no-stdlib</name>
       <version>2.0.4</version>
-      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;&gt;. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
+      <description>A dynamic allocator that may be used with or without the stdlib. This allows a package with nostd to allocate memory dynamically and be used either with a custom allocator, items on the stack, or by a package that wishes to simply use Box&lt;>. It also provides options to use calloc or a mutable global variable for pre-zeroed memory</description>
       <scope>required</scope>
       <hashes>
         <hash alg="SHA-256">cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3</hash>
@@ -100,7 +100,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com></author>
       <name>alloc-stdlib</name>
       <version>0.2.2</version>
       <description>A dynamic allocator example that may be used with the stdlib</description>
@@ -125,7 +125,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21">
-      <author>Zakarum &lt;zaq.dev@icloud.com&gt;</author>
+      <author>Zakarum &lt;zaq.dev@icloud.com></author>
       <name>allocator-api2</name>
       <version>0.2.21</version>
       <description>Mirror of Rust's allocator API</description>
@@ -150,7 +150,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2">
-      <author>Stjepan Glavina &lt;stjepang@gmail.com&gt;, Contributors to futures-rs</author>
+      <author>Stjepan Glavina &lt;stjepang@gmail.com>, Contributors to futures-rs</author>
       <name>atomic-waker</name>
       <version>1.1.2</version>
       <description>A synchronization primitive for task wakeup</description>
@@ -169,7 +169,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0">
-      <author>Josh Stone &lt;cuviper@gmail.com&gt;</author>
+      <author>Josh Stone &lt;cuviper@gmail.com></author>
       <name>autocfg</name>
       <version>1.5.0</version>
       <description>Automatic cfg for Rust compiler features</description>
@@ -254,7 +254,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1">
-      <author>Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>base64</name>
       <version>0.22.1</version>
       <description>encodes and decodes base64 as bytes or utf8</description>
@@ -345,7 +345,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli-decompressor</name>
       <version>5.0.0</version>
       <description>A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli </description>
@@ -370,7 +370,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#brotli@8.0.2">
-      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com&gt;, The Brotli Authors</author>
+      <author>Daniel Reiter Horn &lt;danielrh@dropbox.com>, The Brotli Authors</author>
       <name>brotli</name>
       <version>8.0.2</version>
       <description>A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe.</description>
@@ -395,7 +395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bstr@1.12.1">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>bstr</name>
       <version>1.12.1</version>
       <description>A string type that is not required to be valid UTF-8.</description>
@@ -420,7 +420,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#byteorder@1.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>byteorder</name>
       <version>1.5.0</version>
       <description>Library for reading/writing numbers in big-endian and little-endian.</description>
@@ -445,7 +445,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>bytes</name>
       <version>1.11.1</version>
       <description>Types and traits for working with bytes</description>
@@ -464,7 +464,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cc@1.2.56">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cc</name>
       <version>1.2.56</version>
       <description>A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. </description>
@@ -489,7 +489,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>cfg-if</name>
       <version>1.0.4</version>
       <description>A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. </description>
@@ -623,7 +623,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0">
-      <author>Sam Rijs &lt;srijs@airpost.net&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Sam Rijs &lt;srijs@airpost.net>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>crc32fast</name>
       <version>1.5.0</version>
       <description>Fast, SIMD-accelerated CRC32 (IEEE) checksum computation</description>
@@ -686,7 +686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs-sys</name>
       <version>0.5.0</version>
       <description>System-level helper functions for the dirs and directories crates.</description>
@@ -705,7 +705,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>dirs</name>
       <version>6.0.0</version>
       <description>A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.</description>
@@ -724,7 +724,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35">
-      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi&gt;</author>
+      <author>Henri Sivonen &lt;hsivonen@hsivonen.fi></author>
       <name>encoding_rs</name>
       <version>0.8.35</version>
       <description>A Gecko-oriented implementation of the Encoding Standard</description>
@@ -767,7 +767,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14">
-      <author>Chris Wong &lt;lambda.fairy@gmail.com&gt;, Dan Gohman &lt;dev@sunfishcode.online&gt;</author>
+      <author>Chris Wong &lt;lambda.fairy@gmail.com>, Dan Gohman &lt;dev@sunfishcode.online></author>
       <name>errno</name>
       <version>0.3.14</version>
       <description>Cross-platform interface to the `errno` variable.</description>
@@ -810,7 +810,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org></author>
       <name>flate2</name>
       <version>1.1.9</version>
       <description>DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. </description>
@@ -835,7 +835,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>fnv</name>
       <version>1.0.7</version>
       <description>Fowler–Noll–Vo hash function</description>
@@ -857,7 +857,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0">
-      <author>Orson Peters &lt;orsonpeters@gmail.com&gt;</author>
+      <author>Orson Peters &lt;orsonpeters@gmail.com></author>
       <name>foldhash</name>
       <version>0.2.0</version>
       <description>A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.</description>
@@ -1042,7 +1042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#globset@0.4.18">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>globset</name>
       <version>0.4.18</version>
       <description>Cross platform single glob and glob set matching. Glob set matching is the process of matching one or more glob patterns against a single candidate path simultaneously, and returning all of the globs that matched. </description>
@@ -1067,7 +1067,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>h2</name>
       <version>0.4.13</version>
       <description>An HTTP/2 client and server</description>
@@ -1107,7 +1107,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hdrhistogram@7.5.4">
-      <author>Jon Gjengset &lt;jon@thesquareplanet.com&gt;, Marshall Pierce &lt;marshall@mpierce.org&gt;</author>
+      <author>Jon Gjengset &lt;jon@thesquareplanet.com>, Marshall Pierce &lt;marshall@mpierce.org></author>
       <name>hdrhistogram</name>
       <version>7.5.4</version>
       <description>A port of HdrHistogram to Rust</description>
@@ -1132,7 +1132,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body-util</name>
       <version>0.1.3</version>
       <description>Combinators and adapters for HTTP request or response bodies. </description>
@@ -1154,7 +1154,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Lucio Franco &lt;luciofranco14@gmail.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Lucio Franco &lt;luciofranco14@gmail.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http-body</name>
       <version>1.0.1</version>
       <description>Trait representing an asynchronous, streaming, HTTP request or response body. </description>
@@ -1176,7 +1176,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#http@1.4.0">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Carl Lerche &lt;me@carllerche.com&gt;, Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Carl Lerche &lt;me@carllerche.com>, Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>http</name>
       <version>1.4.0</version>
       <description>A set of types for representing HTTP requests and responses. </description>
@@ -1198,7 +1198,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>httparse</name>
       <version>1.10.1</version>
       <description>A tiny, safe, speedy, zero-copy HTTP/1.x parser.</description>
@@ -1220,7 +1220,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3">
-      <author>Pyfisch &lt;pyfisch@posteo.org&gt;</author>
+      <author>Pyfisch &lt;pyfisch@posteo.org></author>
       <name>httpdate</name>
       <version>1.0.3</version>
       <description>HTTP date parsing and formatting</description>
@@ -1261,7 +1261,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper-util</name>
       <version>0.1.20</version>
       <description>hyper utilities</description>
@@ -1286,7 +1286,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#hyper@1.8.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>hyper</name>
       <version>1.8.1</version>
       <description>A protective and efficient HTTP library for all.</description>
@@ -1311,7 +1311,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65">
-      <author>Andrew Straw &lt;strawman@astraw.com&gt;, René Kijewski &lt;rene.kijewski@fu-berlin.de&gt;, Ryan Lopopolo &lt;rjl@hyperbo.la&gt;</author>
+      <author>Andrew Straw &lt;strawman@astraw.com>, René Kijewski &lt;rene.kijewski@fu-berlin.de>, Ryan Lopopolo &lt;rjl@hyperbo.la></author>
       <name>iana-time-zone</name>
       <version>0.1.65</version>
       <description>get the IANA time zone for the current system</description>
@@ -1351,7 +1351,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0">
-      <author>Kris Price &lt;kris@krisprice.nz&gt;</author>
+      <author>Kris Price &lt;kris@krisprice.nz></author>
       <name>ipnet</name>
       <version>2.12.0</version>
       <description>Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.</description>
@@ -1373,7 +1373,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.17">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>itoa</name>
       <version>1.0.17</version>
       <description>Fast integer primitive to string conversion</description>
@@ -1395,7 +1395,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>jobserver</name>
       <version>0.1.34</version>
       <description>An implementation of the GNU Make jobserver for Rust. </description>
@@ -1439,7 +1439,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libm@0.2.16">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Amanieu d'Antras &lt;amanieu@gmail.com&gt;, Jorge Aparicio &lt;japaricious@gmail.com&gt;, Trevor Gross &lt;tg@trevorgross.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Amanieu d'Antras &lt;amanieu@gmail.com>, Jorge Aparicio &lt;japaricious@gmail.com>, Trevor Gross &lt;tg@trevorgross.com></author>
       <name>libm</name>
       <version>0.2.16</version>
       <description>libm in pure Rust</description>
@@ -1458,7 +1458,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.24">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Josh Triplett &lt;josh@joshtriplett.org&gt;, Sebastian Thiel &lt;sebastian.thiel@icloud.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Josh Triplett &lt;josh@joshtriplett.org>, Sebastian Thiel &lt;sebastian.thiel@icloud.com></author>
       <name>libz-sys</name>
       <version>1.1.24</version>
       <description>Low-level bindings to the system libz library (also known as zlib).</description>
@@ -1480,7 +1480,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>lock_api</name>
       <version>0.4.14</version>
       <description>Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.</description>
@@ -1521,7 +1521,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#matchit@0.8.4">
-      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca&gt;</author>
+      <author>Ibraheem Ahmed &lt;ibraheem@ibraheem.ca></author>
       <name>matchit</name>
       <version>0.8.4</version>
       <description>A high performance, zero-copy URL router.</description>
@@ -1540,7 +1540,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;, bluss</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com>, bluss</author>
       <name>memchr</name>
       <version>2.8.0</version>
       <description>Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. </description>
@@ -1565,7 +1565,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>mime</name>
       <version>0.3.17</version>
       <description>Strongly Typed Mimes</description>
@@ -1587,7 +1587,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com></author>
       <name>mime_guess</name>
       <version>2.0.5</version>
       <description>A simple crate for detection of a file's MIME type by its extension.</description>
@@ -1609,7 +1609,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9">
-      <author>Frommi &lt;daniil.liferenko@gmail.com&gt;, oyvindln &lt;oyvindln@users.noreply.github.com&gt;, Rich Geldreich richgel99@gmail.com</author>
+      <author>Frommi &lt;daniil.liferenko@gmail.com>, oyvindln &lt;oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com</author>
       <name>miniz_oxide</name>
       <version>0.8.9</version>
       <description>DEFLATE compression and decompression library rewritten in Rust based on miniz</description>
@@ -1634,7 +1634,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>mio</name>
       <version>1.2.1</version>
       <description>Lightweight non-blocking I/O.</description>
@@ -1656,7 +1656,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#multer@3.1.0">
-      <author>Rousan Ali &lt;hello@rousan.io&gt;</author>
+      <author>Rousan Ali &lt;hello@rousan.io></author>
       <name>multer</name>
       <version>3.1.0</version>
       <description>An async parser for `multipart/form-data` content-type in Rust.</description>
@@ -1678,7 +1678,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#new_mime_guess@4.0.4">
-      <author>Austin Bonander &lt;austin.bonander@gmail.com&gt;, Lynnesbian &lt;lynne@bune.city&gt;</author>
+      <author>Austin Bonander &lt;austin.bonander@gmail.com>, Lynnesbian &lt;lynne@bune.city></author>
       <name>new_mime_guess</name>
       <version>4.0.4</version>
       <description>A simple crate for associating MIME types to file extensions.</description>
@@ -1725,7 +1725,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.3">
-      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com&gt;</author>
+      <author>Aleksey Kladov &lt;aleksey.kladov@gmail.com></author>
       <name>once_cell</name>
       <version>1.21.3</version>
       <description>Single assignment cells and lazy values.</description>
@@ -1747,7 +1747,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0">
-      <author>Simon Ochsenreither &lt;simon@ochsenreither.de&gt;</author>
+      <author>Simon Ochsenreither &lt;simon@ochsenreither.de></author>
       <name>option-ext</name>
       <version>0.2.0</version>
       <description>Extends `Option` with additional operations</description>
@@ -1772,7 +1772,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot</name>
       <version>0.12.5</version>
       <description>More compact and efficient implementations of the standard synchronization primitives.</description>
@@ -1791,7 +1791,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12">
-      <author>Amanieu d'Antras &lt;amanieu@gmail.com&gt;</author>
+      <author>Amanieu d'Antras &lt;amanieu@gmail.com></author>
       <name>parking_lot_core</name>
       <version>0.9.12</version>
       <description>An advanced API for creating custom synchronization primitives.</description>
@@ -1847,7 +1847,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0">
-      <author>Josef Brandl &lt;mail@josefbrandl.de&gt;</author>
+      <author>Josef Brandl &lt;mail@josefbrandl.de></author>
       <name>pin-utils</name>
       <version>0.1.0</version>
       <description>Utilities for pinning </description>
@@ -1869,7 +1869,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>pkg-config</name>
       <version>0.3.32</version>
       <description>A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. </description>
@@ -1891,7 +1891,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;, Alex Crichton &lt;alex@alexcrichton.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com>, Alex Crichton &lt;alex@alexcrichton.com></author>
       <name>proc-macro2</name>
       <version>1.0.106</version>
       <description>A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.</description>
@@ -1913,7 +1913,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>quote</name>
       <version>1.0.45</version>
       <description>Quasi-quoting macro quote!(...)</description>
@@ -1935,7 +1935,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-automata</name>
       <version>0.4.14</version>
       <description>Automata construction and matching using regular expressions.</description>
@@ -1960,7 +1960,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10">
-      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>The Rust Project Developers, Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>regex-syntax</name>
       <version>0.8.10</version>
       <description>A regular expression parser.</description>
@@ -2042,7 +2042,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>ryu</name>
       <version>1.0.23</version>
       <description>Fast floating point to string conversion</description>
@@ -2064,7 +2064,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>same-file</name>
       <version>1.0.6</version>
       <description>A simple crate for determining whether two file paths point to the same file. </description>
@@ -2111,7 +2111,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde</name>
       <version>1.0.228</version>
       <description>A generic serialization/deserialization framework</description>
@@ -2136,7 +2136,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_core</name>
       <version>1.0.228</version>
       <description>Serde traits only, with no support for derive -- use the `serde` crate instead</description>
@@ -2161,7 +2161,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_derive</name>
       <version>1.0.228</version>
       <description>Macros 1.1 implementation of #[derive(Serialize, Deserialize)]</description>
@@ -2186,7 +2186,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149">
-      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com&gt;, David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>Erick Tryzelaar &lt;erick.tryzelaar@gmail.com>, David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_json</name>
       <version>1.0.149</version>
       <description>A JSON serialization file format</description>
@@ -2208,7 +2208,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>serde_path_to_error</name>
       <version>0.1.20</version>
       <description>Path to the element that failed to deserialize</description>
@@ -2230,7 +2230,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1">
-      <author>Anthony Ramine &lt;n.oxyde@gmail.com&gt;</author>
+      <author>Anthony Ramine &lt;n.oxyde@gmail.com></author>
       <name>serde_urlencoded</name>
       <version>0.7.1</version>
       <description>`x-www-form-urlencoded` meets Serde</description>
@@ -2274,7 +2274,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shellexpand@3.1.2">
-      <author>Vladimir Matveev &lt;vmatveev@citrine.cc&gt;, Ian Jackson &lt;iwj@torproject.org&gt;</author>
+      <author>Vladimir Matveev &lt;vmatveev@citrine.cc>, Ian Jackson &lt;iwj@torproject.org></author>
       <name>shellexpand</name>
       <version>3.1.2</version>
       <description>Shell-like expansions in strings</description>
@@ -2296,7 +2296,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0">
-      <author>comex &lt;comexk@gmail.com&gt;, Fenhl &lt;fenhl@fenhl.net&gt;, Adrian Taylor &lt;adetaylor@chromium.org&gt;, Alex Touchet &lt;alextouchet@outlook.com&gt;, Daniel Parks &lt;dp+git@oxidized.org&gt;, Garrett Berg &lt;googberg@gmail.com&gt;</author>
+      <author>comex &lt;comexk@gmail.com>, Fenhl &lt;fenhl@fenhl.net>, Adrian Taylor &lt;adetaylor@chromium.org>, Alex Touchet &lt;alextouchet@outlook.com>, Daniel Parks &lt;dp+git@oxidized.org>, Garrett Berg &lt;googberg@gmail.com></author>
       <name>shlex</name>
       <version>1.3.0</version>
       <description>Split a string into shell words, like Python's shlex.</description>
@@ -2315,7 +2315,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8">
-      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz&gt;, Masaki Hara &lt;ackie.h.gmai@gmail.com&gt;</author>
+      <author>Michal 'vorner' Vaner &lt;vorner@vorner.cz>, Masaki Hara &lt;ackie.h.gmai@gmail.com></author>
       <name>signal-hook-registry</name>
       <version>1.4.8</version>
       <description>Backend crate for signal-hook</description>
@@ -2337,7 +2337,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.8">
-      <author>Marvin Countryman &lt;me@maar.vin&gt;</author>
+      <author>Marvin Countryman &lt;me@maar.vin></author>
       <name>simd-adler32</name>
       <version>0.3.8</version>
       <description>A SIMD-accelerated Adler-32 hash algorithm implementation.</description>
@@ -2356,7 +2356,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12">
-      <author>Carl Lerche &lt;me@carllerche.com&gt;</author>
+      <author>Carl Lerche &lt;me@carllerche.com></author>
       <name>slab</name>
       <version>0.4.12</version>
       <description>Pre-allocated storage for a uniform data type</description>
@@ -2397,7 +2397,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4">
-      <author>Alex Crichton &lt;alex@alexcrichton.com&gt;, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com&gt;</author>
+      <author>Alex Crichton &lt;alex@alexcrichton.com>, Thomas de Zeeuw &lt;thomasdezeeuw@gmail.com></author>
       <name>socket2</name>
       <version>0.6.4</version>
       <description>Utilities for handling networking sockets with a maximal amount of configuration possible intended. </description>
@@ -2422,7 +2422,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#spin@0.9.9">
-      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl&gt;, John Ericson &lt;git@JohnEricson.me&gt;, Joshua Barretto &lt;joshua.s.barretto@gmail.com&gt;</author>
+      <author>Mathijs van de Nes &lt;git@mathijs.vd-nes.nl>, John Ericson &lt;git@JohnEricson.me>, Joshua Barretto &lt;joshua.s.barretto@gmail.com></author>
       <name>spin</name>
       <version>0.9.9</version>
       <description>Spin-based synchronization primitives</description>
@@ -2441,7 +2441,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>syn</name>
       <version>2.0.117</version>
       <description>Parser for Rust source code</description>
@@ -2463,7 +2463,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2">
-      <author>Actyx AG &lt;developer@actyx.io&gt;</author>
+      <author>Actyx AG &lt;developer@actyx.io></author>
       <name>sync_wrapper</name>
       <version>1.0.2</version>
       <description>A tool for enlisting the compiler's help in proving the absence of concurrency</description>
@@ -2526,7 +2526,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-macros</name>
       <version>2.7.0</version>
       <description>Tokio's proc macros. </description>
@@ -2548,7 +2548,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio-util</name>
       <version>0.7.18</version>
       <description>Additional utilities for working with Tokio. </description>
@@ -2570,7 +2570,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tokio</name>
       <version>1.52.3</version>
       <description>An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. </description>
@@ -2592,7 +2592,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-layer</name>
       <version>0.3.3</version>
       <description>Decorates a `Service` to allow easy composition between `Service`s. </description>
@@ -2617,7 +2617,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower-service</name>
       <version>0.3.3</version>
       <description>Trait representing an asynchronous, request / response based, client or server. </description>
@@ -2642,7 +2642,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3">
-      <author>Tower Maintainers &lt;team@tower-rs.com&gt;</author>
+      <author>Tower Maintainers &lt;team@tower-rs.com></author>
       <name>tower</name>
       <version>0.5.3</version>
       <description>Tower is a library of modular and reusable components for building robust clients and servers. </description>
@@ -2664,7 +2664,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;, Eliza Weisman &lt;eliza@buoyant.io&gt;, David Barsky &lt;dbarsky@amazon.com&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs>, Eliza Weisman &lt;eliza@buoyant.io>, David Barsky &lt;dbarsky@amazon.com></author>
       <name>tracing-attributes</name>
       <version>0.1.31</version>
       <description>Procedural macro attributes for automatically instrumenting functions. </description>
@@ -2686,7 +2686,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36">
-      <author>Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing-core</name>
       <version>0.1.36</version>
       <description>Core primitives for application-level tracing. </description>
@@ -2708,7 +2708,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44">
-      <author>Eliza Weisman &lt;eliza@buoyant.io&gt;, Tokio Contributors &lt;team@tokio.rs&gt;</author>
+      <author>Eliza Weisman &lt;eliza@buoyant.io>, Tokio Contributors &lt;team@tokio.rs></author>
       <name>tracing</name>
       <version>0.1.44</version>
       <description>Application-level tracing for Rust. </description>
@@ -2730,7 +2730,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>try-lock</name>
       <version>0.2.5</version>
       <description>A lightweight atomic lock.</description>
@@ -2776,7 +2776,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>unicase</name>
       <version>2.9.0</version>
       <description>A case-insensitive wrapper around strings.</description>
@@ -2798,7 +2798,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>unicode-ident</name>
       <version>1.0.24</version>
       <description>Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31</description>
@@ -2820,7 +2820,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15">
-      <author>Jim McGrath &lt;jimmc2@gmail.com&gt;</author>
+      <author>Jim McGrath &lt;jimmc2@gmail.com></author>
       <name>vcpkg</name>
       <version>0.2.15</version>
       <description>A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. </description>
@@ -2842,7 +2842,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5">
-      <author>Sergio Benitez &lt;sb@sergio.bz&gt;</author>
+      <author>Sergio Benitez &lt;sb@sergio.bz></author>
       <name>version_check</name>
       <version>0.9.5</version>
       <description>Tiny crate to check the version of the installed/running rustc.</description>
@@ -2864,7 +2864,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0">
-      <author>Andrew Gallant &lt;jamslam@gmail.com&gt;</author>
+      <author>Andrew Gallant &lt;jamslam@gmail.com></author>
       <name>walkdir</name>
       <version>2.5.0</version>
       <description>Recursively walk a directory.</description>
@@ -2889,7 +2889,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#want@0.3.1">
-      <author>Sean McArthur &lt;sean@seanmonstar.com&gt;</author>
+      <author>Sean McArthur &lt;sean@seanmonstar.com></author>
       <name>want</name>
       <version>0.3.1</version>
       <description>Detect when another Future wants a result.</description>
@@ -2932,7 +2932,7 @@
       </externalReferences>
     </component>
     <component type="library" bom-ref="registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21">
-      <author>David Tolnay &lt;dtolnay@gmail.com&gt;</author>
+      <author>David Tolnay &lt;dtolnay@gmail.com></author>
       <name>zmij</name>
       <version>1.0.21</version>
       <description>A double-to-string conversion algorithm based on Schubfach and yy</description>
@@ -2955,7 +2955,7 @@
     </component>
   </components>
   <dependencies>
-    <dependency ref="path+file:///Users/huaijinhao/gitrepo/openobserve/openobserve/src/web#0.1.0">
+    <dependency ref="path+file:///private/tmp/openobserve-cyclonedx-fix.jfwk4d/src/web#0.1.0">
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#axum@0.8.8" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5" />
       <dependency ref="registry+https://github.com/rust-lang/crates.io-index#rust-embed-for-web@11.4.1" />


### PR DESCRIPTION
## Summary

- regenerate Rust CycloneDX SBOMs with cargo-cyclonedx cyclonedx
- update 9 existing SBOMs and add 32 workspace crate SBOMs
- exclude all generated files under src/enterprise

## Validation

- cargo-cyclonedx version: 0.5.9
- all 41 retained XML files pass xmllint --noout
- malformed vcs_url PURL pattern from 0.5.7 is absent
- git diff --check passes
- src/enterprise has no changes